### PR TITLE
Rework low level library/binary rules

### DIFF
--- a/rules/providers.bzl
+++ b/rules/providers.bzl
@@ -1,0 +1,109 @@
+ScalaConfiguration = provider(
+    doc = "Provides access to the Scala compiler jars",
+    fields = {
+        "version": "the Scala full version",
+        "compiler_classpath": "the compiler classpath",
+        "runtime_classpath": "the minimal runtime classpath",
+    },
+)
+
+def _declare_scala_configuration_implementation(ctx):
+    return [ScalaConfiguration(
+        version = ctx.attr.version,
+        compiler_classpath = ctx.files.compiler_classpath,
+        runtime_classpath = ctx.attr.runtime_classpath,
+    )]
+
+declare_scala_configuration = rule(
+    implementation = _declare_scala_configuration_implementation,
+    attrs = {
+        "version": attr.string(
+            mandatory = True,
+        ),
+        "compiler_classpath": attr.label_list(
+            mandatory = True,
+            providers = [JavaInfo],
+        ),
+        "runtime_classpath": attr.label_list(
+            mandatory = True,
+            providers = [JavaInfo],
+        ),
+    },
+)
+
+ScalaInfo = provider(
+    doc = "Provider for cross versioned scala rule outputs",
+    fields = {
+        "scala_configuration": "the scala configuration associated with this output",
+    },
+)
+
+ZincConfiguration = provider(
+    doc = "Provides additional items needed by Zinc",
+    fields = {
+        "compiler_bridge": "the compiled Zinc compiler bridge",
+    },
+)
+
+def _declare_zinc_configuration_implementation(ctx):
+    return [ZincConfiguration(
+        compiler_bridge = ctx.files.compiler_bridge,
+    )]
+
+declare_zinc_configuration = rule(
+    implementation = _declare_zinc_configuration_implementation,
+    attrs = {
+        "compiler_bridge": attr.label(
+            allow_single_file = True,
+            mandatory = True,
+        ),
+    },
+)
+
+ZincInfo = provider(
+    doc = "Provides additional outputs from Zinc",
+    fields = {
+        "analysis": "Zinc analysis file in binary form",
+    },
+)
+
+def _collect(index, entries):
+    return [
+        entry[index]
+        for entry in entries
+        if index in entry
+    ]
+
+def _join_configurations_implementation(ctx):
+    return (
+        _collect(ScalaConfiguration, ctx.attr.configurations) +
+        _collect(ZincConfiguration, ctx.attr.configurations)
+    )
+
+join_configurations = rule(
+    implementation = _join_configurations_implementation,
+    attrs = {
+        "configurations": attr.label_list(
+            mandatory = True,
+            providers = [[ScalaConfiguration], [ZincConfiguration]],
+        ),
+    },
+)
+
+# TODO: move these to another file?
+# TODO: implement these with an aspect?
+
+JarsToLabels = provider(
+    doc = "provides a mapping from jar files to defining labels for improved end user experience",
+    fields = {
+        "lookup": "dictionary with jar files as keys and labels as values",
+    },
+)
+
+IntellijInfo = provider(
+    doc = "Provider for IntelliJ",
+    fields = {
+        "outputs": "java_output_jars",
+        "transitive_exports": "labels of transitive dependencies",
+    },
+)

--- a/rules/scala/private/provider.bzl
+++ b/rules/scala/private/provider.bzl
@@ -8,9 +8,9 @@ def annex_configure_basic_scala_implementation(ctx):
     )]
 
 def annex_configure_scala_implementation(ctx):
-    return [ScalaConfiguration(
+    return ([ScalaConfiguration(
         version = ctx.attr.version,
         compiler_bridge = ctx.file.compiler_bridge,
         compiler_classpath = ctx.files.compiler_classpath,
         runtime_classpath = ctx.attr.runtime_classpath,
-    )]
+    )] + annex_configure_basic_scala_implementation(ctx))

--- a/rules/scala/private/provider.bzl
+++ b/rules/scala/private/provider.bzl
@@ -1,16 +1,37 @@
-load("@rules_scala_annex//rules/scala:provider.bzl", "BasicScalaConfiguration", "ScalaConfiguration")
+load(
+    "@rules_scala_annex//rules/scala:provider.bzl",
+    old_BasicScalaConfiguration = "BasicScalaConfiguration",
+    old_ScalaConfiguration = "ScalaConfiguration",
+)
+load(
+    "@rules_scala_annex//rules:providers.bzl",
+    new_ScalaConfiguration = "ScalaConfiguration",
+    new_ZincConfiguration = "ZincConfiguration",
+)
 
 def annex_configure_basic_scala_implementation(ctx):
