### PR TITLE
Improve scala_format_test ergonomics

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,10 +166,11 @@ scala_format_test(
 ```
 
 ```
-# format files
-$ bazel run :format "$(bazel info | grep workspace: | cut -d' ' -f2)"
-# check format
+# check format, with diffs and non-zero exit in case of differences
 $ bazel test :format
+
+# format files in-place
+$ bazel run :format
 ```
 
 ### Strict & unused deps

--- a/rules/scalafmt/private/format.template.sh
+++ b/rules/scalafmt/private/format.template.sh
@@ -4,7 +4,7 @@ RUNPATH="${TEST_SRCDIR-$0.runfiles}"/%workspace%
 while read original formatted; do
     if ! cmp -s "$RUNPATH/$original" "$RUNPATH/$formatted"; then
         echo $original
-        if [ -z "$1" ]; then
+        if [ -z "$BUILD_WORKSPACE_DIRECTORY" ]; then
             diff "$RUNPATH/$original" "$RUNPATH/$formatted" || true
             EXIT=1
         else


### PR DESCRIPTION
There is no longer a need to pass the root directory when formatting
in-place.

```sh
# check
bazel test :format
```

```sh
# format
bazel run :format
```