### PR TITLE
Support intellij

### DIFF
--- a/3rdparty/maven.bzl
+++ b/3rdparty/maven.bzl
@@ -6,20 +6,16 @@ def declare_maven(hash):
     lang = hash.pop("lang")
     import_args = hash["import_args"]
 
-    if lang == "java":
+    # TODO: Change this back once java_import works again
+    # if lang == "java":
+    if False:
         java_import_external(**import_args)
-    elif lang.startswith("scala"):
-        # TODO: What attributes does scala_import support? Include only those here.
-        if "srcjar_sha256" in import_args:
-            import_args.pop("srcjar_sha256")
-        if "srcjar_urls" in import_args:
-            import_args.pop("srcjar_urls")
+    else:
+        #elif lang.startswith("scala"):
         if "testonly_" in import_args:
             import_args.pop("testonly_")
         if "neverlink" in import_args:
             import_args.pop("neverlink")
-        if "srcjar_urls" in import_args:
-            import_args.pop("srcjar_urls")
 
         scala_import_external(**import_args)
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ At this time there isn't a formal plan on how to incorporate changes upstream ot
 - [x] automatic main method detection
 - [x] errors on unused dependencies
 - [ ] buildozer suggestions to fix unused dependency errors
-- [ ] IntelliJ support
+- [x] IntelliJ support
 - [ ] tests for IntelliJ support
 - [x] scalafmt support
 

