### PR TITLE
Support scaladoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ to completely defer expanding transitive dependency lists until execution time.
 * Supports for all Scala test frameworks via sbt [test-interface](https://github.com/sbt/test-interface).
 * Support test sharding, custom test framework arguments (including options to the JVM itself).
 * Supports scalafmt.
+* Supports Scaladoc. See [#230](https://github.com/bazelbuild/rules_scala/issues/230) and [#256](https://github.com/bazelbuild/rules_scala/issues/256).
 * Has consistently formatted code, via buildifier and scalafmt. See [#74](https://github.com/bazelbuild/rules_scala/issues/474).
 * Reorganized and simplified file and code structure. Less than 8 KLOC excluding tests and dependency resolutions. (`git ls-files | grep -v '^test\|/maven.bzl$\|*.md' | xargs cat | wc -l`)
 * Reorganized Travis CI builds, including better cache reuse.

--- a/rules/scala.bzl
+++ b/rules/scala.bzl
@@ -21,6 +21,11 @@ load(
     _scala_test_private_attributes = "scala_test_private_attributes",
 )
 load(
+    "//rules/scala:private/doc.bzl",
+    _scaladoc_implementation = "scaladoc_implementation",
+    _scaladoc_private_attributes = "scaladoc_private_attributes",
+)
+load(
     "//rules/scala:private/import.bzl",
     _scala_import_implementation = "scala_import_implementation",
     _scala_import_private_attributes = "scala_import_private_attributes",
@@ -181,6 +186,23 @@ scala_import = rule(
         "runtime_deps": attr.label_list(),
         "exports": attr.label_list(),
     }, **_scala_import_private_attributes),
+)
+
+# scaladoc
+
+scaladoc = rule(
+    implementation = _scaladoc_implementation,
+    attrs = dict({
+        "compiler_deps": attr.label_list(allow_files = False, providers = [JavaInfo]),
+        "deps": attr.label_list(allow_files = False, providers = [JavaInfo]),
+        "srcs": attr.label_list(allow_files = [".java", ".scala", ".srcjar"]),
+        "scala": attr.label(
+            default = "@scala",
+            providers = [_ScalaConfiguration, _ZincConfiguration],
+        ),
+        "scalacopts": attr.string_list(default = []),
+        "title": attr.string(),
+    }, **_scaladoc_private_attributes),
 )
 
 ##

--- a/rules/scala/BUILD
+++ b/rules/scala/BUILD
@@ -64,6 +64,7 @@ scalac_library(
     deps = [
         "//rules/common:args",
         "@scala_annex_net_sourceforge_argparse4j_argparse4j",
+        "@scala_annex_org_scala_sbt_zinc_2_12",
     ],
 )
 
@@ -140,6 +141,30 @@ scalac_binary(
         "//rules/common:args",
         "//rules/common:worker",
         "@scala_annex_net_sourceforge_argparse4j_argparse4j",
+    ],
+)
+
+# Doc
+
+scala_binary(
+    name = "doc",
+    srcs = glob(["doc/**/*.scala"]),
+    scala = "//external:scala_annex_scala",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":compiler",
+        "//rules/common:args",
+        "//rules/common:worker",
+        "@scala_annex_net_sourceforge_argparse4j_argparse4j",
+        "@scala_annex_org_scala_sbt_compiler_interface",
+        "@scala_annex_org_scala_sbt_io_2_12",
+        "@scala_annex_org_scala_sbt_util_interface",
+        "@scala_annex_org_scala_sbt_util_logging_2_12",
+        "@scala_annex_org_scala_sbt_zinc_2_12",
+        "@scala_annex_org_scala_sbt_zinc_classpath_2_12",
+        "@scala_annex_org_scala_sbt_zinc_compile_core_2_12",
+        "@scala_annex_org_scala_sbt_zinc_core_2_12",
+        "@scala_annex_org_scala_sbt_zinc_persist_2_12",
     ],
 )
 