-    return [BasicScalaConfiguration(
-        version = ctx.attr.version,
-        compiler_classpath = ctx.files.compiler_classpath,
-        runtime_classpath = ctx.attr.runtime_classpath,
-    )]
+    return [
+        old_BasicScalaConfiguration(
+            version = ctx.attr.version,
+            compiler_classpath = ctx.files.compiler_classpath,
+            runtime_classpath = ctx.attr.runtime_classpath,
+        ),
+        new_ScalaConfiguration(
+            version = ctx.attr.version,
+            compiler_classpath = ctx.files.compiler_classpath,
+            runtime_classpath = ctx.attr.runtime_classpath,
+        ),
+    ]
 
 def annex_configure_scala_implementation(ctx):
-    return ([ScalaConfiguration(
-        version = ctx.attr.version,
-        compiler_bridge = ctx.file.compiler_bridge,
-        compiler_classpath = ctx.files.compiler_classpath,
-        runtime_classpath = ctx.attr.runtime_classpath,
-    )] + annex_configure_basic_scala_implementation(ctx))
+    return ([
+        old_ScalaConfiguration(
+            version = ctx.attr.version,
+            compiler_bridge = ctx.file.compiler_bridge,
+            compiler_classpath = ctx.files.compiler_classpath,
+            runtime_classpath = ctx.attr.runtime_classpath,
+        ),
+        new_ZincConfiguration(
+            compiler_bridge = ctx.file.compiler_bridge,
+        ),
+    ] + annex_configure_basic_scala_implementation(ctx))

--- a/rules/scalac.bzl
+++ b/rules/scalac.bzl
@@ -1,0 +1,50 @@
+"""
+Rules for invoking scalac directly.
+
+These are some of the lower level rules. They are needed
+to bootstrap some of the higher level rules used in the annex.
+
+You probably don't want to use these directly!
+
+"""
+
+load("@rules_scala_annex//rules/scala:provider.bzl", "BasicScalaConfiguration")
+load(
+    "//rules/scalac:private.bzl",
+    _scalac_library_implementation = "scalac_library_implementation",
+    _scalac_library_private_attributes = "scalac_library_private_attributes",
+    _scalac_binary_implementation = "scalac_binary_implementation",
+    _scalac_binary_private_attributes = "scalac_binary_private_attributes",
+)
+
+scalac_library = rule(
+    implementation = _scalac_library_implementation,
+    attrs = _scalac_library_private_attributes + {
+        "srcs": attr.label_list(
+            allow_files = [".scala", ".java", ".srcjar"]
+        ),
+        "deps": attr.label_list(),
+        "scala": attr.label(
+            mandatory = True,
+            providers = [BasicScalaConfiguration],
+        ),
+    },
+    fragments = ["java"],
+)
+
+scalac_binary = rule(
+    implementation = _scalac_binary_implementation,
+    attrs = _scalac_binary_private_attributes + {
+        "srcs": attr.label_list(
+            allow_files = [".scala", ".java", ".srcjar"]
+        ),
+        "deps": attr.label_list(),
+        "main_class": attr.string(mandatory = True),
+        "scala": attr.label(
+            mandatory = True,
+            providers = [BasicScalaConfiguration],
+        ),
+    },
+    fragments = ["java"],
+    executable = True,
+)

