### PR TITLE
Consistently leverage depsets

### DIFF
--- a/rules/providers.bzl
+++ b/rules/providers.bzl
@@ -18,7 +18,7 @@ def _declare_scala_configuration_implementation(ctx):
     return [
         java_common.merge(_collect(JavaInfo, ctx.attr.compiler_classpath)),
         ScalaConfiguration(
-            compiler_classpath = ctx.files.compiler_classpath,
+            compiler_classpath = ctx.attr.compiler_classpath,
             global_plugins = ctx.attr.global_plugins,
             runtime_classpath = ctx.attr.runtime_classpath,
             version = ctx.attr.version,

--- a/rules/scala/private/provider.bzl
+++ b/rules/scala/private/provider.bzl
@@ -7,7 +7,7 @@ load(
 def configure_basic_scala_implementation(ctx):
     return [
         new_ScalaConfiguration(
-            compiler_classpath = ctx.files.compiler_classpath,
+            compiler_classpath = ctx.attr.compiler_classpath,
             global_plugins = ctx.attr.global_plugins,
             runtime_classpath = ctx.attr.runtime_classpath,
             version = ctx.attr.version,

--- a/rules/scala/private/repl.bzl
+++ b/rules/scala/private/repl.bzl
@@ -4,7 +4,7 @@ load(
     _ScalaConfiguration = "ScalaConfiguration",
     _ZincConfiguration = "ZincConfiguration",
 )
-load("//rules/common:private/utils.bzl", "write_launcher")
+load("//rules/common:private/utils.bzl", "write_launcher", _collect = "collect")
 load(":private/core.bzl", _scala_binary_private_attributes = "scala_binary_private_attributes")
 
 scala_repl_private_attributes = _dicts.add(
@@ -22,12 +22,16 @@ def scala_repl_implementation(ctx):
     scala_configuration = ctx.attr.scala[_ScalaConfiguration]
     zinc_configuration = ctx.attr.scala[_ZincConfiguration]
 
+    scompiler_classpath = java_common.merge(
+        _collect(JavaInfo, scala_configuration.compiler_classpath),
+    )
+
     classpath = depset(transitive = [dep[JavaInfo].transitive_runtime_deps for dep in ctx.attr.deps])
     runner_classpath = ctx.attr._runner[JavaInfo].transitive_runtime_deps
 
     args = ctx.actions.args()
     args.add("--compiler_bridge", zinc_configuration.compiler_bridge.short_path)
-    args.add_all("--compiler_classpath", scala_configuration.compiler_classpath, map_each = _short_path)
+    args.add_all("--compiler_classpath", scompiler_classpath.transitive_runtime_jars, map_each = _short_path)
     args.add_all("--classpath", classpath, map_each = _short_path)
     args.add_all(ctx.attr.scalacopts, format_each = "--compiler_option=%s")
     args.set_param_file_format("multiline")
@@ -48,8 +52,8 @@ def scala_repl_implementation(ctx):
     )
 
     files = depset(
-        [args_file, zinc_configuration.compiler_bridge] + launcher_files + scala_configuration.compiler_classpath,
-        transitive = [classpath, runner_classpath],
+        [args_file, zinc_configuration.compiler_bridge] + launcher_files,
+        transitive = [classpath, runner_classpath, scompiler_classpath.transitive_runtime_deps],
     )
     return [
         DefaultInfo(


### PR DESCRIPTION
The `compiler_classpath` was a list of files and `runtime_classpath` was a list of targets, with JavaInfo providers available. This was inconsistent, confusing, and made it harder to take advantage of depsets. Now it's fixed :).