--- a/rules/scala.bzl
+++ b/rules/scala.bzl
@@ -202,7 +202,8 @@ scala_import for use with bazel-deps
 scala_import = rule(
     implementation = scala_import_implementation,
     attrs = {
-        "jars": attr.label_list(allow_files = True),
+        "jars": attr.label_list(allow_files = True),  #current hidden assumption is that these point to full, not ijar'd jars
+        "srcjar": attr.label(allow_single_file = True),
         "deps": attr.label_list(),
         "runtime_deps": attr.label_list(),
         "exports": attr.label_list(),

--- a/rules/scala/private/binary.bzl
+++ b/rules/scala/private/binary.bzl
@@ -30,20 +30,24 @@ def annex_scala_binary_implementation(ctx):
         jvm_flags = [],
     )
 
-    return [
-        res.java_info,
-        res.scala_info,
-        DefaultInfo(
-            executable = launcher,
-            files = res.files,
-            runfiles = ctx.runfiles(
-                files = [mains_file],
-                transitive_files = depset(
-                    order = "default",
-                    direct = [ctx.executable._java],
-                    transitive = [java_info.transitive_runtime_deps],
+    return struct(
+        providers = [
+            res.java_info,
+            res.scala_info,
+            res.intellij_info,
+            DefaultInfo(
+                executable = launcher,
+                files = res.files,
+                runfiles = ctx.runfiles(
+                    files = [mains_file],
+                    transitive_files = depset(
+                        order = "default",
+                        direct = [ctx.executable._java],
+                        transitive = [java_info.transitive_runtime_deps],
+                    ),
+                    collect_default = True,
                 ),
-                collect_default = True,
             ),
-        ),
-    ]
+        ],
+        java = res.intellij_info,
+    )

--- a/rules/scala/private/import.bzl
+++ b/rules/scala/private/import.bzl
@@ -1,50 +1,60 @@
+load("@rules_scala_annex//rules/scala:provider.bzl", "IntellijInfo", "JarsToLabels")
+
 def scala_import_implementation(ctx):
-    s_deps = java_common.merge([
-        entry[JavaInfo]
-        for entry in ctx.attr.deps
-        if JavaInfo in entry
-    ])
-
-    s_exports = java_common.merge([
-        entry[JavaInfo]
-        for entry in ctx.attr.exports
-        if JavaInfo in entry
-    ])
-
-    direct_binary_jars = []
-    for jar in ctx.attr.jars:
-        for file in jar.files:
-            if not file.basename.endswith("-sources.jar"):
-                direct_binary_jars += [file]
-
-    compile_time_jars = depset(
-        direct = direct_binary_jars,
+    default_info = DefaultInfo(
+        files = depset(ctx.files.jars + ctx.files.srcjar),
     )
 
-    transitive_compile_time_jars = depset(
-        direct = direct_binary_jars,
-        transitive = [
-            s_deps.transitive_compile_time_jars,
-            s_exports.transitive_compile_time_jars,
-        ],
-    )
-
-    transitive_runtime_jars = depset(
-        direct = direct_binary_jars,
-        transitive = [
-            s_deps.transitive_runtime_jars,
-            s_exports.transitive_runtime_jars,
-        ],
-    )
-
-    # TODO:
-    # consider exposing a ScalaInfo provider here too
-    # we'd need to infer the scala version from the jar file names
-
-    return [java_common.create_provider(
-        ctx.actions,
+    java_info = JavaInfo(
+        output_jar = ctx.files.jars[0],
         use_ijar = False,
-        compile_time_jars = compile_time_jars,
-        transitive_compile_time_jars = transitive_compile_time_jars,
-        transitive_runtime_jars = transitive_runtime_jars,
-    )]
+        source_jars = ctx.files.srcjar or ctx.files.jars,
+        deps = [dep[JavaInfo] for dep in ctx.attr.deps],
+        actions = ctx.actions,
+    )
+
+    intellij_info = create_intellij_info(ctx.label, ctx.attr.deps, java_info)
+
+    return struct(
+        # IntelliJ reads from java
+        java = intellij_info,
+        providers = [
+            intellij_info,
+            java_info,
+            _scala_import_jars_to_labels(ctx, ctx.files.jars),
+        ],
+    )
+
+def create_intellij_info(label, deps, java_info):
+    # note: tried using transitive_exports from a JavaInfo that was given non-empty exports, but it was always empty
+    return IntellijInfo(
+        outputs = java_info.outputs,
+        transitive_exports = depset(
+            [label],
+            transitive = [(dep[IntellijInfo] if IntellijInfo in dep else dep[JavaInfo]).transitive_exports for dep in deps],
+        ),
+    )
+
+def _scala_import_jars_to_labels(ctx, direct_binary_jars):
+    # build up JarsToLabels
+    # note: consider moving this to an aspect
+
+    lookup = {}
+    for jar in direct_binary_jars:
+        lookup[jar.path] = ctx.label
+
+    for entry in ctx.attr.deps:
+        if JavaInfo in entry:
+            for jar in entry[JavaInfo].compile_jars:
+                lookup[jar.path] = entry.label
+        if JarsToLabels in entry:
+            lookup.update(entry[JarsToLabels].lookup)
+
+    for entry in ctx.attr.exports:
+        if JavaInfo in entry:
+            for jar in entry[JavaInfo].compile_jars.to_list():
+                lookup[jar.path] = entry.label
+        if JarsToLabels in entry:
+            lookup.update(entry[JarsToLabels].lookup)
+
+    return JarsToLabels(lookup = lookup)

--- a/rules/scala/private/provider.bzl
+++ b/rules/scala/private/provider.bzl
@@ -4,7 +4,7 @@ def annex_configure_basic_scala_implementation(ctx):
     return [BasicScalaConfiguration(
         version = ctx.attr.version,
         compiler_classpath = ctx.files.compiler_classpath,
-        runtime_classpath = ctx.files.runtime_classpath,
+        runtime_classpath = ctx.attr.runtime_classpath,
     )]
 
 def annex_configure_scala_implementation(ctx):
@@ -12,5 +12,5 @@ def annex_configure_scala_implementation(ctx):
         version = ctx.attr.version,
         compiler_bridge = ctx.file.compiler_bridge,
         compiler_classpath = ctx.files.compiler_classpath,
-        runtime_classpath = ctx.files.runtime_classpath,
+        runtime_classpath = ctx.attr.runtime_classpath,
     )]

--- a/rules/scala/private/test.bzl
+++ b/rules/scala/private/test.bzl
@@ -7,7 +7,6 @@ annex_scala_test_private_attributes = annex_scala_binary_private_attributes
 def annex_scala_test_implementation(ctx):
     res = runner_common(ctx)
 
-    result = [res.java_info, res.scala_info]
     runner = ctx.actions.declare_file("test")
 
     files = ctx.files._java + [res.analysis]
@@ -40,5 +39,7 @@ def annex_scala_test_implementation(ctx):
         executable = runner,
         runfiles = ctx.runfiles(collect_default = True, collect_data = True, files = files, transitive_files = depset(direct = runner_jars.to_list(), transitive = [test_jars])),
     )
-    result.append(test_info)
-    return result
+    return struct(
+        providers = [res.java_info, res.scala_info, res.intellij_info, test_info],
+        java = res.intellij_info,
+    )

--- a/rules/scala/provider.bzl
+++ b/rules/scala/provider.bzl
@@ -17,9 +17,24 @@ BasicScalaConfiguration = provider(
     },
 )
 