--- a/rules/scala/bloop/BloopRunner.scala
+++ b/rules/scala/bloop/BloopRunner.scala
@@ -76,7 +76,7 @@ object BloopRunner extends WorkerMain[Env] {
     val scalaCompiler: AnalyzingCompiler =
       ZincUtil.scalaCompiler(scalaInstance, compilerBridgeJar)
 
-    val compilers: Compilers = ZincUtil.compilers(scalaInstance, None, scalaCompiler)
+    val compilers: Compilers = ZincUtil.compilers(scalaInstance, ClasspathOptionsUtil.boot, None, scalaCompiler)
 
     val compileOptions: CompileOptions =
       CompileOptions.create

--- a/rules/scala/compiler/AnxLogger.scala
+++ b/rules/scala/compiler/AnxLogger.scala
@@ -1,0 +1,34 @@
+package annex.compiler
+
+import annex.compiler.Arguments.LogLevel
+import java.util.function.Supplier
+import xsbti.Logger
+
+final class AnxLogger(level: String) extends Logger {
+
+  def debug(msg: Supplier[String]) = level match {
+    case LogLevel.Debug => System.err.println(msg.get)
+    case _              =>
+  }
+
+  def error(msg: Supplier[String]) = level match {
+    case LogLevel.Debug | LogLevel.Error | LogLevel.Info | LogLevel.Warn => println(msg.get)
+    case _                                                               =>
+  }
+
+  def info(msg: Supplier[String]) = level match {
+    case LogLevel.Debug | LogLevel.Info => System.err.println(msg.get)
+    case _                              =>
+  }
+
+  def trace(err: Supplier[Throwable]) = level match {
+    case LogLevel.Debug | LogLevel.Error | LogLevel.Info | LogLevel.Warn => err.get.printStackTrace()
+    case _                                                               =>
+  }
+
+  def warn(msg: Supplier[String]) = level match {
+    case LogLevel.Debug | LogLevel.Info | LogLevel.Warn => System.err.println(msg.get)
+    case _                                              =>
+  }
+
+}

--- a/rules/scala/compiler/AnxScalaInstance.scala
+++ b/rules/scala/compiler/AnxScalaInstance.scala
@@ -1,0 +1,31 @@
+package annex.compiler
+
+import java.io.File
+import java.net.URLClassLoader
+import java.util.Properties
+import xsbti.compile.ScalaInstance
+
+final class AnxScalaInstance(val allJars: Array[File]) extends ScalaInstance {
+  lazy val actualVersion = {
+    val stream = loader.getResourceAsStream("compiler.properties")
+    try {
+      val props = new Properties
+      props.load(stream)
+      props.getProperty("version.number")
+    } finally stream.close()
+  }
+
+  def compilerJar = null
+
+  lazy val libraryJar = allJars
+    .find(f => new URLClassLoader(Array(f.toURI.toURL)).findResource("library.properties") != null)
+    .get
+
+  lazy val loader = new URLClassLoader(allJars.map(_.toURI.toURL), null)
+
+  def loaderLibraryOnly = null
+
+  def otherJars = null
+
+  def version = actualVersion
+}

--- a/rules/scala/compiler/FileUtil.scala
+++ b/rules/scala/compiler/FileUtil.scala
@@ -1,4 +1,4 @@
-package annex.zinc
+package annex.compiler
 
 import java.io.IOException
 import java.nio.file.attribute.BasicFileAttributes
@@ -8,6 +8,8 @@ import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.StandardCopyOption
 import java.nio.file.SimpleFileVisitor
+import java.util.zip.ZipInputStream
+import scala.annotation.tailrec
 
 class CopyFileVisitor(source: Path, target: Path) extends SimpleFileVisitor[Path] {
   override def preVisitDirectory(directory: Path, attributes: BasicFileAttributes) = {
@@ -38,4 +40,29 @@ object FileUtil {
   def copy(source: Path, target: Path) = Files.walkFileTree(source, new CopyFileVisitor(source, target))
 
   def delete(path: Path) = Files.walkFileTree(path, new DeleteFileVisitor)
+
+  def extractZip(archive: Path, output: Path) = {
+    val fileStream = Files.newInputStream(archive)
+    try {
+      val zipStream = new ZipInputStream(fileStream)
+      @tailrec
+      def next(files: List[Path]): List[Path] = {
+        zipStream.getNextEntry match {
+          case null => files
+          case entry if entry.isDirectory =>
+            zipStream.closeEntry()
+            next(files)
+          case entry =>
+            val file = output.resolve(entry.getName)
+            Files.createDirectories(file.getParent)
+            Files.copy(zipStream, file, StandardCopyOption.REPLACE_EXISTING)
+            zipStream.closeEntry()
+            next(file :: files)
+        }
+      }
+      next(Nil)
+    } finally {
+      fileStream.close()
+    }
+  }
 }

--- a/rules/scala/doc/DocRunner.scala
+++ b/rules/scala/doc/DocRunner.scala
@@ -1,0 +1,126 @@
+package annex.doc
+
+import annex.args.Implicits._
+import annex.compiler.{AnxLogger, AnxScalaInstance, FileUtil}
+import annex.compiler.Arguments.LogLevel
+import annex.worker.SimpleMain
+import java.io.{File, PrintWriter}
+import java.net.URLClassLoader
+import java.nio.file._
+import java.util.function.Supplier
+import java.util.zip.ZipInputStream
+import java.util.{Collections, Optional, Properties}
+import net.sourceforge.argparse4j.ArgumentParsers
+import net.sourceforge.argparse4j.impl.Arguments
+import net.sourceforge.argparse4j.inf.ArgumentParser
+import net.sourceforge.argparse4j.inf.Namespace
+import sbt.internal.inc.classpath.ClassLoaderCache
+import sbt.internal.inc.{Hash => _, ScalaInstance => _, _}
+import sbt.io.Hash
+import scala.annotation.tailrec
+import scala.collection.JavaConverters._
+import scala.util.Try
+import scala.util.control.NonFatal
+import xsbti.compile.{FileAnalysisStore => _, _}
+import xsbti.{Logger, Reporter}
+
+object DocRunner extends SimpleMain {
+
+  private[this] val classloaderCache = new ClassLoaderCache(null)
+
+  private[this] val parser =
+    ArgumentParsers.newFor("doc").addHelp(true).defaultFormatWidth(80).fromFilePrefix("@").build()
+  parser
+    .addArgument("--classpath")
+    .help("Compilation classpath")
+    .metavar("path")
+    .nargs("*")
+    .`type`(Arguments.fileType.verifyCanRead.verifyIsFile)
+    .setDefault_(Collections.emptyList)
+  parser
+    .addArgument("--compiler_bridge")
+    .help("Compiler bridge")
+    .metavar("path")
+    .required(true)
+    .`type`(Arguments.fileType.verifyCanRead().verifyIsFile())
+  parser
+    .addArgument("--compiler_classpath")
+    .help("Compiler classpath")
+    .metavar("path")
+    .nargs("*")
+    .`type`(Arguments.fileType.verifyCanRead().verifyIsFile())
+    .setDefault_(Collections.emptyList)
+  parser
+    .addArgument("--option")
+    .help("option")
+    .action(Arguments.append)
+    .metavar("option")
+  parser
+    .addArgument("--log_level")
+    .help("Log level")
+    .choices(LogLevel.Debug, LogLevel.Error, LogLevel.Info, LogLevel.None, LogLevel.Warn)
+    .setDefault_(LogLevel.Warn)
+  parser
+    .addArgument("--source_jars")
+    .help("Source jars")
+    .metavar("path")
+    .nargs("*")
+    .`type`(Arguments.fileType.verifyCanRead().verifyIsFile())
+    .setDefault_(Collections.emptyList)
+  parser
+    .addArgument("--tmp")
+    .help("Temporary directory")
+    .metavar("path")
+    .required(true)
+    .`type`(Arguments.fileType)
+  parser
+    .addArgument("--output_html")
+    .help("Output directory")
+    .metavar("path")
+    .required(true)
+    .`type`(Arguments.fileType)
+  parser
+    .addArgument("sources")
+    .help("Source files")
+    .metavar("source")
+    .nargs("*")
+    .`type`(Arguments.fileType.verifyCanRead.verifyIsFile)
+    .setDefault_(Collections.emptyList)
+
+  def work(args: Array[String]): Unit = {
+    val namespace = parser.parseArgsOrFail(args)
+
+    val tmpDir = namespace.get[File]("tmp").toPath
+    try FileUtil.delete(tmpDir)
+    catch { case _: NoSuchFileException => }
+
+    val sources = namespace.getList[File]("sources").asScala ++
+      namespace
+        .getList[File]("source_jars")
+        .asScala
+        .zipWithIndex
+        .flatMap {
+          case (jar, i) => FileUtil.extractZip(jar.toPath, tmpDir.resolve("src").resolve(i.toString))
+        }
+        .map(_.toFile)
+
+    val scalaInstance = new AnxScalaInstance(namespace.getList[File]("compiler_classpath").asScala.toArray)
+
+    val logger = new AnxLogger(namespace.getString("log_level"))
+
+    val scalaCompiler = ZincUtil
+      .scalaCompiler(scalaInstance, namespace.get[File]("compiler_bridge"))
+      .withClassLoaderCache(classloaderCache)
+
+    val classpath = namespace.getList[File]("classpath").asScala.toSeq
+    val output = namespace.get[File]("output_html")
+    output.mkdirs()
+    val options = Option(namespace.getList[String]("option")).fold[Seq[String]](Nil)(_.asScala).toSeq
+    val reporter = new LoggedReporter(10, logger)
+    scalaCompiler.doc(sources, scalaInstance.libraryJar +: classpath, output, options, logger, reporter)
+
+    try FileUtil.delete(tmpDir)
+    catch { case _: NoSuchFileException => }
+    Files.createDirectory(tmpDir)
+  }
+}

--- a/rules/scala/private/doc.bzl
+++ b/rules/scala/private/doc.bzl
@@ -1,0 +1,64 @@
+load(
+    "@rules_scala_annex//rules:providers.bzl",
+    _ScalaConfiguration = "ScalaConfiguration",
+    _ZincConfiguration = "ZincConfiguration",
+)
+
+scaladoc_private_attributes = {
+    "_runner": attr.label(
+        cfg = "host",
+        executable = True,
+        default = "@rules_scala_annex//rules/scala:doc",
+    ),
+}
+
+def scaladoc_implementation(ctx):
+    scala_configuration = ctx.attr.scala[_ScalaConfiguration]
+    zinc_configuration = ctx.attr.scala[_ZincConfiguration]
+
+    html = ctx.actions.declare_directory("html")
+    tmp = ctx.actions.declare_directory("tmp")
+
+    classpath = depset(transitive = [dep[JavaInfo].transitive_compile_time_deps for dep in ctx.attr.deps])
+    compiler_classpath = depset(
+        scala_configuration.compiler_classpath,
+        transitive = [dep[JavaInfo].transitive_runtime_deps for dep in ctx.attr.compiler_deps],
+    )
+
+    srcs = [file for file in ctx.files.srcs if file.extension.lower() in ["java", "scala"]]
+    src_jars = [file for file in ctx.files.srcs if file.extension.lower() == "srcjar"]
+
+    scalacopts = ["-doc-title", ctx.attr.title or ctx.label] + ctx.attr.scalacopts
+
+    args = ctx.actions.args()
+    args.add("--compiler_bridge", zinc_configuration.compiler_bridge)
+    args.add_all("--compiler_classpath", compiler_classpath)
+    args.add_all("--classpath", classpath)
+    args.add_all(scalacopts, format_each = "--option=%s")
+    args.add("--output_html", html)
+    args.add_all("--source_jars", src_jars)
+    args.add("--tmp", tmp)
+    args.add_all("--", srcs)
+    args.set_param_file_format("multiline")
+    args.use_param_file("@%s", use_always = True)
+
+    runner_inputs, _, input_manifests = ctx.resolve_command(tools = [ctx.attr._runner])
+
+    ctx.actions.run(
+        arguments = [args],
+        executable = ctx.attr._runner.files_to_run.executable,
+        execution_requirements = {"supports-workers": "1"},
+        input_manifests = input_manifests,
+        inputs = depset(
+            src_jars + srcs + [zinc_configuration.compiler_bridge],
+            transitive = [classpath, compiler_classpath],
+        ),
+        mnemonic = "ScalaDoc",
+        outputs = [html, tmp],
+    )
+
+    return [
+        DefaultInfo(
+            files = depset([html]),
+        ),
+    ]

--- a/rules/scala/zinc/ZincPersistence.scala
+++ b/rules/scala/zinc/ZincPersistence.scala
@@ -1,5 +1,6 @@
 package annex.zinc
 
+import annex.compiler.FileUtil
 import java.nio.file.{Files, Path}
 
 trait ZincPersistence {

--- a/tests/3rdparty/maven.bzl
+++ b/tests/3rdparty/maven.bzl
@@ -402,7 +402,7 @@ def list_dependencies():
             },
             "lang": "java",
         },
-        # duplicates in org.scala-lang.modules:scala-xml_2.12 promoted to 1.0.6
+        # duplicates in org.scala-lang.modules:scala-xml_2.12 fixed to 1.1.0
         # - org.scala-sbt:sbinary_2.12:0.4.4 wanted version 1.0.5
         # - org.scalatest:scalatest_2.12:3.0.4 wanted version 1.0.5
         # - org.specs2:specs2-common_2.12:4.0.3 wanted version 1.0.6
@@ -413,18 +413,19 @@ def list_dependencies():
             },
             "import_args": {
                 "default_visibility": ["//visibility:public"],
-                "jar_sha256": "7cc3b6ceb56e879cb977e8e043f4bfe2e062f78795efd7efa09f85003cb3230a",
+                "deps": ["@org_scala_lang_scala_library"],
+                "jar_sha256": "cf300196dbc0e4706a94e189d2c99b0c292d3f7650f94ce7c16de81b2a262346",
                 "jar_urls": [
-                    "http://central.maven.org/maven2/org/scala-lang/modules/scala-xml_2.12/1.0.6/scala-xml_2.12-1.0.6.jar",
+                    "http://central.maven.org/maven2/org/scala-lang/modules/scala-xml_2.12/1.1.0/scala-xml_2.12-1.1.0.jar",
                 ],
                 "licenses": ["notice"],
                 "name": "org_scala_lang_modules_scala_xml_2_12",
-                "srcjar_sha256": "a7e8aac79394df396afda98b35537791809d815ce15ab2224f7d31e50c753922",
+                "srcjar_sha256": "46a8f4be00c620b737b783a9f9107725d0d03c973e9b691c817e0336bc1f6192",
                 "srcjar_urls": [
-                    "http://central.maven.org/maven2/org/scala-lang/modules/scala-xml_2.12/1.0.6/scala-xml_2.12-1.0.6-sources.jar",
+                    "http://central.maven.org/maven2/org/scala-lang/modules/scala-xml_2.12/1.1.0/scala-xml_2.12-1.1.0-sources.jar",
                 ],
             },
-            "lang": "java",
+            "lang": "scala",
         },
         {
             "bind_args": {
@@ -448,6 +449,7 @@ def list_dependencies():
         },
         # duplicates in org.scala-lang:scala-library promoted to 2.12.4
         # - com.lihaoyi:utest_2.12:0.6.0 wanted version 2.12.3
+        # - org.scala-lang.modules:scala-xml_2.12:1.1.0 wanted version 2.12.4
         # - org.scala-sbt:zinc-persist_2.12:1.1.5 wanted version 2.12.4
         # - org.scalacheck:scalacheck_2.12:1.13.4 wanted version 2.12.0
         # - org.scalactic:scalactic_2.12:3.0.4 wanted version 2.12.3
@@ -585,7 +587,7 @@ def list_dependencies():
                     "http://central.maven.org/maven2/org/scala-sbt/sbinary_2.12/0.4.4/sbinary_2.12-0.4.4-sources.jar",
                 ],
             },