--- a/rules/scalac.bzl
+++ b/rules/scalac.bzl
@@ -8,7 +8,7 @@ You probably don't want to use these directly!
 
 """
 
-load("@rules_scala_annex//rules/scala:provider.bzl", "BasicScalaConfiguration")
+load("@rules_scala_annex//rules:providers.bzl", "ScalaConfiguration")
 load(
     "//rules/scalac:private.bzl",
     _scalac_library_implementation = "scalac_library_implementation",
@@ -21,12 +21,12 @@ scalac_library = rule(
     implementation = _scalac_library_implementation,
     attrs = _scalac_library_private_attributes + {
         "srcs": attr.label_list(
-            allow_files = [".scala", ".java", ".srcjar"]
+            allow_files = [".scala", ".java", ".srcjar"],
         ),
         "deps": attr.label_list(),
         "scala": attr.label(
             mandatory = True,
-            providers = [BasicScalaConfiguration],
+            providers = [ScalaConfiguration],
         ),
     },
     fragments = ["java"],
@@ -36,13 +36,13 @@ scalac_binary = rule(
     implementation = _scalac_binary_implementation,
     attrs = _scalac_binary_private_attributes + {
         "srcs": attr.label_list(
-            allow_files = [".scala", ".java", ".srcjar"]
+            allow_files = [".scala", ".java", ".srcjar"],
         ),
         "deps": attr.label_list(),
         "main_class": attr.string(mandatory = True),
         "scala": attr.label(
             mandatory = True,
-            providers = [BasicScalaConfiguration],
+            providers = [ScalaConfiguration],
         ),
     },
     fragments = ["java"],

--- a/rules/scalac/private.bzl
+++ b/rules/scalac/private.bzl
@@ -1,0 +1,187 @@
+load("@rules_scala_annex//rules/scala:provider.bzl", "BasicScalaConfiguration")
+load("//rules/common:private/utils.bzl", "strip_margin")
+load("//rules/common:private/utils.bzl", "write_launcher")
+load("//rules/scala:private/import.bzl", "create_intellij_info")
+
+_common_private_attributes = {
+    "_host_javabase": attr.label(
+        default = Label("@bazel_tools//tools/jdk:current_java_runtime"),
+        cfg = "host",
+    ),
+    "_java": attr.label(
+        default = Label("@bazel_tools//tools/jdk:java"),
+        executable = True,
+        cfg = "host",
+    ),
+    "_jar": attr.label(
+        default = Label("@bazel_tools//tools/jdk:jar"),
+        executable = True,
+        cfg = "host",
+    ),
+    "_jar_creator": attr.label(
+        default = Label("@rules_scala_annex//rules/common/third_party/bazel/src/java_tools/buildjar/java/com/google/devtools/build/buildjar/jarhelper:jarcreator_bin"),
+        executable = True,
+        cfg = "host",
+    ),
+    "_java_toolchain": attr.label(
+        default = Label("@bazel_tools//tools/jdk:current_java_toolchain"),
+    ),
+}
+
+scalac_library_private_attributes = _common_private_attributes
+scalac_binary_private_attributes = _common_private_attributes + {
+    "_java_stub_template": attr.label(
+        default = Label("@anx_java_stub_template//file"),
+    ),
+}
+
+def scalac_binary_implementation(ctx):
+    res = _scalac_common(ctx)
+    launcher = ctx.new_file("%s.sh" % ctx.label.name)
+    write_launcher(
+        ctx,
+        launcher,
+        res['java_info'].transitive_runtime_deps,
+        main_class = ctx.attr.main_class,
+        jvm_flags = [],
+    )
+    return _format_providers(ctx, res + {
+        'executable': launcher
+    })
+
+def scalac_library_implementation(ctx):
+    res = _scalac_common(ctx)
+    return _format_providers(ctx, res)
+
+def _scalac_common(ctx):
+    name = ctx.label.name
+    jar = ctx.executable._jar
+    java = ctx.executable._java
+    jar_creator = ctx.executable._jar_creator
+
+    output_jar = ctx.actions.declare_file("%s.jar" % name)
+
+    scala = ctx.attr.scala[BasicScalaConfiguration]
+
+    deps = [dep[JavaInfo] for dep in scala.runtime_classpath + ctx.attr.deps]
+
+    sdep = java_common.merge(deps)
+
+    # Note: we pull in transitive_compile_time_jars for the time being
+    # to make development of runners way easier (bloop/zinc have big dep graphs).
+    # Consider removing transitive_compile_time_jars in the future.
+    compile_deps = sdep.transitive_compile_time_jars
+    runtime_deps = sdep.transitive_runtime_jars
+
+    compiler_classpath_str = ":".join([file.path for file in scala.compiler_classpath])
+    compile_classpath_str = ":".join([file.path for file in compile_deps])
+
+    inputs = depset()
+    inputs += [jar]
+    inputs += [java]
+    inputs += [jar_creator]
+    inputs += ctx.files.srcs
+    inputs += scala.compiler_classpath
+    inputs += compile_deps
+
+    srcs = [
+        file.path
+        for file in ctx.files.srcs
+        if file.path.endswith(".java") or file.path.endswith(".scala")
+    ]
+
+    src_jars = [
+        file.path
+        for file in ctx.files.srcs
+        if file.path.endswith(".srcjar")
+    ]
+
+    if len(src_jars) > 0:
+        fail("source jars aren't yet supported for direct scalac rules")
+
+    srcs_string = " ".join(srcs)
+    src_jars_string = " ".join(src_jars)
+
+    ctx.actions.run_shell(
+        inputs = inputs,
+        outputs = [output_jar],
+        command = strip_margin(
+            """
+            |set -eo pipefail
+            |
+            |mkdir tmp/classes
+            |
+            |{java} \\
+            |  -cp {compiler_classpath} \\
+            |  scala.tools.nsc.Main \\
+            |  -cp {compile_classpath} \\
+            |  -d tmp/classes \\
+            |  {srcs}
+            |
+            |{jar_creator} {output_jar} tmp/classes 2> /dev/null
+            |""".format(
+                jar = jar.path,
+                java = java.path,
+                jar_creator = jar_creator.path,
+                compiler_classpath = compiler_classpath_str,
+                compile_classpath = compile_classpath_str,
+                srcs = srcs_string,
+                src_jars = src_jars_string,
+                output_jar = output_jar.path,
+            ),
+        ),
+    )
+
+    java_info = JavaInfo(
+        output_jar = output_jar,
+        use_ijar = False,
+        sources = ctx.files.srcs,
+        deps = deps,
+        actions = ctx.actions,
+        host_javabase = ctx.attr._host_javabase,
+        java_toolchain = ctx.attr._java_toolchain,
+    )
+
+    return {
+        'output_jar': output_jar,
+        'java_info': java_info,
+    }
+
+
+# TODO: put me in a common place?
+
+def _create_default_info(ctx, blob):
+    args = {}
+    if 'executable' in blob:
+        args += {
+            'executable': blob['executable'],
+            'runfiles': ctx.runfiles(
+                transitive_files = depset(
+                    order = "default",
+                    direct = [ctx.executable._java],
+                    transitive = [blob['java_info'].transitive_runtime_deps],
+                ),
+                collect_default = True,
+            )
+        }
+
+    files = []
+    if 'output_jar' in blob:
+        files += [blob['output_jar']]
+    args += { 'files': depset(files) }
+    return DefaultInfo(**args)
+
+def _format_providers(ctx, blob):
+
+    default_info = _create_default_info(ctx, blob)
+    java_info = blob['java_info']
+    intellij_info = create_intellij_info(ctx.label, ctx.attr.deps, java_info)
+
+    return struct(
+        providers = [
+            default_info,
+            java_info,
+            intellij_info,
+        ],
+        java = java_info,
+    )

--- a/tests/providers/BUILD
+++ b/tests/providers/BUILD
@@ -1,0 +1,90 @@
+load(
+    "@rules_scala_annex//rules:providers.bzl",
+    "declare_scala_configuration",
+    "declare_zinc_configuration",
+    "join_configurations",
+)
+load(
+    "@rules_scala_annex//rules:scalac.bzl",
+    "scalac_library",
+)
+load(
+    ":build.bzl",
+    "consume_scala_configuration",
+    "consume_zinc_configuration",
+    "consume_scala_and_zinc_configuration",
+)
+
+declare_scala_configuration(
+    name = "provided_scala_configuration",
+    compiler_classpath = [
+        "@scala_2_12_scala_compiler//jar",
+        "@scala_2_12_scala_reflect//jar",
+        "@scala_2_12_scala_library//jar",
+    ],
+    runtime_classpath = [
+        "@scala_2_12_scala_library//jar",
+    ],
+    version = "2.12.4",
+)
+
+scalac_library(
+    name = "compiler_bridge",
+    srcs = ["@compiler_bridge_2_12//:src"],
+    scala = ":provided_scala_configuration",
+    deps = [
+        "@scala_2_12_scala_compiler//jar",
+        "@scala_2_12_scala_library//jar",
+        "@scala_2_12_scala_reflect//jar",
+        "@scala_annex_org_scala_sbt_compiler_interface",
+        "@scala_annex_org_scala_sbt_util_interface",
+    ],
+)
+
+declare_zinc_configuration(
+    name = "provided_zinc_configuration",
+    compiler_bridge = ":compiler_bridge",
+)
+
+join_configurations(
+    name = "provided_scala_and_zinc_configuration",
+    configurations = [
+        ":provided_scala_configuration",
+        ":provided_zinc_configuration",
+    ],
+)
+
+consume_scala_configuration(
+    name = "consume_scala_configuration",
+    configuration = ":provided_scala_configuration",
+)
+
+consume_scala_configuration(
+    name = "consume_scala_as_zinc_configuration",
+    configuration = ":provided_zinc_configuration",
+)
+
+consume_zinc_configuration(
+    name = "consume_zinc_configuration",
+    configuration = ":provided_zinc_configuration",
+)
+
+consume_zinc_configuration(
+    name = "consume_zinc_as_scala_configuration",
+    configuration = ":provided_scala_configuration",
+)
+
+consume_scala_and_zinc_configuration(
+    name = "consume_scala_and_zinc_configuration",
+    configuration = ":provided_scala_and_zinc_configuration",
+)
+
+consume_scala_configuration(
+    name = "consume_scala_and_zinc_as_scala_configuration",
+    configuration = ":provided_scala_and_zinc_configuration",
+)
+
+consume_zinc_configuration(
+    name = "consume_scala_and_zinc_as_zinc_configuration",
+    configuration = ":provided_scala_and_zinc_configuration",
+)

--- a/tests/providers/build.bzl
+++ b/tests/providers/build.bzl
@@ -1,0 +1,38 @@
+load(
+    "@rules_scala_annex//rules:providers.bzl",
+    "ScalaConfiguration",
+    "ZincConfiguration",
+)
+
+def _implementation(ctx):
+    return []
+
+consume_scala_configuration = rule(
+    implementation = _implementation,
+    attrs = {
+        "configuration": attr.label(
+            mandatory = True,
+            providers = [ScalaConfiguration],
+        ),
+    },
+)
+
+consume_zinc_configuration = rule(
+    implementation = _implementation,
+    attrs = {
+        "configuration": attr.label(
+            mandatory = True,
+            providers = [ZincConfiguration],
+        ),
+    },
+)
+
+consume_scala_and_zinc_configuration = rule(
+    implementation = _implementation,
+    attrs = {
+        "configuration": attr.label(
+            mandatory = True,
+            providers = [ScalaConfiguration, ZincConfiguration],
+        ),
+    },
+)

--- a/tests/providers/test
+++ b/tests/providers/test
@@ -1,0 +1,7 @@
+> bazel build :consume_scala_configuration
+-> bazel build :consume_scala_as_zinc_configuration
+> bazel build :consume_zinc_configuration
+-> bazel build :consume_zinc_as_scala_configuration
+> bazel build :consume_scala_and_zinc_configuration
+> bazel build :consume_scala_and_zinc_as_scala_configuration
+> bazel build :consume_scala_and_zinc_as_zinc_configuration

--- a/tests/scalac/BUILD
+++ b/tests/scalac/BUILD
@@ -1,0 +1,19 @@
+load(
+        "@rules_scala_annex//rules:scalac.bzl",
+        "scalac_library",
+        "scalac_binary",
+)
+
+scalac_library(
+    name = "hello_world_lib",
+    srcs = ["HelloWorldLib.scala"],
+    scala = "@scala_2_12",
+)
+
+scalac_binary(
+    name = "hello_world_bin",
+    srcs = ["HelloWorldBin.scala"],
+    deps = [":hello_world_lib"],
+    main_class = "anx.HelloWorld",
+    scala = "@scala_2_12",
+)

--- a/tests/scalac/BUILD
+++ b/tests/scalac/BUILD
@@ -1,7 +1,7 @@
 load(
-        "@rules_scala_annex//rules:scalac.bzl",
-        "scalac_library",
-        "scalac_binary",
+    "@rules_scala_annex//rules:scalac.bzl",
+    "scalac_library",
+    "scalac_binary",
 )
 
 scalac_library(
@@ -13,7 +13,7 @@ scalac_library(
 scalac_binary(
     name = "hello_world_bin",
     srcs = ["HelloWorldBin.scala"],
-    deps = [":hello_world_lib"],
     main_class = "anx.HelloWorld",
     scala = "@scala_2_12",
+    deps = [":hello_world_lib"],
 )

--- a/tests/scalac/HelloWorldBin.scala
+++ b/tests/scalac/HelloWorldBin.scala
@@ -1,0 +1,14 @@
+package anx
+
+object HelloWorld extends Hello with World {
+  def main(args: Array[String]): Unit = {
+    println(s"${decode(this.hello)} ${decode(this.world)}")
+    assert(decode(this.hello) == "hello")
+    assert(decode(this.world) == "world")
+  }
+
+  private def decode(input: String): String =
+    input.zipWithIndex
+      .map { case (c, i) => (c - i).toChar }
+      .mkString
+}

--- a/tests/scalac/HelloWorldLib.scala
+++ b/tests/scalac/HelloWorldLib.scala
@@ -1,0 +1,9 @@
+package anx
+
+trait Hello {
+  def hello: String = "hfnos"
+}
+
+trait World {
+  def world: String = "wptoh"
+}

--- a/tests/scalac/test
+++ b/tests/scalac/test
@@ -1,0 +1,2 @@
+> bazel build :hello_world_lib
+> bazel run :hello_world_bin


### PR DESCRIPTION
- Adds new providers that I want to progressively migrate towards
- Adds new low level scalac rules that use the new `ScalaConfiguration` provider
- Updates existing provider rules to emit old and new providers as a stopgap until we're fully migrated