+IntellijInfo = provider(
+    doc = "Provider for IntelliJ",
+    fields = {
+        "outputs": "java_output_jars",
+        "transitive_exports": "labels of transitive dependencies",
+    },
+)
+
 ScalaInfo = provider(
     doc = "Provider for cross versioned scala outputs",
     fields = {
         "analysis": "Zinc analysis file",
+    },
+)
+
+JarsToLabels = provider(
+    doc = "provides a mapping from jar files to defining labels for improved end user experience",
+    fields = {
+        "lookup": "dictionary with jar files as keys and labels as values",
     },
 )

--- a/rules/scalafmt/3rdparty/maven.bzl
+++ b/rules/scalafmt/3rdparty/maven.bzl
@@ -6,20 +6,16 @@ def declare_maven(hash):
     lang = hash.pop("lang")
     import_args = hash["import_args"]
 
-    if lang == "java":
+    # TODO: Change this back once java_import works again
+    # if lang == "java":
+    if False:
         java_import_external(**import_args)
-    elif lang.startswith("scala"):
-        # TODO: What attributes does scala_import support? Include only those here.
-        if "srcjar_sha256" in import_args:
-            import_args.pop("srcjar_sha256")
-        if "srcjar_urls" in import_args:
-            import_args.pop("srcjar_urls")
+    else:
+        #elif lang.startswith("scala"):
         if "testonly_" in import_args:
             import_args.pop("testonly_")
         if "neverlink" in import_args:
             import_args.pop("neverlink")
-        if "srcjar_urls" in import_args:
-            import_args.pop("srcjar_urls")
 
         scala_import_external(**import_args)
 

--- a/setup-tools.sh
+++ b/setup-tools.sh
@@ -14,7 +14,7 @@ rm -fr external-tools/bazel-deps
 mkdir -p external-tools/bazel-deps
 echo Downloading bazel-deps
 # TODO: move back to johnynek/bazel-deps when it supports scala_import_external
-curl -L -sS https://github.com/lucidsoftware/bazel-deps/archive/5b52be9ad309f4eb82b063ec61819d5fb86d7d77.tar.gz | tar zxf - --strip 1 -C external-tools/bazel-deps
+curl -L -sS https://github.com/lucidsoftware/bazel-deps/archive/b95e44421a6f1f9ade584154b00a91bf9d53dde9.tar.gz | tar zxf - --strip 1 -C external-tools/bazel-deps
 
 echo Building bazel-deps
 (cd external-tools/bazel-deps; bazel run --script_path=../bazel-deps.sh parse)

--- a/tests/3rdparty/workspace.bzl
+++ b/tests/3rdparty/workspace.bzl
@@ -6,20 +6,16 @@ def declare_maven(hash):
     lang = hash.pop("lang")
     import_args = hash["import_args"]
 
-    if lang == "java":
+    # TODO: Change this back once java_import works again
+    # if lang == "java":
+    if False:
         java_import_external(**import_args)
-    elif lang.startswith("scala"):
-        # TODO: What attributes does scala_import support? Include only those here.
-        if "srcjar_sha256" in import_args:
-            import_args.pop("srcjar_sha256")
-        if "srcjar_urls" in import_args:
-            import_args.pop("srcjar_urls")
+    else:
+        #elif lang.startswith("scala"):
         if "testonly_" in import_args:
             import_args.pop("testonly_")
         if "neverlink" in import_args:
             import_args.pop("neverlink")
-        if "srcjar_urls" in import_args:
-            import_args.pop("srcjar_urls")
 
         scala_import_external(**import_args)
 


### PR DESCRIPTION
Currently requires using scala_import/scala_import_external which provide IntellijInfo, for transitivity. (Also in Bazel 0.12.0, java_import breaks labels.)

If we don't need transitivity, other imports are fine. IMO, an IDE should query for transitive deps anyway.