-            "lang": "java",
+            "lang": "scala",
         },
         {
             "bind_args": {
@@ -961,7 +963,7 @@ def list_dependencies():
                     "http://central.maven.org/maven2/org/specs2/specs2-common_2.12/4.0.3/specs2-common_2.12-4.0.3-sources.jar",
                 ],
             },
-            "lang": "java",
+            "lang": "scala",
         },
         {
             "bind_args": {
@@ -1072,7 +1074,7 @@ def list_dependencies():
                     "http://central.maven.org/maven2/org/specs2/specs2-matcher_2.12/4.0.3/specs2-matcher_2.12-4.0.3-sources.jar",
                 ],
             },
-            "lang": "java",
+            "lang": "scala",
         },
         {
             "bind_args": {

--- a/tests/dependencies.yaml
+++ b/tests/dependencies.yaml
@@ -5,6 +5,11 @@ options:
 
 dependencies:
 
+  org.scala-lang.modules:
+    scala-xml:
+      lang: scala
+      version: 1.1.0
+
   org.scala-sbt:
     zinc-persist:
       lang: scala

--- a/tests/scaladoc/A.scala
+++ b/tests/scaladoc/A.scala
@@ -1,0 +1,6 @@
+/**
+ * A Scaladoc
+ */
+object A {
+    def a = B
+}

--- a/tests/scaladoc/B.scala
+++ b/tests/scaladoc/B.scala
@@ -1,0 +1,1 @@
+object B {}

--- a/tests/scaladoc/BUILD
+++ b/tests/scaladoc/BUILD
@@ -1,0 +1,13 @@
+load("@rules_scala_annex//rules:scala.bzl", "scaladoc")
+
+scaladoc(
+    name = "a_doc",
+    srcs = [
+        "A.scala",
+        "B.scala",
+    ],
+    compiler_deps = [
+        "@org_scala_lang_modules_scala_xml_2_12",
+    ],
+    scala = "@scala_2_12",
+)

--- a/tests/scaladoc/test
+++ b/tests/scaladoc/test
@@ -1,0 +1,5 @@
+#!/bin/bash -e
+. "$(dirname "$0")"/../common.sh
+
+bazel build :a_doc
+grep -q '<title>//scaladoc:a_doc' "$(bazel info bazel-bin)/scaladoc/html/index.html"


### PR DESCRIPTION
This is a very simple rule, and isn't fancy about reusing scala_library info.
It also requires the user to provider the scala-xml dependency. This should be
addressed, but we may want to change Scala configuration generally.

I used the zinc interface for scaladoc, so I move some code from zinc/ to the common compiler/