### PR TITLE
Support UTF-8 encoding and handle errors in scalafmt

### DIFF
--- a/rules/scala.bzl
+++ b/rules/scala.bzl
@@ -243,6 +243,7 @@ def _scala_runner_toolchain_implementation(ctx):
     return [platform_common.ToolchainInfo(
         runner = ctx.attr.runner,
         scalacopts = ctx.attr.scalacopts,
+        encoding = ctx.attr.encoding,
     )]
 
 """
@@ -257,6 +258,7 @@ scala_runner_toolchain = rule(
             cfg = "host",
         ),
         "scalacopts": attr.string_list(),
+        "encoding": attr.string(),
     },
 )
 

--- a/rules/scala/BUILD
+++ b/rules/scala/BUILD
@@ -40,6 +40,7 @@ toolchain(
 
 scala_runner_toolchain(
     name = "config_toolchain_implementation",
+    encoding = "UTF-8",
     runner = select({
         ":config_use_bloop": "@rules_scala_annex//rules/scala:bloop",
         "//conditions:default": "@rules_scala_annex//rules/scala:zinc",

--- a/rules/scalafmt.bzl
+++ b/rules/scalafmt.bzl
@@ -18,6 +18,7 @@ scala_format_test = rule(
         ),
     }, **_scala_format_private_attributes),
     test = True,
+    toolchains = ["@rules_scala_annex//rules/scala:runner_toolchain_type"],
     outputs = {
         "runner": "%{name}-format",
     },

--- a/rules/scalafmt/scalafmt/ScalafmtRunner.scala
+++ b/rules/scalafmt/scalafmt/ScalafmtRunner.scala
@@ -1,25 +1,40 @@
 package annex.scalafmt
 
-import annex.worker.SimpleMain
+import annex.worker.WorkerMain
 import java.io.File
+import java.nio.charset.Charset
 import java.nio.file.Files
 import net.sourceforge.argparse4j.ArgumentParsers
 import net.sourceforge.argparse4j.impl.Arguments
+import net.sourceforge.argparse4j.inf.Namespace
 import org.scalafmt.Scalafmt
 import org.scalafmt.config.Config
+import org.scalafmt.util.FileOps
 import scala.annotation.tailrec
+import scala.io.Codec
 
-object ScalafmtRunner extends SimpleMain {
+object ScalafmtRunner extends WorkerMain[Unit] {
 
-  private[this] val parser = ArgumentParsers.newFor("scalafmt").addHelp(true).build
-  parser.addArgument("--config").required(true).`type`(Arguments.fileType)
-  parser.addArgument("input").`type`(Arguments.fileType)
-  parser.addArgument("output").`type`(Arguments.fileType)
+  protected[this] def init(args: Option[Array[String]]): Unit = {
 
-  protected[this] def work(args: Array[String]): Unit = {
+  }
+
+  protected[this] def work(worker: Unit, args: Array[String]): Unit = {
+
+    val parser = ArgumentParsers.newFor("scalafmt").addHelp(true).defaultFormatWidth(80).fromFilePrefix("@").build
+    parser.addArgument("--config").required(true).`type`(Arguments.fileType)
+    parser.addArgument("input").`type`(Arguments.fileType)
+    parser.addArgument("output").`type`(Arguments.fileType)
+
     val namespace = parser.parseArgsOrFail(args)
 
-    val source = new String(Files.readAllBytes(namespace.get[File]("input").toPath))
+    val source = FileOps.readFile(namespace.get[File]("input"))(Codec.UTF8)
+
+    System.getenv.forEach((name, value) => println(s"$name: $value"))
+
+    if (namespace.get[File]("input").toPath.toString.contains("Features")) {
+      println(source)
+    }
 
     val config = Config.fromHoconFile(namespace.get[File]("config")).get
     @tailrec
@@ -27,7 +42,16 @@ object ScalafmtRunner extends SimpleMain {
       val formatted = Scalafmt.format(code, config).get
       if (code == formatted) code else format(formatted)
     }
-    val output = format(source)
+
+    val output = try {
+      format(source)
+    } catch {
+      case e: Throwable => {
+        System.err.println(Console.YELLOW + "WARN: " + Console.WHITE + "Unable to format file due to bug in scalafmt")
+        System.err.println(Console.YELLOW + "WARN: " + Console.WHITE + e)
+        source
+      }
+    }
 
     Files.write(namespace.get[File]("output").toPath, output.getBytes)
   }


### PR DESCRIPTION
- Format the Scala code
  - Support UTF-8 encoding
  - Catch the error in `org.scalafmt.Scalafmt`