### PR TITLE
Support scalac plugins build within the same workspace

### DIFF
--- a/rules/common/private/utils.bzl
+++ b/rules/common/private/utils.bzl
@@ -94,6 +94,11 @@ def action_singlejar(
     # For a full list of available command line options see:
     # https://github.com/bazelbuild/bazel/blob/master/src/java_tools/singlejar/java/com/google/devtools/build/singlejar/SingleJar.java#L311
 
+    if type(inputs) == "list":
+        inputs = depset(inputs)
+    if type(phantom_inputs) == "list":
+        phantom_inputs = depset(phantom_inputs)
+
     args = ctx.actions.args()
     args.add("--exclude_build_data")
     args.add("--normalize")
@@ -104,11 +109,6 @@ def action_singlejar(
         args.add("--main_class", main_class)
         args.set_param_file_format("multiline")
         args.use_param_file("@%s", use_always = True)
-
-    if type(inputs) == "list":
-        inputs = depset(inputs)
-    if type(phantom_inputs) == "list":
-        phantom_inputs = depset()
 
     all_inputs = depset(transitive = [inputs, phantom_inputs])
 

--- a/rules/common/private/utils.bzl
+++ b/rules/common/private/utils.bzl
@@ -89,7 +89,8 @@ def action_singlejar(
         output,
         phantom_inputs = depset(),
         main_class = None,
-        progress_message = None):
+        progress_message = None,
+        resources = {}):
     # This calls bazels singlejar utility.
     # For a full list of available command line options see:
     # https://github.com/bazelbuild/bazel/blob/master/src/java_tools/singlejar/java/com/google/devtools/build/singlejar/SingleJar.java#L311
@@ -103,6 +104,7 @@ def action_singlejar(
     args.add("--exclude_build_data")
     args.add("--normalize")
     args.add_all("--sources", inputs)
+    args.add_all("--resources", ["{}:{}".format(value.path, key) for key, value in resources.items()])
     args.add("--output", output)
     args.add("--warn_duplicate_resources")
     if main_class != None:
@@ -110,7 +112,7 @@ def action_singlejar(
         args.set_param_file_format("multiline")
         args.use_param_file("@%s", use_always = True)
 
-    all_inputs = depset(transitive = [inputs, phantom_inputs])
+    all_inputs = depset(resources.values(), transitive = [inputs, phantom_inputs])
 
     ctx.actions.run(
         arguments = [args],

--- a/rules/common/private/utils.bzl
+++ b/rules/common/private/utils.bzl
@@ -27,6 +27,8 @@ def _strip_margin_line(line, delim):
     else:
         return line
 
+_SINGLE_JAR_MNEMONIC = "SingleJar"
+
 def write_launcher(
         ctx,
         prefix,
@@ -80,3 +82,42 @@ def safe_name(value):
 
 def _short_path(file):
     return file.short_path
+
+def action_singlejar(
+        ctx,
+        inputs,
+        output,
+        phantom_inputs = depset(),
+        main_class = None,
+        progress_message = None):
+    # This calls bazels singlejar utility.
+    # For a full list of available command line options see:
+    # https://github.com/bazelbuild/bazel/blob/master/src/java_tools/singlejar/java/com/google/devtools/build/singlejar/SingleJar.java#L311
+
+    args = ctx.actions.args()
+    args.add("--exclude_build_data")
+    args.add("--normalize")
+    args.add_all("--sources", inputs)
+    args.add("--output", output)
+    args.add("--warn_duplicate_resources")
+    if main_class != None:
+        args.add("--main_class", main_class)
+        args.set_param_file_format("multiline")
+        args.use_param_file("@%s", use_always = True)
+
+    if type(inputs) == "list":
+        inputs = depset(inputs)
+    if type(phantom_inputs) == "list":
+        phantom_inputs = depset()
+
+    all_inputs = depset(transitive = [inputs, phantom_inputs])
+
+    ctx.actions.run(
+        arguments = [args],
+        executable = ctx.executable._singlejar,
+        execution_requirements = {"supports-workers": "1"},
+        mnemonic = _SINGLE_JAR_MNEMONIC,
+        inputs = all_inputs,
+        outputs = [output],
+        progress_message = progress_message,
+    )

--- a/rules/scala/private/core.bzl
+++ b/rules/scala/private/core.bzl
@@ -102,11 +102,6 @@ runner_common_attributes = {
         default = "@bazel_tools//tools/jdk:singlejar",
         executable = True,
     ),
-    "_zipper": attr.label(
-        cfg = "host",
-        default = "@bazel_tools//tools/zip:zipper",
-        executable = True,
-    ),
 }
 
 scala_library_private_attributes = runner_common_attributes

--- a/rules/scala/private/phases.bzl
+++ b/rules/scala/private/phases.bzl
@@ -436,7 +436,7 @@ def phase_singlejar(ctx, g):
     # including them in the args for singlejar to process. This will
     # cause the build to fail, cleanly, if any declared outputs are
     # missing from previous phases.
-    inputs = [g.compile.jar] + [f for f in ctx.files.resource_jars if f.extension.lower() in ["jar"]]
+    inputs = [f for f in ctx.files.resource_jars if f.extension.lower() in ["jar"]]
     phantom_inputs = []
     for v in [getattr(g, k) for k in dir(g) if k not in ["to_json", "to_proto"]]:
         if hasattr(v, "jar"):

--- a/rules/scala/private/phases.bzl
+++ b/rules/scala/private/phases.bzl
@@ -80,25 +80,19 @@ def run_phases(ctx, phases):
 #
 
 def phase_resources(ctx, g):
-    zipper_inputs, _, zipper_manifests = ctx.resolve_command(tools = [ctx.attr._zipper])
-
     if ctx.files.resources:
-        jar = ctx.actions.declare_file("{}/resources.zip".format(ctx.label.name))
-        args = ctx.actions.args()
-        args.add("c", jar)
-        args.set_param_file_format("multiline")
-        args.use_param_file("@%s")
-        for file in ctx.files.resources:
-            args.add("{}={}".format(_resources_make_path(file, ctx.attr.resource_strip_prefix), file.path))
-        ctx.actions.run(
-            arguments = [args],
-            executable = ctx.executable._zipper,
-            inputs = ctx.files.resources,
-            input_manifests = zipper_manifests,
-            outputs = [jar],
-            tools = zipper_inputs,
+        resource_jar = ctx.actions.declare_file("{}/resources.jar".format(ctx.label.name))
+        _action_singlejar(
+            ctx,
+            inputs = [],
+            output = resource_jar,
+            progress_message = "singlejar resources %s" % ctx.label.name,
+            resources = {
+                _resources_make_path(file, ctx.attr.resource_strip_prefix): file
+                for file in ctx.files.resources
+            },
         )
-        return struct(jar = jar)
+        return struct(jar = resource_jar)
     else:
         return struct()
 

--- a/rules/scala/private/phases.bzl
+++ b/rules/scala/private/phases.bzl
@@ -7,9 +7,23 @@ load(
     _ZincConfiguration = "ZincConfiguration",
     _ZincInfo = "ZincInfo",
 )
-load("//rules/common:private/utils.bzl", _collect = "collect", _strip_margin = "strip_margin", _write_launcher = "write_launcher")
-load("//rules/scalafmt:private/test.bzl", _build_format = "build_format", _format_runner = "format_runner", _format_tester = "format_tester")
-load(":private/import.bzl", _create_intellij_info = "create_intellij_info")
+load(
+    "//rules/common:private/utils.bzl",
+    _action_singlejar = "action_singlejar",
+    _collect = "collect",
+    _strip_margin = "strip_margin",
+    _write_launcher = "write_launcher",
+)
+load(
+    "//rules/scalafmt:private/test.bzl",
+    _build_format = "build_format",
+    _format_runner = "format_runner",
+    _format_tester = "format_tester",
+)
+load(
+    ":private/import.bzl",
+    _create_intellij_info = "create_intellij_info",
+)
 
 def run_phases(ctx, phases):
     # init currently holds info derived from core attributes and the
@@ -23,8 +37,8 @@ def run_phases(ctx, phases):
     )
     init = struct(
         scala_configuration = scala_configuration,
-        sdeps = sdeps,
         scompiler_classpath = scompiler_classpath,
+        sdeps = sdeps,
     )
 
     phase_providers = [p[_ScalaRulePhase] for p in ctx.attr.plugins if _ScalaRulePhase in p]
@@ -55,8 +69,6 @@ def run_phases(ctx, phases):
             g = struct(**gd)
 
     return g
-
-_SINGLE_JAR_MNEMONIC = "SingleJar"
 
 #
 # PHASE: resources
@@ -115,7 +127,37 @@ def phase_compile(ctx, g):
     runner = ctx.toolchains["@rules_scala_annex//rules/scala:runner_toolchain_type"]
     class_jar = ctx.actions.declare_file("{}/classes.jar".format(ctx.label.name))
 
-    splugins = java_common.merge(_collect(JavaInfo, ctx.attr.plugins + g.init.scala_configuration.global_plugins))
+    plugin_skip_jars = java_common.merge(
+        _collect(JavaInfo, g.init.scala_configuration.compiler_classpath +
+                           g.init.scala_configuration.runtime_classpath),
+    ).transitive_runtime_jars.to_list()
+
+    actual_plugins = []
+    for plugin in ctx.attr.plugins + g.init.scala_configuration.global_plugins:
+        deps = [dep for dep in plugin[JavaInfo].transitive_runtime_jars if dep not in plugin_skip_jars]
+        if len(deps) == 1:
+            actual_plugins.extend(deps)
+        else:
+            # scalac expects each plugin to be fully isolated, so we need to
+            # smash everything together with singlejar
+            print("WARNING! " +
+                  "It is slightly inefficient to use a JVM target with " +
+                  "dependencies directly as a scalac plugin. Please " +
+                  "SingleJar the target before using it as a scalac plugin " +
+                  "in order to avoid additional overhead.")
+
+            plugin_singlejar = ctx.actions.declare_file(
+                "{}/scalac_plugin_{}.jar".format(ctx.label.name, plugin.label.name),
+            )
+            _action_singlejar(
+                ctx,
+                inputs = deps,
+                output = plugin_singlejar,
+                progress_message = "singlejar scalac plugin %s" % plugin.label.name,
+            )
+            actual_plugins.append(plugin_singlejar)
+
+    actual_plugins = depset(actual_plugins)
 
     zinc_configuration = ctx.attr.scala[_ZincConfiguration]
 
@@ -162,7 +204,7 @@ def phase_compile(ctx, g):
     args.add("--output_setup", setup)
     args.add("--output_stamps", stamps)
     args.add("--output_used", used)
-    args.add_all("--plugins", splugins.transitive_runtime_deps)
+    args.add_all("--plugins", actual_plugins)
     args.add_all("--source_jars", src_jars)
     args.add("--tmp", tmp.path)
     args.add_all("--", srcs)
@@ -173,7 +215,7 @@ def phase_compile(ctx, g):
     inputs = depset(
         [zinc_configuration.compiler_bridge] + ctx.files.data + ctx.files.srcs + runner_inputs,
         transitive = [
-            splugins.transitive_runtime_deps,
+            actual_plugins,
             compile_classpath,
             g.init.scompiler_classpath.transitive_runtime_deps,
         ] + [zinc.deps_files for zinc in zincs],
@@ -390,39 +432,20 @@ def _depscheck_labeled_group(labeled_jars):
 #
 
 def phase_singlejar(ctx, g):
-    inputs = [g.compile.jar] + ctx.files.resource_jars
-    args = ctx.actions.args()
-    args.add("--exclude_build_data")
-    args.add("--normalize")
-
+    # We're going to declare all phase outputs as inputs but skip
+    # including them in the args for singlejar to process. This will
+    # cause the build to fail, cleanly, if any declared outputs are
+    # missing from previous phases.
+    inputs = [g.compile.jar] + [f for f in ctx.files.resource_jars if f.extension.lower() in ["jar"]]
+    phantom_inputs = []
     for v in [getattr(g, k) for k in dir(g) if k not in ["to_json", "to_proto"]]:
         if hasattr(v, "jar"):
             jar = getattr(v, "jar")
-            args.add("--sources", jar)
             inputs.append(jar)
         if hasattr(v, "outputs"):
-            # Declare all phase outputs as inputs but _don't_ include them in the args
-            # for singlejar to process. This will cause the build to fail, cleanly, if
-            # any declared outputs are missing from previous phases.
-            inputs.extend(getattr(v, "outputs"))
+            phantom_inputs.extend(getattr(v, "outputs"))
 
-    for file in [f for f in ctx.files.resource_jars if f.extension.lower() in ["jar"]]:
-        args.add("--sources")
-        args.add(file)
-
-    args.add("--output", ctx.outputs.jar)
-    args.add("--warn_duplicate_resources")
-    args.set_param_file_format("multiline")
-    args.use_param_file("@%s", use_always = True)
-
-    ctx.actions.run(
-        arguments = [args],
-        executable = ctx.executable._singlejar,
-        execution_requirements = {"supports-workers": "1"},
-        mnemonic = _SINGLE_JAR_MNEMONIC,
-        inputs = inputs,  # TODO: build up inputs as a depset
-        outputs = [ctx.outputs.jar],
-    )
+    _action_singlejar(ctx, inputs, ctx.outputs.jar, phantom_inputs)
 
 #
 # PHASE: javainfo
@@ -537,31 +560,18 @@ def phase_non_default_format(ctx, g):
 #
 
 def phase_binary_deployjar(ctx, g):
-    transitive_rjars = g.javainfo.java_info.transitive_runtime_jars
-    rjars = depset([ctx.outputs.jar], transitive = [transitive_rjars])
-    _binary_deployjar_build_deployable(ctx, rjars.to_list())
-
-def _binary_deployjar_build_deployable(ctx, jars_list):
-    # This calls bazels singlejar utility.
-    # For a full list of available command line options see:
-    # https://github.com/bazelbuild/bazel/blob/master/src/java_tools/singlejar/java/com/google/devtools/build/singlejar/SingleJar.java#L311
-    args = ctx.actions.args()
-    args.add("--normalize")
-    args.add("--compression")
-    args.add("--sources")
-    args.add_all([j.path for j in jars_list])
+    main_class = None
     if getattr(ctx.attr, "main_class", ""):
-        args.add_all(["--main_class", ctx.attr.main_class])
-    args.add_all(["--output", ctx.outputs.deploy_jar.path])
-
-    ctx.actions.run(
-        inputs = jars_list,
-        outputs = [ctx.outputs.deploy_jar],
-        executable = ctx.executable._singlejar,
-        execution_requirements = {"supports-workers": "1"},
-        mnemonic = _SINGLE_JAR_MNEMONIC,
+        main_class = ctx.attr.main_class
+    _action_singlejar(
+        ctx,
+        inputs = depset(
+            [ctx.outputs.jar],
+            transitive = [g.javainfo.java_info.transitive_runtime_jars],
+        ),
+        main_class = main_class,
+        output = ctx.outputs.deploy_jar,
         progress_message = "scala deployable %s" % ctx.label,
-        arguments = [args],
     )
 
 #

--- a/tests/compile/srcjar/expected
+++ b/tests/compile/srcjar/expected
@@ -1,8 +1,4 @@
-  Length      Date    Time    Name
----------  ---------- -----   ----
-        0  1980-01-01 00:00   META-INF/
-       48  1980-01-01 00:00   META-INF/MANIFEST.MF
-      377  1980-01-01 00:00   Example$.class
-      328  1980-01-01 00:00   Example.class
----------                     -------
-      753                     4 files
+-rw----     2.0 fat        0 bx  0% stor 19800101.000000 META-INF/
+-rw----     2.0 fat       48 b-  0% stor 19800101.000000 META-INF/MANIFEST.MF
+-rw----     2.0 fat      377 b-  0% stor 19800101.000002 Example$.class
+-rw----     2.0 fat      328 b-  0% stor 19800101.000002 Example.class

--- a/tests/compile/srcjar/test
+++ b/tests/compile/srcjar/test
@@ -3,7 +3,6 @@
 
 zip example.srcjar Example.scala
 bazel build :lib
-! unzip -v | grep -q Debian || diff expected  <( \
-  unzip -l "$(bazel info bazel-bin)/compile/srcjar/lib.jar" \
-  | tail -n+2 \
+diff expected  <(
+    zipinfo -m -T --h-t "$(bazel info bazel-bin)/compile/srcjar/lib.jar"
 )

--- a/tests/deployjar/expected
+++ b/tests/deployjar/expected
@@ -1,2555 +1,2550 @@
-  Length      Date    Time    Name
----------  ---------- -----   ----
-        0  1980-01-01 00:00   META-INF/
-       48  1980-01-01 00:00   META-INF/MANIFEST.MF
-       72  1980-01-01 00:00   build-data.properties
-        0  1980-01-01 00:00   foo/
-      838  1980-01-01 00:00   foo/TestBinary$.class
-      615  1980-01-01 00:00   foo/TestBinary.class
-      207  1980-01-01 00:00   library.properties
-     3956  1980-01-01 00:00   rootdoc.txt
-        0  1980-01-01 00:00   scala/
-      658  1980-01-01 00:00   scala/AnyVal.class
-      384  1980-01-01 00:00   scala/AnyValCompanion.class
-     5238  1980-01-01 00:00   scala/App.class
-     1678  1980-01-01 00:00   scala/Array$$anon$2.class
-    35320  1980-01-01 00:00   scala/Array$.class
-    15429  1980-01-01 00:00   scala/Array.class
-      938  1980-01-01 00:00   scala/Boolean$.class
-     1632  1980-01-01 00:00   scala/Boolean.class
-     1576  1980-01-01 00:00   scala/Byte$.class
-     7332  1980-01-01 00:00   scala/Byte.class
-     1481  1980-01-01 00:00   scala/Char$.class
-     7250  1980-01-01 00:00   scala/Char.class
-      369  1980-01-01 00:00   scala/Cloneable.class
-     5009  1980-01-01 00:00   scala/Console$.class
-     6127  1980-01-01 00:00   scala/Console.class
-      813  1980-01-01 00:00   scala/DelayedInit.class
-     5523  1980-01-01 00:00   scala/DeprecatedConsole.class
-     9093  1980-01-01 00:00   scala/DeprecatedPredef.class
-     1434  1980-01-01 00:00   scala/Double$.class
-     6244  1980-01-01 00:00   scala/Double.class
-      300  1980-01-01 00:00   scala/Dynamic.class
-     3735  1980-01-01 00:00   scala/Enumeration$Val.class
-     2824  1980-01-01 00:00   scala/Enumeration$Value.class
-     3652  1980-01-01 00:00   scala/Enumeration$ValueOrdering$.class
-     4923  1980-01-01 00:00   scala/Enumeration$ValueSet$$anon$1.class
-     1725  1980-01-01 00:00   scala/Enumeration$ValueSet$$anon$2.class
-     2496  1980-01-01 00:00   scala/Enumeration$ValueSet$.class
-    15943  1980-01-01 00:00   scala/Enumeration$ValueSet.class
-    16749  1980-01-01 00:00   scala/Enumeration.class
-      507  1980-01-01 00:00   scala/Equals.class
-     1457  1980-01-01 00:00   scala/FallbackArrayBuilding$$anon$1.class
-     1474  1980-01-01 00:00   scala/FallbackArrayBuilding.class
-     1510  1980-01-01 00:00   scala/Float$.class
-     6321  1980-01-01 00:00   scala/Float.class
-    11715  1980-01-01 00:00   scala/Function$.class
-     6646  1980-01-01 00:00   scala/Function.class
-      291  1980-01-01 00:00   scala/Function0$mcB$sp.class
-      291  1980-01-01 00:00   scala/Function0$mcC$sp.class
-      291  1980-01-01 00:00   scala/Function0$mcD$sp.class
-      291  1980-01-01 00:00   scala/Function0$mcF$sp.class
-      291  1980-01-01 00:00   scala/Function0$mcI$sp.class
-      291  1980-01-01 00:00   scala/Function0$mcJ$sp.class
-      291  1980-01-01 00:00   scala/Function0$mcS$sp.class
-      298  1980-01-01 00:00   scala/Function0$mcV$sp.class
-      291  1980-01-01 00:00   scala/Function0$mcZ$sp.class
-     3726  1980-01-01 00:00   scala/Function0.class
-      328  1980-01-01 00:00   scala/Function1$mcDD$sp.class
-      328  1980-01-01 00:00   scala/Function1$mcDF$sp.class
-      328  1980-01-01 00:00   scala/Function1$mcDI$sp.class
-      328  1980-01-01 00:00   scala/Function1$mcDJ$sp.class
-      328  1980-01-01 00:00   scala/Function1$mcFD$sp.class
-      328  1980-01-01 00:00   scala/Function1$mcFF$sp.class
-      328  1980-01-01 00:00   scala/Function1$mcFI$sp.class
-      328  1980-01-01 00:00   scala/Function1$mcFJ$sp.class
-      328  1980-01-01 00:00   scala/Function1$mcID$sp.class
-      328  1980-01-01 00:00   scala/Function1$mcIF$sp.class
-      328  1980-01-01 00:00   scala/Function1$mcII$sp.class
-      328  1980-01-01 00:00   scala/Function1$mcIJ$sp.class
-      328  1980-01-01 00:00   scala/Function1$mcJD$sp.class
-      328  1980-01-01 00:00   scala/Function1$mcJF$sp.class
-      328  1980-01-01 00:00   scala/Function1$mcJI$sp.class
-      328  1980-01-01 00:00   scala/Function1$mcJJ$sp.class
-      335  1980-01-01 00:00   scala/Function1$mcVD$sp.class
-      335  1980-01-01 00:00   scala/Function1$mcVF$sp.class
-      335  1980-01-01 00:00   scala/Function1$mcVI$sp.class
-      335  1980-01-01 00:00   scala/Function1$mcVJ$sp.class
-      328  1980-01-01 00:00   scala/Function1$mcZD$sp.class
-      328  1980-01-01 00:00   scala/Function1$mcZF$sp.class
-      328  1980-01-01 00:00   scala/Function1$mcZI$sp.class
-      328  1980-01-01 00:00   scala/Function1$mcZJ$sp.class
-    10435  1980-01-01 00:00   scala/Function1.class
-     5643  1980-01-01 00:00   scala/Function10.class
-     5868  1980-01-01 00:00   scala/Function11.class
-     6100  1980-01-01 00:00   scala/Function12.class
-     6326  1980-01-01 00:00   scala/Function13.class
-     6555  1980-01-01 00:00   scala/Function14.class
-     6785  1980-01-01 00:00   scala/Function15.class
-     7015  1980-01-01 00:00   scala/Function16.class
-     7245  1980-01-01 00:00   scala/Function17.class
-     7474  1980-01-01 00:00   scala/Function18.class
-     7724  1980-01-01 00:00   scala/Function19.class
-      365  1980-01-01 00:00   scala/Function2$mcDDD$sp.class
-      365  1980-01-01 00:00   scala/Function2$mcDDI$sp.class
-      365  1980-01-01 00:00   scala/Function2$mcDDJ$sp.class
-      365  1980-01-01 00:00   scala/Function2$mcDID$sp.class
-      365  1980-01-01 00:00   scala/Function2$mcDII$sp.class
-      365  1980-01-01 00:00   scala/Function2$mcDIJ$sp.class
-      365  1980-01-01 00:00   scala/Function2$mcDJD$sp.class
-      365  1980-01-01 00:00   scala/Function2$mcDJI$sp.class
-      365  1980-01-01 00:00   scala/Function2$mcDJJ$sp.class
-      365  1980-01-01 00:00   scala/Function2$mcFDD$sp.class
-      365  1980-01-01 00:00   scala/Function2$mcFDI$sp.class
-      365  1980-01-01 00:00   scala/Function2$mcFDJ$sp.class
-      365  1980-01-01 00:00   scala/Function2$mcFID$sp.class
-      365  1980-01-01 00:00   scala/Function2$mcFII$sp.class
-      365  1980-01-01 00:00   scala/Function2$mcFIJ$sp.class
-      365  1980-01-01 00:00   scala/Function2$mcFJD$sp.class
-      365  1980-01-01 00:00   scala/Function2$mcFJI$sp.class
-      365  1980-01-01 00:00   scala/Function2$mcFJJ$sp.class
-      365  1980-01-01 00:00   scala/Function2$mcIDD$sp.class
-      365  1980-01-01 00:00   scala/Function2$mcIDI$sp.class
-      365  1980-01-01 00:00   scala/Function2$mcIDJ$sp.class
-      365  1980-01-01 00:00   scala/Function2$mcIID$sp.class
-      365  1980-01-01 00:00   scala/Function2$mcIII$sp.class
-      365  1980-01-01 00:00   scala/Function2$mcIIJ$sp.class
-      365  1980-01-01 00:00   scala/Function2$mcIJD$sp.class
-      365  1980-01-01 00:00   scala/Function2$mcIJI$sp.class
-      365  1980-01-01 00:00   scala/Function2$mcIJJ$sp.class
-      365  1980-01-01 00:00   scala/Function2$mcJDD$sp.class
-      365  1980-01-01 00:00   scala/Function2$mcJDI$sp.class
-      365  1980-01-01 00:00   scala/Function2$mcJDJ$sp.class
-      365  1980-01-01 00:00   scala/Function2$mcJID$sp.class
-      365  1980-01-01 00:00   scala/Function2$mcJII$sp.class
-      365  1980-01-01 00:00   scala/Function2$mcJIJ$sp.class
-      365  1980-01-01 00:00   scala/Function2$mcJJD$sp.class
-      365  1980-01-01 00:00   scala/Function2$mcJJI$sp.class
-      365  1980-01-01 00:00   scala/Function2$mcJJJ$sp.class
-      372  1980-01-01 00:00   scala/Function2$mcVDD$sp.class
-      372  1980-01-01 00:00   scala/Function2$mcVDI$sp.class
-      372  1980-01-01 00:00   scala/Function2$mcVDJ$sp.class
-      372  1980-01-01 00:00   scala/Function2$mcVID$sp.class
-      372  1980-01-01 00:00   scala/Function2$mcVII$sp.class
-      372  1980-01-01 00:00   scala/Function2$mcVIJ$sp.class
-      372  1980-01-01 00:00   scala/Function2$mcVJD$sp.class
-      372  1980-01-01 00:00   scala/Function2$mcVJI$sp.class
-      372  1980-01-01 00:00   scala/Function2$mcVJJ$sp.class
-      365  1980-01-01 00:00   scala/Function2$mcZDD$sp.class
-      365  1980-01-01 00:00   scala/Function2$mcZDI$sp.class
-      365  1980-01-01 00:00   scala/Function2$mcZDJ$sp.class
-      365  1980-01-01 00:00   scala/Function2$mcZID$sp.class
-      365  1980-01-01 00:00   scala/Function2$mcZII$sp.class
-      365  1980-01-01 00:00   scala/Function2$mcZIJ$sp.class
-      365  1980-01-01 00:00   scala/Function2$mcZJD$sp.class
-      365  1980-01-01 00:00   scala/Function2$mcZJI$sp.class
-      365  1980-01-01 00:00   scala/Function2$mcZJJ$sp.class
-    20688  1980-01-01 00:00   scala/Function2.class
-     7958  1980-01-01 00:00   scala/Function20.class
-     8192  1980-01-01 00:00   scala/Function21.class
-     8426  1980-01-01 00:00   scala/Function22.class
-     4220  1980-01-01 00:00   scala/Function3.class
-     4702  1980-01-01 00:00   scala/Function4.class
-     4547  1980-01-01 00:00   scala/Function5.class
-     4760  1980-01-01 00:00   scala/Function6.class
-     4976  1980-01-01 00:00   scala/Function7.class
-     5189  1980-01-01 00:00   scala/Function8.class
-     5402  1980-01-01 00:00   scala/Function9.class
-      310  1980-01-01 00:00   scala/Immutable.class
-     1376  1980-01-01 00:00   scala/Int$.class
-     7147  1980-01-01 00:00   scala/Int.class
-     1286  1980-01-01 00:00   scala/Long$.class
-     7050  1980-01-01 00:00   scala/Long.class
-     1652  1980-01-01 00:00   scala/LowPriorityImplicits$$anon$4.class
-     8361  1980-01-01 00:00   scala/LowPriorityImplicits.class
-     1913  1980-01-01 00:00   scala/MatchError.class
-      303  1980-01-01 00:00   scala/Mutable.class
-     2110  1980-01-01 00:00   scala/None$.class
-     5063  1980-01-01 00:00   scala/None.class
-      858  1980-01-01 00:00   scala/NotImplementedError.class
-      397  1980-01-01 00:00   scala/NotNull.class
-     1373  1980-01-01 00:00   scala/Option$.class
-     3711  1980-01-01 00:00   scala/Option$WithFilter.class
-    10570  1980-01-01 00:00   scala/Option.class
-     8333  1980-01-01 00:00   scala/PartialFunction$$anon$1.class
-     1254  1980-01-01 00:00   scala/PartialFunction$$anonfun$1.class
-     1325  1980-01-01 00:00   scala/PartialFunction$$anonfun$apply$1.class
-     4257  1980-01-01 00:00   scala/PartialFunction$.class
-     8437  1980-01-01 00:00   scala/PartialFunction$AndThen.class
-     1776  1980-01-01 00:00   scala/PartialFunction$Lifted.class
-     2909  1980-01-01 00:00   scala/PartialFunction$OrElse.class
-     1680  1980-01-01 00:00   scala/PartialFunction$Unlifted.class
-     8283  1980-01-01 00:00   scala/PartialFunction.class
-      724  1980-01-01 00:00   scala/Predef$$anon$1.class
-      712  1980-01-01 00:00   scala/Predef$$anon$2.class
-     1344  1980-01-01 00:00   scala/Predef$$anon$3.class
-      982  1980-01-01 00:00   scala/Predef$$eq$colon$eq$.class
-     6075  1980-01-01 00:00   scala/Predef$$eq$colon$eq.class
-     6087  1980-01-01 00:00   scala/Predef$$less$colon$less.class
-    19181  1980-01-01 00:00   scala/Predef$.class
-     1653  1980-01-01 00:00   scala/Predef$ArrayCharSequence.class
-     1694  1980-01-01 00:00   scala/Predef$ArrowAssoc$.class
-     1757  1980-01-01 00:00   scala/Predef$ArrowAssoc.class
-      663  1980-01-01 00:00   scala/Predef$DummyImplicit$.class
-      396  1980-01-01 00:00   scala/Predef$DummyImplicit.class
-     3041  1980-01-01 00:00   scala/Predef$Ensuring$.class
-     2748  1980-01-01 00:00   scala/Predef$Ensuring.class
-     1174  1980-01-01 00:00   scala/Predef$Pair$.class
-     1966  1980-01-01 00:00   scala/Predef$RichException$.class
-     1361  1980-01-01 00:00   scala/Predef$RichException.class
-     1894  1980-01-01 00:00   scala/Predef$SeqCharSequence.class
-     1873  1980-01-01 00:00   scala/Predef$StringFormat$.class
-     1812  1980-01-01 00:00   scala/Predef$StringFormat.class
-     1287  1980-01-01 00:00   scala/Predef$Triple$.class
-     1760  1980-01-01 00:00   scala/Predef$any2stringadd$.class
-     1472  1980-01-01 00:00   scala/Predef$any2stringadd.class
-    24873  1980-01-01 00:00   scala/Predef.class
-     1381  1980-01-01 00:00   scala/Product$$anon$1.class
-     1586  1980-01-01 00:00   scala/Product.class
-      732  1980-01-01 00:00   scala/Product1$.class
-      252  1980-01-01 00:00   scala/Product1$mcD$sp.class
-      252  1980-01-01 00:00   scala/Product1$mcI$sp.class
-      252  1980-01-01 00:00   scala/Product1$mcJ$sp.class
-     3046  1980-01-01 00:00   scala/Product1.class
-     1003  1980-01-01 00:00   scala/Product10$.class
-     3701  1980-01-01 00:00   scala/Product10.class
-     1035  1980-01-01 00:00   scala/Product11$.class
-     3883  1980-01-01 00:00   scala/Product11.class
-     1067  1980-01-01 00:00   scala/Product12$.class
-     4066  1980-01-01 00:00   scala/Product12.class
-     1099  1980-01-01 00:00   scala/Product13$.class
-     4247  1980-01-01 00:00   scala/Product13.class
-     1131  1980-01-01 00:00   scala/Product14$.class
-     4428  1980-01-01 00:00   scala/Product14.class
-     1163  1980-01-01 00:00   scala/Product15$.class
-     4609  1980-01-01 00:00   scala/Product15.class
-     1195  1980-01-01 00:00   scala/Product16$.class
-     4790  1980-01-01 00:00   scala/Product16.class
-     1227  1980-01-01 00:00   scala/Product17$.class
-     4971  1980-01-01 00:00   scala/Product17.class
-     1259  1980-01-01 00:00   scala/Product18$.class
-     5152  1980-01-01 00:00   scala/Product18.class
-     1291  1980-01-01 00:00   scala/Product19$.class
-     5333  1980-01-01 00:00   scala/Product19.class
-      761  1980-01-01 00:00   scala/Product2$.class
-      271  1980-01-01 00:00   scala/Product2$mcDD$sp.class
-      271  1980-01-01 00:00   scala/Product2$mcDI$sp.class
-      271  1980-01-01 00:00   scala/Product2$mcDJ$sp.class
-      271  1980-01-01 00:00   scala/Product2$mcID$sp.class
-      271  1980-01-01 00:00   scala/Product2$mcII$sp.class
-      271  1980-01-01 00:00   scala/Product2$mcIJ$sp.class
-      271  1980-01-01 00:00   scala/Product2$mcJD$sp.class
-      271  1980-01-01 00:00   scala/Product2$mcJI$sp.class
-      271  1980-01-01 00:00   scala/Product2$mcJJ$sp.class
-     3788  1980-01-01 00:00   scala/Product2.class
-     1323  1980-01-01 00:00   scala/Product20$.class
-     5514  1980-01-01 00:00   scala/Product20.class
-     1355  1980-01-01 00:00   scala/Product21$.class
-     5695  1980-01-01 00:00   scala/Product21.class
-     1387  1980-01-01 00:00   scala/Product22$.class
-     5876  1980-01-01 00:00   scala/Product22.class
-      790  1980-01-01 00:00   scala/Product3$.class
-     2513  1980-01-01 00:00   scala/Product3.class
-      819  1980-01-01 00:00   scala/Product4$.class
-     2674  1980-01-01 00:00   scala/Product4.class
-      848  1980-01-01 00:00   scala/Product5$.class
-     2836  1980-01-01 00:00   scala/Product5.class
-      877  1980-01-01 00:00   scala/Product6$.class
-     2998  1980-01-01 00:00   scala/Product6.class
-      906  1980-01-01 00:00   scala/Product7$.class
-     3159  1980-01-01 00:00   scala/Product7.class
-      935  1980-01-01 00:00   scala/Product8$.class
-     3330  1980-01-01 00:00   scala/Product8.class
-      964  1980-01-01 00:00   scala/Product9$.class
-     3505  1980-01-01 00:00   scala/Product9.class
-      387  1980-01-01 00:00   scala/Proxy$.class
-      339  1980-01-01 00:00   scala/Proxy$Typed.class
-     1892  1980-01-01 00:00   scala/Proxy.class
-      915  1980-01-01 00:00   scala/Responder$$anon$1.class
-     2417  1980-01-01 00:00   scala/Responder$$anon$2.class
-     2413  1980-01-01 00:00   scala/Responder$$anon$3.class
-     2514  1980-01-01 00:00   scala/Responder$$anon$4.class
-     5141  1980-01-01 00:00   scala/Responder$.class
-     5028  1980-01-01 00:00   scala/Responder.class
-     1693  1980-01-01 00:00   scala/ScalaReflectionException$.class
-     5306  1980-01-01 00:00   scala/ScalaReflectionException.class
-      744  1980-01-01 00:00   scala/SerialVersionUID.class
-      377  1980-01-01 00:00   scala/Serializable.class
-     1483  1980-01-01 00:00   scala/Short$.class
-     7246  1980-01-01 00:00   scala/Short.class
-     1230  1980-01-01 00:00   scala/Some$.class
-     4725  1980-01-01 00:00   scala/Some.class
-     4548  1980-01-01 00:00   scala/Specializable$.class
-      682  1980-01-01 00:00   scala/Specializable$Group.class
-      248  1980-01-01 00:00   scala/Specializable$SpecializedGroup.class
-     2760  1980-01-01 00:00   scala/Specializable.class
-     3889  1980-01-01 00:00   scala/StringContext$.class
-     2023  1980-01-01 00:00   scala/StringContext$InvalidEscapeException.class
-     7956  1980-01-01 00:00   scala/StringContext.class
-     1711  1980-01-01 00:00   scala/Symbol$.class
-     2358  1980-01-01 00:00   scala/Symbol.class
-     2680  1980-01-01 00:00   scala/Tuple1$.class
-     1242  1980-01-01 00:00   scala/Tuple1$mcD$sp.class
-     1244  1980-01-01 00:00   scala/Tuple1$mcI$sp.class
-     1238  1980-01-01 00:00   scala/Tuple1$mcJ$sp.class
-     6023  1980-01-01 00:00   scala/Tuple1.class
-     2501  1980-01-01 00:00   scala/Tuple10$.class
-    13153  1980-01-01 00:00   scala/Tuple10.class
-     2637  1980-01-01 00:00   scala/Tuple11$.class
-    14500  1980-01-01 00:00   scala/Tuple11.class
-     2773  1980-01-01 00:00   scala/Tuple12$.class
-    15915  1980-01-01 00:00   scala/Tuple12.class
-     2909  1980-01-01 00:00   scala/Tuple13$.class
-    17406  1980-01-01 00:00   scala/Tuple13.class
-     3045  1980-01-01 00:00   scala/Tuple14$.class
-    18947  1980-01-01 00:00   scala/Tuple14.class
-     3181  1980-01-01 00:00   scala/Tuple15$.class
-    20568  1980-01-01 00:00   scala/Tuple15.class
-     3317  1980-01-01 00:00   scala/Tuple16$.class
-    22236  1980-01-01 00:00   scala/Tuple16.class
-     3453  1980-01-01 00:00   scala/Tuple17$.class
-    23984  1980-01-01 00:00   scala/Tuple17.class
-     3589  1980-01-01 00:00   scala/Tuple18$.class
-    25800  1980-01-01 00:00   scala/Tuple18.class
-     3725  1980-01-01 00:00   scala/Tuple19$.class
-    27672  1980-01-01 00:00   scala/Tuple19.class
-    11897  1980-01-01 00:00   scala/Tuple2$.class
-     2075  1980-01-01 00:00   scala/Tuple2$mcCC$sp.class
-     2217  1980-01-01 00:00   scala/Tuple2$mcCD$sp.class
-     2219  1980-01-01 00:00   scala/Tuple2$mcCI$sp.class
-     2213  1980-01-01 00:00   scala/Tuple2$mcCJ$sp.class
-     2213  1980-01-01 00:00   scala/Tuple2$mcCZ$sp.class
-     2217  1980-01-01 00:00   scala/Tuple2$mcDC$sp.class
-     2123  1980-01-01 00:00   scala/Tuple2$mcDD$sp.class
-     2267  1980-01-01 00:00   scala/Tuple2$mcDI$sp.class
-     2261  1980-01-01 00:00   scala/Tuple2$mcDJ$sp.class
-     2207  1980-01-01 00:00   scala/Tuple2$mcDZ$sp.class
-     2219  1980-01-01 00:00   scala/Tuple2$mcIC$sp.class
-     2267  1980-01-01 00:00   scala/Tuple2$mcID$sp.class
-     2125  1980-01-01 00:00   scala/Tuple2$mcII$sp.class
-     2263  1980-01-01 00:00   scala/Tuple2$mcIJ$sp.class
-     2209  1980-01-01 00:00   scala/Tuple2$mcIZ$sp.class
-     2213  1980-01-01 00:00   scala/Tuple2$mcJC$sp.class
-     2261  1980-01-01 00:00   scala/Tuple2$mcJD$sp.class
-     2263  1980-01-01 00:00   scala/Tuple2$mcJI$sp.class
-     2119  1980-01-01 00:00   scala/Tuple2$mcJJ$sp.class
-     2203  1980-01-01 00:00   scala/Tuple2$mcJZ$sp.class
-     2213  1980-01-01 00:00   scala/Tuple2$mcZC$sp.class
-     2207  1980-01-01 00:00   scala/Tuple2$mcZD$sp.class
-     2209  1980-01-01 00:00   scala/Tuple2$mcZI$sp.class
-     2203  1980-01-01 00:00   scala/Tuple2$mcZJ$sp.class
-     2065  1980-01-01 00:00   scala/Tuple2$mcZZ$sp.class
-    16966  1980-01-01 00:00   scala/Tuple2.class
-     3861  1980-01-01 00:00   scala/Tuple20$.class
-    29624  1980-01-01 00:00   scala/Tuple20.class
-     3997  1980-01-01 00:00   scala/Tuple21$.class
-    31632  1980-01-01 00:00   scala/Tuple21.class
-     4133  1980-01-01 00:00   scala/Tuple22$.class
-    33714  1980-01-01 00:00   scala/Tuple22.class
-     1580  1980-01-01 00:00   scala/Tuple3$.class
-     5729  1980-01-01 00:00   scala/Tuple3.class
-     1709  1980-01-01 00:00   scala/Tuple4$.class
-     6574  1980-01-01 00:00   scala/Tuple4.class
-     1838  1980-01-01 00:00   scala/Tuple5$.class
-     7490  1980-01-01 00:00   scala/Tuple5.class
-     1967  1980-01-01 00:00   scala/Tuple6$.class
-     8475  1980-01-01 00:00   scala/Tuple6.class
-     2096  1980-01-01 00:00   scala/Tuple7$.class
-     9532  1980-01-01 00:00   scala/Tuple7.class
-     2225  1980-01-01 00:00   scala/Tuple8$.class
-    10654  1980-01-01 00:00   scala/Tuple8.class
-     2354  1980-01-01 00:00   scala/Tuple9$.class
-    11841  1980-01-01 00:00   scala/Tuple9.class
-      629  1980-01-01 00:00   scala/UninitializedError.class
-     1700  1980-01-01 00:00   scala/UninitializedFieldError$.class
-     5519  1980-01-01 00:00   scala/UninitializedFieldError.class
-     4084  1980-01-01 00:00   scala/UniquenessCache.class
-      915  1980-01-01 00:00   scala/Unit$.class
-     1185  1980-01-01 00:00   scala/Unit.class
-     1079  1980-01-01 00:00   scala/ValueOf$.class
-     1933  1980-01-01 00:00   scala/ValueOf.class
-        0  1980-01-01 00:00   scala/annotation/
-      544  1980-01-01 00:00   scala/annotation/Annotation.class
-      447  1980-01-01 00:00   scala/annotation/ClassfileAnnotation.class
-      366  1980-01-01 00:00   scala/annotation/StaticAnnotation.class
-      359  1980-01-01 00:00   scala/annotation/TypeConstraint.class
-      757  1980-01-01 00:00   scala/annotation/bridge.class
-     1017  1980-01-01 00:00   scala/annotation/compileTimeOnly.class
-     3984  1980-01-01 00:00   scala/annotation/elidable$.class
-     2505  1980-01-01 00:00   scala/annotation/elidable.class
-      836  1980-01-01 00:00   scala/annotation/implicitAmbiguous.class
-      832  1980-01-01 00:00   scala/annotation/implicitNotFound.class
-      623  1980-01-01 00:00   scala/annotation/inductive.class
-        0  1980-01-01 00:00   scala/annotation/meta/
-      652  1980-01-01 00:00   scala/annotation/meta/beanGetter.class
-      652  1980-01-01 00:00   scala/annotation/meta/beanSetter.class
-      669  1980-01-01 00:00   scala/annotation/meta/companionClass.class
-      673  1980-01-01 00:00   scala/annotation/meta/companionMethod.class
-      673  1980-01-01 00:00   scala/annotation/meta/companionObject.class
-      631  1980-01-01 00:00   scala/annotation/meta/field.class
-      636  1980-01-01 00:00   scala/annotation/meta/getter.class
-      959  1980-01-01 00:00   scala/annotation/meta/languageFeature.class
-      421  1980-01-01 00:00   scala/annotation/meta/package$.class
-      366  1980-01-01 00:00   scala/annotation/meta/package.class
-      631  1980-01-01 00:00   scala/annotation/meta/param.class
-      636  1980-01-01 00:00   scala/annotation/meta/setter.class
-      890  1980-01-01 00:00   scala/annotation/migration.class
-      522  1980-01-01 00:00   scala/annotation/showAsInfix$.class
-     1097  1980-01-01 00:00   scala/annotation/showAsInfix.class
-      619  1980-01-01 00:00   scala/annotation/strictfp.class
-      611  1980-01-01 00:00   scala/annotation/switch.class
-      615  1980-01-01 00:00   scala/annotation/tailrec.class
-        0  1980-01-01 00:00   scala/annotation/unchecked/
-      689  1980-01-01 00:00   scala/annotation/unchecked/uncheckedStable.class
-      697  1980-01-01 00:00   scala/annotation/unchecked/uncheckedVariance.class
-      640  1980-01-01 00:00   scala/annotation/unspecialized.class
-      615  1980-01-01 00:00   scala/annotation/varargs.class
-        0  1980-01-01 00:00   scala/beans/
-      922  1980-01-01 00:00   scala/beans/BeanDescription.class
-      899  1980-01-01 00:00   scala/beans/BeanDisplayName.class
-      689  1980-01-01 00:00   scala/beans/BeanInfo.class
-      570  1980-01-01 00:00   scala/beans/BeanInfoSkip.class
-      678  1980-01-01 00:00   scala/beans/BeanProperty.class
-      707  1980-01-01 00:00   scala/beans/BooleanBeanProperty.class
-     6138  1980-01-01 00:00   scala/beans/ScalaBeanInfo.class
-        0  1980-01-01 00:00   scala/collection/
-     1489  1980-01-01 00:00   scala/collection/$colon$plus$.class
-      912  1980-01-01 00:00   scala/collection/$colon$plus.class
-     1489  1980-01-01 00:00   scala/collection/$plus$colon$.class
-      912  1980-01-01 00:00   scala/collection/$plus$colon.class
-    10474  1980-01-01 00:00   scala/collection/AbstractIterable.class
-    28653  1980-01-01 00:00   scala/collection/AbstractIterator.class
-    18850  1980-01-01 00:00   scala/collection/AbstractMap.class
-    22450  1980-01-01 00:00   scala/collection/AbstractSeq.class
-    15774  1980-01-01 00:00   scala/collection/AbstractSet.class
-    33564  1980-01-01 00:00   scala/collection/AbstractTraversable.class
-     2029  1980-01-01 00:00   scala/collection/BitSet$.class
-     1811  1980-01-01 00:00   scala/collection/BitSet.class
-     1963  1980-01-01 00:00   scala/collection/BitSetLike$$anon$1.class
-     1265  1980-01-01 00:00   scala/collection/BitSetLike$.class
-    14363  1980-01-01 00:00   scala/collection/BitSetLike.class
-     1825  1980-01-01 00:00   scala/collection/BufferedIterator.class
-     1598  1980-01-01 00:00   scala/collection/CustomParallelizable.class
-     5109  1980-01-01 00:00   scala/collection/DebugUtils$.class
-     1693  1980-01-01 00:00   scala/collection/DebugUtils.class
-     4014  1980-01-01 00:00   scala/collection/DefaultMap.class
-     1308  1980-01-01 00:00   scala/collection/GenIterable$.class
-     8538  1980-01-01 00:00   scala/collection/GenIterable.class
-     2473  1980-01-01 00:00   scala/collection/GenIterableLike.class
-     1396  1980-01-01 00:00   scala/collection/GenMap$.class
-     2055  1980-01-01 00:00   scala/collection/GenMap.class
-     6509  1980-01-01 00:00   scala/collection/GenMapLike.class
-     1268  1980-01-01 00:00   scala/collection/GenSeq$.class
-     8443  1980-01-01 00:00   scala/collection/GenSeq.class
-    11885  1980-01-01 00:00   scala/collection/GenSeqLike.class
-     1278  1980-01-01 00:00   scala/collection/GenSet$.class
-     8476  1980-01-01 00:00   scala/collection/GenSet.class
-     4935  1980-01-01 00:00   scala/collection/GenSetLike.class
-     1332  1980-01-01 00:00   scala/collection/GenTraversable$.class
-    11244  1980-01-01 00:00   scala/collection/GenTraversable.class
-     6211  1980-01-01 00:00   scala/collection/GenTraversableLike.class
-    10338  1980-01-01 00:00   scala/collection/GenTraversableOnce.class
-     1102  1980-01-01 00:00   scala/collection/IndexedSeq$$anon$1.class
-     1925  1980-01-01 00:00   scala/collection/IndexedSeq$.class
-     8946  1980-01-01 00:00   scala/collection/IndexedSeq.class
-     3604  1980-01-01 00:00   scala/collection/IndexedSeqLike$Elements.class
-     4240  1980-01-01 00:00   scala/collection/IndexedSeqLike.class
-     1585  1980-01-01 00:00   scala/collection/IndexedSeqOptimized$$anon$1.class
-    24319  1980-01-01 00:00   scala/collection/IndexedSeqOptimized.class
-     1486  1980-01-01 00:00   scala/collection/Iterable$.class
-     8893  1980-01-01 00:00   scala/collection/Iterable.class
-    45922  1980-01-01 00:00   scala/collection/IterableLike$$anon$1.class
-    20245  1980-01-01 00:00   scala/collection/IterableLike.class
-      863  1980-01-01 00:00   scala/collection/IterableProxy.class
-     7655  1980-01-01 00:00   scala/collection/IterableProxyLike.class
-     1747  1980-01-01 00:00   scala/collection/IterableView$$anon$1.class
-      865  1980-01-01 00:00   scala/collection/IterableView$.class
-     1482  1980-01-01 00:00   scala/collection/IterableView.class
-     2784  1980-01-01 00:00   scala/collection/IterableViewLike$$anon$1.class
-     2177  1980-01-01 00:00   scala/collection/IterableViewLike$$anon$10.class
-     2662  1980-01-01 00:00   scala/collection/IterableViewLike$$anon$11.class
-     2803  1980-01-01 00:00   scala/collection/IterableViewLike$$anon$2.class
-     2813  1980-01-01 00:00   scala/collection/IterableViewLike$$anon$3.class
-     3640  1980-01-01 00:00   scala/collection/IterableViewLike$$anon$4.class
-     3778  1980-01-01 00:00   scala/collection/IterableViewLike$$anon$5.class
-     3703  1980-01-01 00:00   scala/collection/IterableViewLike$$anon$6.class
-     2969  1980-01-01 00:00   scala/collection/IterableViewLike$$anon$7.class
-     2778  1980-01-01 00:00   scala/collection/IterableViewLike$$anon$8.class
-     4067  1980-01-01 00:00   scala/collection/IterableViewLike$$anon$9.class
-    46300  1980-01-01 00:00   scala/collection/IterableViewLike$AbstractTransformed.class
-     2655  1980-01-01 00:00   scala/collection/IterableViewLike$Appended.class
-     1594  1980-01-01 00:00   scala/collection/IterableViewLike$DroppedWhile.class
-     1538  1980-01-01 00:00   scala/collection/IterableViewLike$EmptyView.class
-     1555  1980-01-01 00:00   scala/collection/IterableViewLike$Filtered.class
-     1604  1980-01-01 00:00   scala/collection/IterableViewLike$FlatMapped.class
-     1483  1980-01-01 00:00   scala/collection/IterableViewLike$Forced.class
-     1564  1980-01-01 00:00   scala/collection/IterableViewLike$Mapped.class
-     2722  1980-01-01 00:00   scala/collection/IterableViewLike$Prepended.class
-     1529  1980-01-01 00:00   scala/collection/IterableViewLike$Sliced.class
-     1576  1980-01-01 00:00   scala/collection/IterableViewLike$TakenWhile.class
-     2173  1980-01-01 00:00   scala/collection/IterableViewLike$Transformed.class
-     1841  1980-01-01 00:00   scala/collection/IterableViewLike$Zipped.class
-     2063  1980-01-01 00:00   scala/collection/IterableViewLike$ZippedAll.class
-    20233  1980-01-01 00:00   scala/collection/IterableViewLike.class
-     2306  1980-01-01 00:00   scala/collection/Iterator$$anon$1.class
-     1184  1980-01-01 00:00   scala/collection/Iterator$$anon$10.class
-     1973  1980-01-01 00:00   scala/collection/Iterator$$anon$11.class
-     2055  1980-01-01 00:00   scala/collection/Iterator$$anon$12.class
-     1632  1980-01-01 00:00   scala/collection/Iterator$$anon$13.class
-     1989  1980-01-01 00:00   scala/collection/Iterator$$anon$14.class
-     2378  1980-01-01 00:00   scala/collection/Iterator$$anon$15.class
-     1776  1980-01-01 00:00   scala/collection/Iterator$$anon$16.class
-     1704  1980-01-01 00:00   scala/collection/Iterator$$anon$17.class
-     1344  1980-01-01 00:00   scala/collection/Iterator$$anon$18.class
-     1632  1980-01-01 00:00   scala/collection/Iterator$$anon$19.class
-      924  1980-01-01 00:00   scala/collection/Iterator$$anon$2.class
-     1633  1980-01-01 00:00   scala/collection/Iterator$$anon$20.class
-     1799  1980-01-01 00:00   scala/collection/Iterator$$anon$21.class
-     2116  1980-01-01 00:00   scala/collection/Iterator$$anon$22.class
-     1919  1980-01-01 00:00   scala/collection/Iterator$$anon$23.class
-     1334  1980-01-01 00:00   scala/collection/Iterator$$anon$3.class
-     1448  1980-01-01 00:00   scala/collection/Iterator$$anon$4.class
-     1621  1980-01-01 00:00   scala/collection/Iterator$$anon$5.class
-     1771  1980-01-01 00:00   scala/collection/Iterator$$anon$6.class
-     1202  1980-01-01 00:00   scala/collection/Iterator$$anon$7.class
-     1293  1980-01-01 00:00   scala/collection/Iterator$$anon$8.class
-      936  1980-01-01 00:00   scala/collection/Iterator$$anon$9.class
-     4278  1980-01-01 00:00   scala/collection/Iterator$.class
-    30807  1980-01-01 00:00   scala/collection/Iterator$ConcatIterator.class
-     1686  1980-01-01 00:00   scala/collection/Iterator$ConcatIteratorCell.class
-     9246  1980-01-01 00:00   scala/collection/Iterator$GroupedIterator.class
-     2668  1980-01-01 00:00   scala/collection/Iterator$Leading$1.class
-     2545  1980-01-01 00:00   scala/collection/Iterator$PartitionIterator$1.class
-     2363  1980-01-01 00:00   scala/collection/Iterator$Partner$1.class
-     3071  1980-01-01 00:00   scala/collection/Iterator$SliceIterator.class
-    34873  1980-01-01 00:00   scala/collection/Iterator.class
-    16869  1980-01-01 00:00   scala/collection/JavaConversions$.class
-     7722  1980-01-01 00:00   scala/collection/JavaConversions.class
-    22368  1980-01-01 00:00   scala/collection/JavaConverters$.class
-    12862  1980-01-01 00:00   scala/collection/JavaConverters.class
-     1400  1980-01-01 00:00   scala/collection/LinearSeq$.class
-     8797  1980-01-01 00:00   scala/collection/LinearSeq.class
-     1872  1980-01-01 00:00   scala/collection/LinearSeqLike$$anon$1.class
-     3845  1980-01-01 00:00   scala/collection/LinearSeqLike.class
-    15936  1980-01-01 00:00   scala/collection/LinearSeqOptimized.class
-     1509  1980-01-01 00:00   scala/collection/Map$.class
-     1617  1980-01-01 00:00   scala/collection/Map$WithDefault.class
-     2780  1980-01-01 00:00   scala/collection/Map.class
-     1319  1980-01-01 00:00   scala/collection/MapLike$$anon$1.class
-     1321  1980-01-01 00:00   scala/collection/MapLike$$anon$2.class
-     2748  1980-01-01 00:00   scala/collection/MapLike$DefaultKeySet.class
-     1502  1980-01-01 00:00   scala/collection/MapLike$DefaultValuesIterable.class
-     5165  1980-01-01 00:00   scala/collection/MapLike$FilteredKeys.class
-     6241  1980-01-01 00:00   scala/collection/MapLike$MappedValues.class
-    20848  1980-01-01 00:00   scala/collection/MapLike.class
-      859  1980-01-01 00:00   scala/collection/MapProxy.class
-    11152  1980-01-01 00:00   scala/collection/MapProxyLike.class
-      336  1980-01-01 00:00   scala/collection/Parallel.class
-     3071  1980-01-01 00:00   scala/collection/Parallelizable.class
-     1279  1980-01-01 00:00   scala/collection/Searching$.class
-     1844  1980-01-01 00:00   scala/collection/Searching$Found$.class
-     2602  1980-01-01 00:00   scala/collection/Searching$Found.class
-     1938  1980-01-01 00:00   scala/collection/Searching$InsertionPoint$.class
-     2559  1980-01-01 00:00   scala/collection/Searching$InsertionPoint.class
-     4662  1980-01-01 00:00   scala/collection/Searching$SearchImpl.class
-      478  1980-01-01 00:00   scala/collection/Searching$SearchResult.class
-     3663  1980-01-01 00:00   scala/collection/Searching.class
-     1346  1980-01-01 00:00   scala/collection/Seq$.class
-     8991  1980-01-01 00:00   scala/collection/Seq.class
-      557  1980-01-01 00:00   scala/collection/SeqExtractors.class
-     1154  1980-01-01 00:00   scala/collection/SeqLike$$anon$1.class
-    66364  1980-01-01 00:00   scala/collection/SeqLike$$anon$2.class
-     7975  1980-01-01 00:00   scala/collection/SeqLike$$anon$3.class
-     7972  1980-01-01 00:00   scala/collection/SeqLike$$anon$4.class
-     8843  1980-01-01 00:00   scala/collection/SeqLike$$anon$5.class
-     5678  1980-01-01 00:00   scala/collection/SeqLike$.class
-    11393  1980-01-01 00:00   scala/collection/SeqLike$CombinationsItr.class
-     6942  1980-01-01 00:00   scala/collection/SeqLike$PermutationsItr.class
-    32822  1980-01-01 00:00   scala/collection/SeqLike.class
-      811  1980-01-01 00:00   scala/collection/SeqProxy.class
-    21800  1980-01-01 00:00   scala/collection/SeqProxyLike.class
-     1717  1980-01-01 00:00   scala/collection/SeqView$$anon$1.class
-      835  1980-01-01 00:00   scala/collection/SeqView$.class
-     1414  1980-01-01 00:00   scala/collection/SeqView.class
-     3626  1980-01-01 00:00   scala/collection/SeqViewLike$$anon$1.class
-     3695  1980-01-01 00:00   scala/collection/SeqViewLike$$anon$10.class
-     4178  1980-01-01 00:00   scala/collection/SeqViewLike$$anon$11.class
-     2304  1980-01-01 00:00   scala/collection/SeqViewLike$$anon$12.class
-     3370  1980-01-01 00:00   scala/collection/SeqViewLike$$anon$13.class
-     4225  1980-01-01 00:00   scala/collection/SeqViewLike$$anon$2.class
-     4238  1980-01-01 00:00   scala/collection/SeqViewLike$$anon$3.class
-     4441  1980-01-01 00:00   scala/collection/SeqViewLike$$anon$4.class
-     5214  1980-01-01 00:00   scala/collection/SeqViewLike$$anon$5.class
-     4924  1980-01-01 00:00   scala/collection/SeqViewLike$$anon$6.class
-     3762  1980-01-01 00:00   scala/collection/SeqViewLike$$anon$7.class
-     4010  1980-01-01 00:00   scala/collection/SeqViewLike$$anon$8.class
-     5234  1980-01-01 00:00   scala/collection/SeqViewLike$$anon$9.class
-    66682  1980-01-01 00:00   scala/collection/SeqViewLike$AbstractTransformed.class
-     2150  1980-01-01 00:00   scala/collection/SeqViewLike$Appended.class
-     2157  1980-01-01 00:00   scala/collection/SeqViewLike$DroppedWhile.class
-     1721  1980-01-01 00:00   scala/collection/SeqViewLike$EmptyView.class
-     3658  1980-01-01 00:00   scala/collection/SeqViewLike$Filtered.class
-     4223  1980-01-01 00:00   scala/collection/SeqViewLike$FlatMapped.class
-     1649  1980-01-01 00:00   scala/collection/SeqViewLike$Forced.class
-     1706  1980-01-01 00:00   scala/collection/SeqViewLike$Mapped.class
-     3049  1980-01-01 00:00   scala/collection/SeqViewLike$Patched.class
-     2162  1980-01-01 00:00   scala/collection/SeqViewLike$Prepended.class
-     3953  1980-01-01 00:00   scala/collection/SeqViewLike$Reversed.class
-     2863  1980-01-01 00:00   scala/collection/SeqViewLike$Sliced.class
-     2114  1980-01-01 00:00   scala/collection/SeqViewLike$TakenWhile.class
-     1380  1980-01-01 00:00   scala/collection/SeqViewLike$Transformed.class
-     2371  1980-01-01 00:00   scala/collection/SeqViewLike$Zipped.class
-     2761  1980-01-01 00:00   scala/collection/SeqViewLike$ZippedAll.class
-    28923  1980-01-01 00:00   scala/collection/SeqViewLike.class
-     1436  1980-01-01 00:00   scala/collection/Set$.class
-     2521  1980-01-01 00:00   scala/collection/Set.class
-     2607  1980-01-01 00:00   scala/collection/SetLike$$anon$1.class
-     5003  1980-01-01 00:00   scala/collection/SetLike$SubsetsItr.class
-    12171  1980-01-01 00:00   scala/collection/SetLike.class
-      809  1980-01-01 00:00   scala/collection/SetProxy.class
-     5308  1980-01-01 00:00   scala/collection/SetProxyLike.class
-     1750  1980-01-01 00:00   scala/collection/SortedMap$.class
-     4233  1980-01-01 00:00   scala/collection/SortedMap$Default.class
-     3468  1980-01-01 00:00   scala/collection/SortedMap.class
-     2280  1980-01-01 00:00   scala/collection/SortedMapLike$$anon$1$$anonfun$valuesIteratorFrom$1.class
-    15219  1980-01-01 00:00   scala/collection/SortedMapLike$$anon$1.class
-    14803  1980-01-01 00:00   scala/collection/SortedMapLike$$anon$2.class
-     9430  1980-01-01 00:00   scala/collection/SortedMapLike$DefaultKeySortedSet.class
-     9177  1980-01-01 00:00   scala/collection/SortedMapLike.class
-     1993  1980-01-01 00:00   scala/collection/SortedSet$.class
-     2681  1980-01-01 00:00   scala/collection/SortedSet.class
-     5155  1980-01-01 00:00   scala/collection/SortedSetLike.class
-     1726  1980-01-01 00:00   scala/collection/Traversable$.class
-     8955  1980-01-01 00:00   scala/collection/Traversable.class
-    39768  1980-01-01 00:00   scala/collection/TraversableLike$$anon$1.class
-     5694  1980-01-01 00:00   scala/collection/TraversableLike$WithFilter.class
-    50212  1980-01-01 00:00   scala/collection/TraversableLike.class
-     1184  1980-01-01 00:00   scala/collection/TraversableOnce$$anon$2.class
-     2362  1980-01-01 00:00   scala/collection/TraversableOnce$.class
-     3768  1980-01-01 00:00   scala/collection/TraversableOnce$BufferedCanBuildFrom.class
-     2227  1980-01-01 00:00   scala/collection/TraversableOnce$FlattenOps$$anon$1.class
-     1186  1980-01-01 00:00   scala/collection/TraversableOnce$FlattenOps.class
-      492  1980-01-01 00:00   scala/collection/TraversableOnce$ForceImplicitAmbiguity.class
-     1864  1980-01-01 00:00   scala/collection/TraversableOnce$MonadOps.class
-     1891  1980-01-01 00:00   scala/collection/TraversableOnce$OnceCanBuildFrom.class
-    38660  1980-01-01 00:00   scala/collection/TraversableOnce.class
-      894  1980-01-01 00:00   scala/collection/TraversableProxy.class
-    30943  1980-01-01 00:00   scala/collection/TraversableProxyLike.class
-     1765  1980-01-01 00:00   scala/collection/TraversableView$$anon$1.class
-      883  1980-01-01 00:00   scala/collection/TraversableView$.class
-     4515  1980-01-01 00:00   scala/collection/TraversableView$NoBuilder.class
-     1813  1980-01-01 00:00   scala/collection/TraversableView.class
-     2255  1980-01-01 00:00   scala/collection/TraversableViewLike$$anon$1.class
-     2270  1980-01-01 00:00   scala/collection/TraversableViewLike$$anon$2.class
-     2276  1980-01-01 00:00   scala/collection/TraversableViewLike$$anon$3.class
-     3111  1980-01-01 00:00   scala/collection/TraversableViewLike$$anon$4.class
-     3233  1980-01-01 00:00   scala/collection/TraversableViewLike$$anon$5.class
-     3151  1980-01-01 00:00   scala/collection/TraversableViewLike$$anon$6.class
-     2425  1980-01-01 00:00   scala/collection/TraversableViewLike$$anon$7.class
-     2210  1980-01-01 00:00   scala/collection/TraversableViewLike$$anon$8.class
-     3511  1980-01-01 00:00   scala/collection/TraversableViewLike$$anon$9.class
-    39734  1980-01-01 00:00   scala/collection/TraversableViewLike$AbstractTransformed.class
-     1832  1980-01-01 00:00   scala/collection/TraversableViewLike$Appended.class
-     3424  1980-01-01 00:00   scala/collection/TraversableViewLike$DroppedWhile.class
-     1567  1980-01-01 00:00   scala/collection/TraversableViewLike$EmptyView.class
-     3139  1980-01-01 00:00   scala/collection/TraversableViewLike$Filtered.class
-     3753  1980-01-01 00:00   scala/collection/TraversableViewLike$FlatMapped.class
-     1747  1980-01-01 00:00   scala/collection/TraversableViewLike$Forced.class
-     2936  1980-01-01 00:00   scala/collection/TraversableViewLike$Mapped.class
-     1839  1980-01-01 00:00   scala/collection/TraversableViewLike$Prepended.class
-     4468  1980-01-01 00:00   scala/collection/TraversableViewLike$Sliced.class
-     3699  1980-01-01 00:00   scala/collection/TraversableViewLike$TakenWhile.class
-     5288  1980-01-01 00:00   scala/collection/TraversableViewLike$Transformed.class
-    33825  1980-01-01 00:00   scala/collection/TraversableViewLike.class
-     5350  1980-01-01 00:00   scala/collection/ViewMkString.class
-        0  1980-01-01 00:00   scala/collection/concurrent/
-      349  1980-01-01 00:00   scala/collection/concurrent/BasicNode.class
-     2101  1980-01-01 00:00   scala/collection/concurrent/CNode$.class
-    14002  1980-01-01 00:00   scala/collection/concurrent/CNode.class
-     1501  1980-01-01 00:00   scala/collection/concurrent/CNodeBase.class
-     3338  1980-01-01 00:00   scala/collection/concurrent/Debug$.class
-     1050  1980-01-01 00:00   scala/collection/concurrent/Debug.class
-     2315  1980-01-01 00:00   scala/collection/concurrent/FailedNode.class
-      290  1980-01-01 00:00   scala/collection/concurrent/Gen.class
-     1412  1980-01-01 00:00   scala/collection/concurrent/INode$.class
-    22363  1980-01-01 00:00   scala/collection/concurrent/INode.class
-     1558  1980-01-01 00:00   scala/collection/concurrent/INodeBase.class
-      640  1980-01-01 00:00   scala/collection/concurrent/KVNode.class
-     5579  1980-01-01 00:00   scala/collection/concurrent/LNode.class
-     2161  1980-01-01 00:00   scala/collection/concurrent/MainNode.class
-     2995  1980-01-01 00:00   scala/collection/concurrent/Map.class
-     2377  1980-01-01 00:00   scala/collection/concurrent/RDCSS_Descriptor$.class
-     7099  1980-01-01 00:00   scala/collection/concurrent/RDCSS_Descriptor.class
-     1032  1980-01-01 00:00   scala/collection/concurrent/RestartException$.class
-     1713  1980-01-01 00:00   scala/collection/concurrent/RestartException.class
-     3443  1980-01-01 00:00   scala/collection/concurrent/SNode.class
-     3636  1980-01-01 00:00   scala/collection/concurrent/TNode.class
-     2570  1980-01-01 00:00   scala/collection/concurrent/TrieMap$.class
-      954  1980-01-01 00:00   scala/collection/concurrent/TrieMap$MangledHashing.class
-    78520  1980-01-01 00:00   scala/collection/concurrent/TrieMap.class
-      616  1980-01-01 00:00   scala/collection/concurrent/TrieMapIterator$.class
-    38860  1980-01-01 00:00   scala/collection/concurrent/TrieMapIterator.class
-     1920  1980-01-01 00:00   scala/collection/concurrent/TrieMapSerializationEnd$.class
-     1662  1980-01-01 00:00   scala/collection/concurrent/TrieMapSerializationEnd.class
-        0  1980-01-01 00:00   scala/collection/convert/
-    13467  1980-01-01 00:00   scala/collection/convert/AsJavaConverters.class
-    11210  1980-01-01 00:00   scala/collection/convert/AsScalaConverters.class
-    16521  1980-01-01 00:00   scala/collection/convert/DecorateAsJava.class
-    14195  1980-01-01 00:00   scala/collection/convert/DecorateAsScala.class
-      440  1980-01-01 00:00   scala/collection/convert/Decorators$.class
-      857  1980-01-01 00:00   scala/collection/convert/Decorators$AsJava.class
-     1085  1980-01-01 00:00   scala/collection/convert/Decorators$AsJavaCollection.class
-     1129  1980-01-01 00:00   scala/collection/convert/Decorators$AsJavaDictionary.class
-     1092  1980-01-01 00:00   scala/collection/convert/Decorators$AsJavaEnumeration.class
-      861  1980-01-01 00:00   scala/collection/convert/Decorators$AsScala.class
-     1653  1980-01-01 00:00   scala/collection/convert/Decorators.class
-    10573  1980-01-01 00:00   scala/collection/convert/ImplicitConversions$.class
-     5812  1980-01-01 00:00   scala/collection/convert/ImplicitConversions.class
-     6097  1980-01-01 00:00   scala/collection/convert/ImplicitConversionsToJava$.class
-     3500  1980-01-01 00:00   scala/collection/convert/ImplicitConversionsToJava.class
-     5022  1980-01-01 00:00   scala/collection/convert/ImplicitConversionsToScala$.class
-     2944  1980-01-01 00:00   scala/collection/convert/ImplicitConversionsToScala.class
-    13572  1980-01-01 00:00   scala/collection/convert/LowPriorityWrapAsJava.class
-    11287  1980-01-01 00:00   scala/collection/convert/LowPriorityWrapAsScala.class
-     9430  1980-01-01 00:00   scala/collection/convert/ToJavaImplicits.class
-     7777  1980-01-01 00:00   scala/collection/convert/ToScalaImplicits.class
-     9571  1980-01-01 00:00   scala/collection/convert/WrapAsJava$.class
-    10058  1980-01-01 00:00   scala/collection/convert/WrapAsJava.class
-     7814  1980-01-01 00:00   scala/collection/convert/WrapAsScala$.class
-     8332  1980-01-01 00:00   scala/collection/convert/WrapAsScala.class
-     9868  1980-01-01 00:00   scala/collection/convert/Wrappers$.class
-     5799  1980-01-01 00:00   scala/collection/convert/Wrappers$ConcurrentMapWrapper.class
-     1927  1980-01-01 00:00   scala/collection/convert/Wrappers$DictionaryWrapper$.class
-     5439  1980-01-01 00:00   scala/collection/convert/Wrappers$DictionaryWrapper.class
-     1837  1980-01-01 00:00   scala/collection/convert/Wrappers$IterableWrapper$.class
-     4557  1980-01-01 00:00   scala/collection/convert/Wrappers$IterableWrapper.class
-     2042  1980-01-01 00:00   scala/collection/convert/Wrappers$IterableWrapperTrait.class
-     1837  1980-01-01 00:00   scala/collection/convert/Wrappers$IteratorWrapper$.class
-     4587  1980-01-01 00:00   scala/collection/convert/Wrappers$IteratorWrapper.class
-     1837  1980-01-01 00:00   scala/collection/convert/Wrappers$JCollectionWrapper$.class
-     4045  1980-01-01 00:00   scala/collection/convert/Wrappers$JCollectionWrapper.class
-     2003  1980-01-01 00:00   scala/collection/convert/Wrappers$JConcurrentMapWrapper$.class
-    13969  1980-01-01 00:00   scala/collection/convert/Wrappers$JConcurrentMapWrapper.class
-     1889  1980-01-01 00:00   scala/collection/convert/Wrappers$JDictionaryWrapper$.class
-     7116  1980-01-01 00:00   scala/collection/convert/Wrappers$JDictionaryWrapper.class
-     1853  1980-01-01 00:00   scala/collection/convert/Wrappers$JEnumerationWrapper$.class
-     3610  1980-01-01 00:00   scala/collection/convert/Wrappers$JEnumerationWrapper.class
-     1805  1980-01-01 00:00   scala/collection/convert/Wrappers$JIterableWrapper$.class
-     3828  1980-01-01 00:00   scala/collection/convert/Wrappers$JIterableWrapper.class
-     1805  1980-01-01 00:00   scala/collection/convert/Wrappers$JIteratorWrapper$.class
-     3530  1980-01-01 00:00   scala/collection/convert/Wrappers$JIteratorWrapper.class
-     1741  1980-01-01 00:00   scala/collection/convert/Wrappers$JListWrapper$.class
-     7095  1980-01-01 00:00   scala/collection/convert/Wrappers$JListWrapper.class
-     1777  1980-01-01 00:00   scala/collection/convert/Wrappers$JMapWrapper$.class
-    11809  1980-01-01 00:00   scala/collection/convert/Wrappers$JMapWrapper.class
-     1967  1980-01-01 00:00   scala/collection/convert/Wrappers$JMapWrapperLike$$anon$2.class
-     5250  1980-01-01 00:00   scala/collection/convert/Wrappers$JMapWrapperLike.class
-     2087  1980-01-01 00:00   scala/collection/convert/Wrappers$JPropertiesWrapper$$anon$3.class
-     2035  1980-01-01 00:00   scala/collection/convert/Wrappers$JPropertiesWrapper$.class
-    11857  1980-01-01 00:00   scala/collection/convert/Wrappers$JPropertiesWrapper.class
-     1725  1980-01-01 00:00   scala/collection/convert/Wrappers$JSetWrapper$.class
-     9489  1980-01-01 00:00   scala/collection/convert/Wrappers$JSetWrapper.class
-     2691  1980-01-01 00:00   scala/collection/convert/Wrappers$MapWrapper$$anon$1$$anon$5$$anon$6.class
-     4111  1980-01-01 00:00   scala/collection/convert/Wrappers$MapWrapper$$anon$1$$anon$5.class
-     1528  1980-01-01 00:00   scala/collection/convert/Wrappers$MapWrapper$$anon$1.class
-     2494  1980-01-01 00:00   scala/collection/convert/Wrappers$MapWrapper.class
-     1923  1980-01-01 00:00   scala/collection/convert/Wrappers$MutableBufferWrapper$.class
-     5185  1980-01-01 00:00   scala/collection/convert/Wrappers$MutableBufferWrapper.class
-     1927  1980-01-01 00:00   scala/collection/convert/Wrappers$MutableMapWrapper$.class
-     4174  1980-01-01 00:00   scala/collection/convert/Wrappers$MutableMapWrapper.class
-     1875  1980-01-01 00:00   scala/collection/convert/Wrappers$MutableSeqWrapper$.class
-     4710  1980-01-01 00:00   scala/collection/convert/Wrappers$MutableSeqWrapper.class
-     1875  1980-01-01 00:00   scala/collection/convert/Wrappers$MutableSetWrapper$.class
-     3614  1980-01-01 00:00   scala/collection/convert/Wrappers$MutableSetWrapper.class
-     1757  1980-01-01 00:00   scala/collection/convert/Wrappers$SeqWrapper$.class
-     4327  1980-01-01 00:00   scala/collection/convert/Wrappers$SeqWrapper.class
-     3037  1980-01-01 00:00   scala/collection/convert/Wrappers$SetWrapper$$anon$4.class
-     1966  1980-01-01 00:00   scala/collection/convert/Wrappers$SetWrapper.class
-     1437  1980-01-01 00:00   scala/collection/convert/Wrappers$ToIteratorWrapper.class
-    22532  1980-01-01 00:00   scala/collection/convert/Wrappers.class
-    16873  1980-01-01 00:00   scala/collection/convert/package$$anon$1.class
-    12861  1980-01-01 00:00   scala/collection/convert/package$$anon$2.class
-    10061  1980-01-01 00:00   scala/collection/convert/package$$anon$3.class
-     9574  1980-01-01 00:00   scala/collection/convert/package$$anon$4.class
-     7814  1980-01-01 00:00   scala/collection/convert/package$$anon$5.class
-     1946  1980-01-01 00:00   scala/collection/convert/package$.class
-     1884  1980-01-01 00:00   scala/collection/convert/package.class
-        0  1980-01-01 00:00   scala/collection/generic/
-     2713  1980-01-01 00:00   scala/collection/generic/AtomicIndexFlag.class
-      449  1980-01-01 00:00   scala/collection/generic/BitOperations$.class
-     2761  1980-01-01 00:00   scala/collection/generic/BitOperations$Int$.class
-     6124  1980-01-01 00:00   scala/collection/generic/BitOperations$Int.class
-     2775  1980-01-01 00:00   scala/collection/generic/BitOperations$Long$.class
-     6260  1980-01-01 00:00   scala/collection/generic/BitOperations$Long.class
-     1928  1980-01-01 00:00   scala/collection/generic/BitOperations.class
-     1654  1980-01-01 00:00   scala/collection/generic/BitSetFactory$$anon$1.class
-     3958  1980-01-01 00:00   scala/collection/generic/BitSetFactory.class
-     1157  1980-01-01 00:00   scala/collection/generic/CanBuildFrom.class
-     1203  1980-01-01 00:00   scala/collection/generic/CanCombineFrom.class
-     2221  1980-01-01 00:00   scala/collection/generic/ClassTagTraversableFactory$GenericCanBuildFrom.class
-     1521  1980-01-01 00:00   scala/collection/generic/ClassTagTraversableFactory.class
-      428  1980-01-01 00:00   scala/collection/generic/Clearable.class
-     2002  1980-01-01 00:00   scala/collection/generic/DefaultSignalling.class
-     2296  1980-01-01 00:00   scala/collection/generic/DelegatedContext.class
-     2924  1980-01-01 00:00   scala/collection/generic/DelegatedSignalling.class
-     1775  1980-01-01 00:00   scala/collection/generic/FilterMonadic.class
-     1814  1980-01-01 00:00   scala/collection/generic/GenMapFactory$MapCanBuildFrom.class
-     2529  1980-01-01 00:00   scala/collection/generic/GenMapFactory.class
-      955  1980-01-01 00:00   scala/collection/generic/GenSeqFactory.class
-     1719  1980-01-01 00:00   scala/collection/generic/GenSetFactory$$anon$1.class
-     1807  1980-01-01 00:00   scala/collection/generic/GenSetFactory.class
-     1203  1980-01-01 00:00   scala/collection/generic/GenTraversableFactory$$anon$1.class
-     1875  1980-01-01 00:00   scala/collection/generic/GenTraversableFactory$GenericCanBuildFrom.class
-    22262  1980-01-01 00:00   scala/collection/generic/GenTraversableFactory.class
-     2354  1980-01-01 00:00   scala/collection/generic/GenericClassTagCompanion.class
-     3444  1980-01-01 00:00   scala/collection/generic/GenericClassTagTraversableTemplate.class
-     2085  1980-01-01 00:00   scala/collection/generic/GenericCompanion.class
-     2335  1980-01-01 00:00   scala/collection/generic/GenericOrderedCompanion.class
-     2358  1980-01-01 00:00   scala/collection/generic/GenericOrderedTraversableTemplate.class
-      941  1980-01-01 00:00   scala/collection/generic/GenericParCompanion.class
-      955  1980-01-01 00:00   scala/collection/generic/GenericParMapCompanion.class
-     2442  1980-01-01 00:00   scala/collection/generic/GenericParMapTemplate.class
-     3128  1980-01-01 00:00   scala/collection/generic/GenericParTemplate.class
-      623  1980-01-01 00:00   scala/collection/generic/GenericSeqCompanion.class
-     1617  1980-01-01 00:00   scala/collection/generic/GenericSetTemplate.class
-    12300  1980-01-01 00:00   scala/collection/generic/GenericTraversableTemplate.class
-     4080  1980-01-01 00:00   scala/collection/generic/Growable.class
-      716  1980-01-01 00:00   scala/collection/generic/HasNewBuilder.class
-      746  1980-01-01 00:00   scala/collection/generic/HasNewCombiner.class
-      470  1980-01-01 00:00   scala/collection/generic/IdleSignalling$.class
-      954  1980-01-01 00:00   scala/collection/generic/IdleSignalling.class
-      990  1980-01-01 00:00   scala/collection/generic/ImmutableMapFactory.class
-     1725  1980-01-01 00:00   scala/collection/generic/ImmutableSetFactory.class
-     1055  1980-01-01 00:00   scala/collection/generic/ImmutableSortedMapFactory.class
-     1017  1980-01-01 00:00   scala/collection/generic/ImmutableSortedSetFactory.class
-     1582  1980-01-01 00:00   scala/collection/generic/IndexedSeqFactory.class
-     2380  1980-01-01 00:00   scala/collection/generic/IsSeqLike$$anon$1.class
-     1029  1980-01-01 00:00   scala/collection/generic/IsSeqLike$$anon$2.class
-     1321  1980-01-01 00:00   scala/collection/generic/IsSeqLike$.class
-     1814  1980-01-01 00:00   scala/collection/generic/IsSeqLike.class
-     2450  1980-01-01 00:00   scala/collection/generic/IsTraversableLike$$anon$1.class
-     1118  1980-01-01 00:00   scala/collection/generic/IsTraversableLike$$anon$2.class
-     1431  1980-01-01 00:00   scala/collection/generic/IsTraversableLike$.class
-     1962  1980-01-01 00:00   scala/collection/generic/IsTraversableLike.class
-     2414  1980-01-01 00:00   scala/collection/generic/IsTraversableOnce$$anon$1.class
-     1112  1980-01-01 00:00   scala/collection/generic/IsTraversableOnce$$anon$2.class
-     1428  1980-01-01 00:00   scala/collection/generic/IsTraversableOnce$.class
-     1951  1980-01-01 00:00   scala/collection/generic/IsTraversableOnce.class
-     2311  1980-01-01 00:00   scala/collection/generic/IterableForwarder.class
-     1098  1980-01-01 00:00   scala/collection/generic/MapFactory.class
-     1402  1980-01-01 00:00   scala/collection/generic/MutableMapFactory.class
-     1408  1980-01-01 00:00   scala/collection/generic/MutableSetFactory.class
-     1043  1980-01-01 00:00   scala/collection/generic/MutableSortedMapFactory.class
-     1706  1980-01-01 00:00   scala/collection/generic/MutableSortedSetFactory.class
-     2195  1980-01-01 00:00   scala/collection/generic/OrderedTraversableFactory$GenericCanBuildFrom.class
-     1518  1980-01-01 00:00   scala/collection/generic/OrderedTraversableFactory.class
-     2531  1980-01-01 00:00   scala/collection/generic/ParFactory$GenericCanCombineFrom.class
-     1521  1980-01-01 00:00   scala/collection/generic/ParFactory.class
-     2157  1980-01-01 00:00   scala/collection/generic/ParMapFactory$CanCombineFromMap.class
-     2285  1980-01-01 00:00   scala/collection/generic/ParMapFactory.class
-     2093  1980-01-01 00:00   scala/collection/generic/ParSetFactory$GenericCanCombineFrom.class
-     2016  1980-01-01 00:00   scala/collection/generic/ParSetFactory.class
-     1426  1980-01-01 00:00   scala/collection/generic/SeqFactory.class
-    11156  1980-01-01 00:00   scala/collection/generic/SeqForwarder.class
-     1034  1980-01-01 00:00   scala/collection/generic/SetFactory.class
-     3624  1980-01-01 00:00   scala/collection/generic/Shrinkable.class
-      901  1980-01-01 00:00   scala/collection/generic/Signalling.class
-      412  1980-01-01 00:00   scala/collection/generic/Sizing.class
-      998  1980-01-01 00:00   scala/collection/generic/SliceInterval$.class
-     2231  1980-01-01 00:00   scala/collection/generic/SliceInterval.class
-     4968  1980-01-01 00:00   scala/collection/generic/Sorted.class
-     2093  1980-01-01 00:00   scala/collection/generic/SortedMapFactory$SortedMapCanBuildFrom.class
-     2950  1980-01-01 00:00   scala/collection/generic/SortedMapFactory.class
-     2016  1980-01-01 00:00   scala/collection/generic/SortedSetFactory$SortedSetCanBuildFrom.class
-     3119  1980-01-01 00:00   scala/collection/generic/SortedSetFactory.class
-     3841  1980-01-01 00:00   scala/collection/generic/Subtractable.class
-     1052  1980-01-01 00:00   scala/collection/generic/TaggedDelegatedContext.class
-      836  1980-01-01 00:00   scala/collection/generic/TraversableFactory.class
-    20156  1980-01-01 00:00   scala/collection/generic/TraversableForwarder.class
-     1485  1980-01-01 00:00   scala/collection/generic/VolatileAbort.class
-      431  1980-01-01 00:00   scala/collection/generic/package$.class
-     1214  1980-01-01 00:00   scala/collection/generic/package.class
-        0  1980-01-01 00:00   scala/collection/immutable/
-     1850  1980-01-01 00:00   scala/collection/immutable/$colon$colon$.class
-     4828  1980-01-01 00:00   scala/collection/immutable/$colon$colon.class
-    12101  1980-01-01 00:00   scala/collection/immutable/AbstractMap.class
-     4406  1980-01-01 00:00   scala/collection/immutable/BitSet$$anon$1.class
-     3339  1980-01-01 00:00   scala/collection/immutable/BitSet$.class
-     2196  1980-01-01 00:00   scala/collection/immutable/BitSet$BitSet1.class
-     2280  1980-01-01 00:00   scala/collection/immutable/BitSet$BitSet2.class
-     1709  1980-01-01 00:00   scala/collection/immutable/BitSet$BitSetN.class
-    18665  1980-01-01 00:00   scala/collection/immutable/BitSet.class
-     4612  1980-01-01 00:00   scala/collection/immutable/DefaultMap.class
-     1474  1980-01-01 00:00   scala/collection/immutable/HashMap$$anon$2$$anon$3.class
-     1616  1980-01-01 00:00   scala/collection/immutable/HashMap$$anon$2.class
-     8304  1980-01-01 00:00   scala/collection/immutable/HashMap$.class
-     1346  1980-01-01 00:00   scala/collection/immutable/HashMap$EmptyHashMap$.class
-     6661  1980-01-01 00:00   scala/collection/immutable/HashMap$HashMap1.class
-     8738  1980-01-01 00:00   scala/collection/immutable/HashMap$HashMapCollision1.class
-     1562  1980-01-01 00:00   scala/collection/immutable/HashMap$HashTrieMap$$anon$1.class
-    11539  1980-01-01 00:00   scala/collection/immutable/HashMap$HashTrieMap.class
-      864  1980-01-01 00:00   scala/collection/immutable/HashMap$Merger.class
-     5174  1980-01-01 00:00   scala/collection/immutable/HashMap$SerializationProxy.class
-    23359  1980-01-01 00:00   scala/collection/immutable/HashMap.class
-     4048  1980-01-01 00:00   scala/collection/immutable/HashSet$.class
-     1132  1980-01-01 00:00   scala/collection/immutable/HashSet$EmptyHashSet$.class
-     5800  1980-01-01 00:00   scala/collection/immutable/HashSet$HashSet1.class
-     9268  1980-01-01 00:00   scala/collection/immutable/HashSet$HashSetCollision1.class
-     1393  1980-01-01 00:00   scala/collection/immutable/HashSet$HashTrieSet$$anon$1.class
-    11954  1980-01-01 00:00   scala/collection/immutable/HashSet$HashTrieSet.class
-      555  1980-01-01 00:00   scala/collection/immutable/HashSet$LeafHashSet.class
-     4372  1980-01-01 00:00   scala/collection/immutable/HashSet$SerializationProxy.class
-    22190  1980-01-01 00:00   scala/collection/immutable/HashSet.class
-     1475  1980-01-01 00:00   scala/collection/immutable/IndexedSeq$.class
-     7359  1980-01-01 00:00   scala/collection/immutable/IndexedSeq$Impl.class
-     9686  1980-01-01 00:00   scala/collection/immutable/IndexedSeq.class
-     1834  1980-01-01 00:00   scala/collection/immutable/IntMap$$anon$1.class
-     3296  1980-01-01 00:00   scala/collection/immutable/IntMap$.class
-     2275  1980-01-01 00:00   scala/collection/immutable/IntMap$Bin$.class
-     3775  1980-01-01 00:00   scala/collection/immutable/IntMap$Bin.class
-     2017  1980-01-01 00:00   scala/collection/immutable/IntMap$Nil$.class
-     1824  1980-01-01 00:00   scala/collection/immutable/IntMap$Tip$.class
-     2734  1980-01-01 00:00   scala/collection/immutable/IntMap$Tip.class
-    28846  1980-01-01 00:00   scala/collection/immutable/IntMap.class
-     2034  1980-01-01 00:00   scala/collection/immutable/IntMapEntryIterator.class
-     3626  1980-01-01 00:00   scala/collection/immutable/IntMapIterator.class
-     1817  1980-01-01 00:00   scala/collection/immutable/IntMapKeyIterator.class
-     4398  1980-01-01 00:00   scala/collection/immutable/IntMapUtils$.class
-     2405  1980-01-01 00:00   scala/collection/immutable/IntMapUtils.class
-     1521  1980-01-01 00:00   scala/collection/immutable/IntMapValueIterator.class
-     1500  1980-01-01 00:00   scala/collection/immutable/Iterable$.class
-     9634  1980-01-01 00:00   scala/collection/immutable/Iterable.class
-     1402  1980-01-01 00:00   scala/collection/immutable/LinearSeq$.class
-     8948  1980-01-01 00:00   scala/collection/immutable/LinearSeq.class
-     6245  1980-01-01 00:00   scala/collection/immutable/List$$anon$1.class
-     2770  1980-01-01 00:00   scala/collection/immutable/List$.class
-     2543  1980-01-01 00:00   scala/collection/immutable/List$SerializationProxy.class
-    36650  1980-01-01 00:00   scala/collection/immutable/List.class
-     1847  1980-01-01 00:00   scala/collection/immutable/ListMap$.class
-      791  1980-01-01 00:00   scala/collection/immutable/ListMap$EmptyListMap$.class
-     8573  1980-01-01 00:00   scala/collection/immutable/ListMap$Node.class
-    13125  1980-01-01 00:00   scala/collection/immutable/ListMap.class
-     1890  1980-01-01 00:00   scala/collection/immutable/ListSerializeEnd$.class
-     1618  1980-01-01 00:00   scala/collection/immutable/ListSerializeEnd.class
-     1534  1980-01-01 00:00   scala/collection/immutable/ListSet$.class
-      767  1980-01-01 00:00   scala/collection/immutable/ListSet$EmptyListSet$.class
-     5500  1980-01-01 00:00   scala/collection/immutable/ListSet$Node.class
-    11468  1980-01-01 00:00   scala/collection/immutable/ListSet.class
-     1848  1980-01-01 00:00   scala/collection/immutable/LongMap$$anon$1.class
-     3315  1980-01-01 00:00   scala/collection/immutable/LongMap$.class
-     2290  1980-01-01 00:00   scala/collection/immutable/LongMap$Bin$.class
-     3857  1980-01-01 00:00   scala/collection/immutable/LongMap$Bin.class
-     2029  1980-01-01 00:00   scala/collection/immutable/LongMap$Nil$.class
-     1828  1980-01-01 00:00   scala/collection/immutable/LongMap$Tip$.class
-     2797  1980-01-01 00:00   scala/collection/immutable/LongMap$Tip.class
-    29007  1980-01-01 00:00   scala/collection/immutable/LongMap.class
-     2049  1980-01-01 00:00   scala/collection/immutable/LongMapEntryIterator.class
-     3644  1980-01-01 00:00   scala/collection/immutable/LongMapIterator.class
-     1832  1980-01-01 00:00   scala/collection/immutable/LongMapKeyIterator.class
-     4435  1980-01-01 00:00   scala/collection/immutable/LongMapUtils$.class
-     2429  1980-01-01 00:00   scala/collection/immutable/LongMapUtils.class
-     1539  1980-01-01 00:00   scala/collection/immutable/LongMapValueIterator.class
-     1643  1980-01-01 00:00   scala/collection/immutable/Map$.class
-     4210  1980-01-01 00:00   scala/collection/immutable/Map$EmptyMap$.class
-     4955  1980-01-01 00:00   scala/collection/immutable/Map$Map1.class
-     5317  1980-01-01 00:00   scala/collection/immutable/Map$Map2.class
-     5811  1980-01-01 00:00   scala/collection/immutable/Map$Map3.class
-     6244  1980-01-01 00:00   scala/collection/immutable/Map$Map4.class
-    13932  1980-01-01 00:00   scala/collection/immutable/Map$WithDefault.class
-    10432  1980-01-01 00:00   scala/collection/immutable/Map.class
-    14561  1980-01-01 00:00   scala/collection/immutable/MapLike$$anon$1.class
-    14566  1980-01-01 00:00   scala/collection/immutable/MapLike$$anon$2.class
-     6795  1980-01-01 00:00   scala/collection/immutable/MapLike$ImmutableDefaultKeySet.class
-    10188  1980-01-01 00:00   scala/collection/immutable/MapLike.class
-    54926  1980-01-01 00:00   scala/collection/immutable/MapProxy$$anon$1.class
-    47916  1980-01-01 00:00   scala/collection/immutable/MapProxy$$anon$2.class
-     7675  1980-01-01 00:00   scala/collection/immutable/MapProxy.class
-     2594  1980-01-01 00:00   scala/collection/immutable/Nil$.class
-    29492  1980-01-01 00:00   scala/collection/immutable/Nil.class
-     6792  1980-01-01 00:00   scala/collection/immutable/NumericRange$$anon$1.class
-     9380  1980-01-01 00:00   scala/collection/immutable/NumericRange$.class
-     2272  1980-01-01 00:00   scala/collection/immutable/NumericRange$Exclusive.class
-     2284  1980-01-01 00:00   scala/collection/immutable/NumericRange$Inclusive.class
-    22728  1980-01-01 00:00   scala/collection/immutable/NumericRange.class
-     4743  1980-01-01 00:00   scala/collection/immutable/Page.class
-     9049  1980-01-01 00:00   scala/collection/immutable/PagedSeq$.class
-    14931  1980-01-01 00:00   scala/collection/immutable/PagedSeq.class
-     4048  1980-01-01 00:00   scala/collection/immutable/Queue$.class
-      859  1980-01-01 00:00   scala/collection/immutable/Queue$EmptyQueue$.class
-    20931  1980-01-01 00:00   scala/collection/immutable/Queue.class
-     2156  1980-01-01 00:00   scala/collection/immutable/Range$.class
-     2360  1980-01-01 00:00   scala/collection/immutable/Range$BigDecimal$.class
-     2095  1980-01-01 00:00   scala/collection/immutable/Range$BigInt$.class
-     4132  1980-01-01 00:00   scala/collection/immutable/Range$Double$.class
-      778  1980-01-01 00:00   scala/collection/immutable/Range$Inclusive.class
-     1941  1980-01-01 00:00   scala/collection/immutable/Range$Int$.class
-     1943  1980-01-01 00:00   scala/collection/immutable/Range$Long$.class
-     2035  1980-01-01 00:00   scala/collection/immutable/Range$Partial$.class
-     1809  1980-01-01 00:00   scala/collection/immutable/Range$Partial.class
-    28612  1980-01-01 00:00   scala/collection/immutable/Range.class
-    37178  1980-01-01 00:00   scala/collection/immutable/RedBlackTree$.class
-     2412  1980-01-01 00:00   scala/collection/immutable/RedBlackTree$BlackTree$.class
-     2205  1980-01-01 00:00   scala/collection/immutable/RedBlackTree$BlackTree.class
-     1705  1980-01-01 00:00   scala/collection/immutable/RedBlackTree$EntriesIterator.class
-     1396  1980-01-01 00:00   scala/collection/immutable/RedBlackTree$KeysIterator.class
-     1912  1980-01-01 00:00   scala/collection/immutable/RedBlackTree$NList$.class
-     1170  1980-01-01 00:00   scala/collection/immutable/RedBlackTree$NList.class
-     2392  1980-01-01 00:00   scala/collection/immutable/RedBlackTree$RedTree$.class
-     2207  1980-01-01 00:00   scala/collection/immutable/RedBlackTree$RedTree.class
-     1995  1980-01-01 00:00   scala/collection/immutable/RedBlackTree$Tree.class
-    33152  1980-01-01 00:00   scala/collection/immutable/RedBlackTree$TreeIterator.class
-     1404  1980-01-01 00:00   scala/collection/immutable/RedBlackTree$ValuesIterator.class
-    18322  1980-01-01 00:00   scala/collection/immutable/RedBlackTree.class
-     1360  1980-01-01 00:00   scala/collection/immutable/Seq$.class
-     9693  1980-01-01 00:00   scala/collection/immutable/Seq.class
-     1217  1980-01-01 00:00   scala/collection/immutable/Set$.class
-     8973  1980-01-01 00:00   scala/collection/immutable/Set$EmptySet$.class
-     8076  1980-01-01 00:00   scala/collection/immutable/Set$Set1.class
-     8328  1980-01-01 00:00   scala/collection/immutable/Set$Set2.class
-     8609  1980-01-01 00:00   scala/collection/immutable/Set$Set3.class
-     8888  1980-01-01 00:00   scala/collection/immutable/Set$Set4.class
-     9778  1980-01-01 00:00   scala/collection/immutable/Set.class
-    30065  1980-01-01 00:00   scala/collection/immutable/SetProxy$$anon$1.class
-     3330  1980-01-01 00:00   scala/collection/immutable/SetProxy.class
-     2306  1980-01-01 00:00   scala/collection/immutable/SortedMap$$anon$1$$anonfun$valuesIteratorFrom$1.class
-    22541  1980-01-01 00:00   scala/collection/immutable/SortedMap$$anon$1.class
-    22107  1980-01-01 00:00   scala/collection/immutable/SortedMap$$anon$2.class
-     1943  1980-01-01 00:00   scala/collection/immutable/SortedMap$.class
-     4509  1980-01-01 00:00   scala/collection/immutable/SortedMap$Default.class
-    10588  1980-01-01 00:00   scala/collection/immutable/SortedMap$DefaultKeySortedSet.class
-     9939  1980-01-01 00:00   scala/collection/immutable/SortedMap.class
-     1995  1980-01-01 00:00   scala/collection/immutable/SortedSet$.class
-     2813  1980-01-01 00:00   scala/collection/immutable/SortedSet.class
-     2843  1980-01-01 00:00   scala/collection/immutable/Stack$.class
-    25535  1980-01-01 00:00   scala/collection/immutable/Stack.class
-    71425  1980-01-01 00:00   scala/collection/immutable/Stream$$anon$1.class
-     1238  1980-01-01 00:00   scala/collection/immutable/Stream$$hash$colon$colon$.class
-    13498  1980-01-01 00:00   scala/collection/immutable/Stream$.class
-     2849  1980-01-01 00:00   scala/collection/immutable/Stream$Cons.class
-     1722  1980-01-01 00:00   scala/collection/immutable/Stream$ConsWrapper.class
-     1458  1980-01-01 00:00   scala/collection/immutable/Stream$Empty$.class
-     2413  1980-01-01 00:00   scala/collection/immutable/Stream$StreamBuilder.class
-      925  1980-01-01 00:00   scala/collection/immutable/Stream$StreamCanBuildFrom.class
-     5641  1980-01-01 00:00   scala/collection/immutable/Stream$StreamWithFilter.class
-     1559  1980-01-01 00:00   scala/collection/immutable/Stream$cons$.class
-    58127  1980-01-01 00:00   scala/collection/immutable/Stream.class
-     1745  1980-01-01 00:00   scala/collection/immutable/StreamIterator$LazyCell.class
-     4702  1980-01-01 00:00   scala/collection/immutable/StreamIterator.class
-      735  1980-01-01 00:00   scala/collection/immutable/StreamView.class
-     3868  1980-01-01 00:00   scala/collection/immutable/StreamViewLike$$anon$1.class
-     3937  1980-01-01 00:00   scala/collection/immutable/StreamViewLike$$anon$10.class
-     4403  1980-01-01 00:00   scala/collection/immutable/StreamViewLike$$anon$11.class
-     3593  1980-01-01 00:00   scala/collection/immutable/StreamViewLike$$anon$12.class
-    70913  1980-01-01 00:00   scala/collection/immutable/StreamViewLike$$anon$13.class
-     4469  1980-01-01 00:00   scala/collection/immutable/StreamViewLike$$anon$2.class
-     4483  1980-01-01 00:00   scala/collection/immutable/StreamViewLike$$anon$3.class
-     4683  1980-01-01 00:00   scala/collection/immutable/StreamViewLike$$anon$4.class
-     5460  1980-01-01 00:00   scala/collection/immutable/StreamViewLike$$anon$5.class
-     5159  1980-01-01 00:00   scala/collection/immutable/StreamViewLike$$anon$6.class
-     4025  1980-01-01 00:00   scala/collection/immutable/StreamViewLike$$anon$7.class
-     4249  1980-01-01 00:00   scala/collection/immutable/StreamViewLike$$anon$8.class
-     5471  1980-01-01 00:00   scala/collection/immutable/StreamViewLike$$anon$9.class
-    18772  1980-01-01 00:00   scala/collection/immutable/StreamViewLike$AbstractTransformed.class
-      648  1980-01-01 00:00   scala/collection/immutable/StreamViewLike$Appended.class
-      637  1980-01-01 00:00   scala/collection/immutable/StreamViewLike$DroppedWhile.class
-      646  1980-01-01 00:00   scala/collection/immutable/StreamViewLike$EmptyView.class
-      621  1980-01-01 00:00   scala/collection/immutable/StreamViewLike$Filtered.class
-      656  1980-01-01 00:00   scala/collection/immutable/StreamViewLike$FlatMapped.class
-      640  1980-01-01 00:00   scala/collection/immutable/StreamViewLike$Forced.class
-      640  1980-01-01 00:00   scala/collection/immutable/StreamViewLike$Mapped.class
-      644  1980-01-01 00:00   scala/collection/immutable/StreamViewLike$Patched.class
-      652  1980-01-01 00:00   scala/collection/immutable/StreamViewLike$Prepended.class
-      621  1980-01-01 00:00   scala/collection/immutable/StreamViewLike$Reversed.class
-      613  1980-01-01 00:00   scala/collection/immutable/StreamViewLike$Sliced.class
-      629  1980-01-01 00:00   scala/collection/immutable/StreamViewLike$TakenWhile.class
-     1391  1980-01-01 00:00   scala/collection/immutable/StreamViewLike$Transformed.class
-      659  1980-01-01 00:00   scala/collection/immutable/StreamViewLike$Zipped.class
-      697  1980-01-01 00:00   scala/collection/immutable/StreamViewLike$ZippedAll.class
-    14004  1980-01-01 00:00   scala/collection/immutable/StreamViewLike.class
-     2344  1980-01-01 00:00   scala/collection/immutable/StringLike$$anon$1.class
-      678  1980-01-01 00:00   scala/collection/immutable/StringLike$.class
-    21490  1980-01-01 00:00   scala/collection/immutable/StringLike.class
-     2852  1980-01-01 00:00   scala/collection/immutable/StringOps$.class
-    55445  1980-01-01 00:00   scala/collection/immutable/StringOps.class
-     1524  1980-01-01 00:00   scala/collection/immutable/Traversable$.class
-     8955  1980-01-01 00:00   scala/collection/immutable/Traversable.class
-     1934  1980-01-01 00:00   scala/collection/immutable/TreeMap$.class
-    69351  1980-01-01 00:00   scala/collection/immutable/TreeMap.class
-     1794  1980-01-01 00:00   scala/collection/immutable/TreeSet$.class
-    60255  1980-01-01 00:00   scala/collection/immutable/TreeSet.class
-     1237  1980-01-01 00:00   scala/collection/immutable/TrieIterator$$anon$1.class
-     2804  1980-01-01 00:00   scala/collection/immutable/TrieIterator$DupIterator.class
-    15205  1980-01-01 00:00   scala/collection/immutable/TrieIterator.class
-     1544  1980-01-01 00:00   scala/collection/immutable/Vector$$anon$1.class
-     2361  1980-01-01 00:00   scala/collection/immutable/Vector$.class
-    40272  1980-01-01 00:00   scala/collection/immutable/Vector.class
-    11154  1980-01-01 00:00   scala/collection/immutable/VectorBuilder.class
-     8772  1980-01-01 00:00   scala/collection/immutable/VectorIterator.class
-    14579  1980-01-01 00:00   scala/collection/immutable/VectorPointer.class
-     1711  1980-01-01 00:00   scala/collection/immutable/WrappedString$$anon$1.class
-     2723  1980-01-01 00:00   scala/collection/immutable/WrappedString$.class
-    29007  1980-01-01 00:00   scala/collection/immutable/WrappedString.class
-        0  1980-01-01 00:00   scala/collection/mutable/
-    11594  1980-01-01 00:00   scala/collection/mutable/AbstractBuffer.class
-     3573  1980-01-01 00:00   scala/collection/mutable/AbstractIterable.class
-    18959  1980-01-01 00:00   scala/collection/mutable/AbstractMap.class
-     5446  1980-01-01 00:00   scala/collection/mutable/AbstractSeq.class
-    23638  1980-01-01 00:00   scala/collection/mutable/AbstractSet.class
-    12812  1980-01-01 00:00   scala/collection/mutable/AbstractSortedMap.class
-     9211  1980-01-01 00:00   scala/collection/mutable/AbstractSortedSet.class
-    30150  1980-01-01 00:00   scala/collection/mutable/AnyRefMap$$anon$1.class
-     1763  1980-01-01 00:00   scala/collection/mutable/AnyRefMap$$anon$2.class
-     6177  1980-01-01 00:00   scala/collection/mutable/AnyRefMap$.class
-     4942  1980-01-01 00:00   scala/collection/mutable/AnyRefMap$AnyRefMapBuilder.class
-     6712  1980-01-01 00:00   scala/collection/mutable/AnyRefMap$ExceptionDefault.class
-    26470  1980-01-01 00:00   scala/collection/mutable/AnyRefMap.class
-     1553  1980-01-01 00:00   scala/collection/mutable/ArrayBuffer$.class
-    36076  1980-01-01 00:00   scala/collection/mutable/ArrayBuffer.class
-     2723  1980-01-01 00:00   scala/collection/mutable/ArrayBuilder$.class
-     4183  1980-01-01 00:00   scala/collection/mutable/ArrayBuilder$ofBoolean.class
-     4180  1980-01-01 00:00   scala/collection/mutable/ArrayBuilder$ofByte.class
-     4180  1980-01-01 00:00   scala/collection/mutable/ArrayBuilder$ofChar.class
-     4198  1980-01-01 00:00   scala/collection/mutable/ArrayBuilder$ofDouble.class
-     4189  1980-01-01 00:00   scala/collection/mutable/ArrayBuilder$ofFloat.class
-     4167  1980-01-01 00:00   scala/collection/mutable/ArrayBuilder$ofInt.class
-     4180  1980-01-01 00:00   scala/collection/mutable/ArrayBuilder$ofLong.class
-     4586  1980-01-01 00:00   scala/collection/mutable/ArrayBuilder$ofRef.class
-     4189  1980-01-01 00:00   scala/collection/mutable/ArrayBuilder$ofShort.class
-     2687  1980-01-01 00:00   scala/collection/mutable/ArrayBuilder$ofUnit.class
-     9926  1980-01-01 00:00   scala/collection/mutable/ArrayBuilder.class
-     8519  1980-01-01 00:00   scala/collection/mutable/ArrayLike$$anon$1.class
-     1423  1980-01-01 00:00   scala/collection/mutable/ArrayLike.class
-      434  1980-01-01 00:00   scala/collection/mutable/ArrayOps$.class
-     2372  1980-01-01 00:00   scala/collection/mutable/ArrayOps$ofBoolean$.class
-    53229  1980-01-01 00:00   scala/collection/mutable/ArrayOps$ofBoolean.class
-     2348  1980-01-01 00:00   scala/collection/mutable/ArrayOps$ofByte$.class
-    53228  1980-01-01 00:00   scala/collection/mutable/ArrayOps$ofByte.class
-     2348  1980-01-01 00:00   scala/collection/mutable/ArrayOps$ofChar$.class
-    53238  1980-01-01 00:00   scala/collection/mutable/ArrayOps$ofChar.class
-     2364  1980-01-01 00:00   scala/collection/mutable/ArrayOps$ofDouble$.class
-    53252  1980-01-01 00:00   scala/collection/mutable/ArrayOps$ofDouble.class
-     2356  1980-01-01 00:00   scala/collection/mutable/ArrayOps$ofFloat$.class
-    53240  1980-01-01 00:00   scala/collection/mutable/ArrayOps$ofFloat.class
-     2336  1980-01-01 00:00   scala/collection/mutable/ArrayOps$ofInt$.class
-    53189  1980-01-01 00:00   scala/collection/mutable/ArrayOps$ofInt.class
-     2348  1980-01-01 00:00   scala/collection/mutable/ArrayOps$ofLong$.class
-    53228  1980-01-01 00:00   scala/collection/mutable/ArrayOps$ofLong.class
-     3131  1980-01-01 00:00   scala/collection/mutable/ArrayOps$ofRef$.class
-    52787  1980-01-01 00:00   scala/collection/mutable/ArrayOps$ofRef.class
-     2356  1980-01-01 00:00   scala/collection/mutable/ArrayOps$ofShort$.class
-    53240  1980-01-01 00:00   scala/collection/mutable/ArrayOps$ofShort.class
-     2747  1980-01-01 00:00   scala/collection/mutable/ArrayOps$ofUnit$.class
-    54494  1980-01-01 00:00   scala/collection/mutable/ArrayOps$ofUnit.class
-    27293  1980-01-01 00:00   scala/collection/mutable/ArrayOps.class
-      962  1980-01-01 00:00   scala/collection/mutable/ArraySeq$$anon$1.class
-     2938  1980-01-01 00:00   scala/collection/mutable/ArraySeq$.class
-    28618  1980-01-01 00:00   scala/collection/mutable/ArraySeq.class
-     1470  1980-01-01 00:00   scala/collection/mutable/ArrayStack$$anon$1.class
-     4287  1980-01-01 00:00   scala/collection/mutable/ArrayStack$.class
-    34243  1980-01-01 00:00   scala/collection/mutable/ArrayStack.class
-     2632  1980-01-01 00:00   scala/collection/mutable/BitSet$.class
-    22790  1980-01-01 00:00   scala/collection/mutable/BitSet.class
-     1370  1980-01-01 00:00   scala/collection/mutable/Buffer$.class
-     8563  1980-01-01 00:00   scala/collection/mutable/Buffer.class
-    15332  1980-01-01 00:00   scala/collection/mutable/BufferLike.class
-    63783  1980-01-01 00:00   scala/collection/mutable/BufferProxy$$anon$1.class
-     8873  1980-01-01 00:00   scala/collection/mutable/BufferProxy.class
-     5068  1980-01-01 00:00   scala/collection/mutable/Builder$$anon$1.class
-     4338  1980-01-01 00:00   scala/collection/mutable/Builder.class
-     1246  1980-01-01 00:00   scala/collection/mutable/Cloneable.class
-     3077  1980-01-01 00:00   scala/collection/mutable/DefaultEntry.class
-     5145  1980-01-01 00:00   scala/collection/mutable/DefaultMapModel.class
-     5238  1980-01-01 00:00   scala/collection/mutable/DoubleLinkedList$$anon$1.class
-     1628  1980-01-01 00:00   scala/collection/mutable/DoubleLinkedList$.class
-    18956  1980-01-01 00:00   scala/collection/mutable/DoubleLinkedList.class
-     8952  1980-01-01 00:00   scala/collection/mutable/DoubleLinkedListLike.class
-     1900  1980-01-01 00:00   scala/collection/mutable/DoublingUnrolledBuffer.class
-     1694  1980-01-01 00:00   scala/collection/mutable/FlatHashTable$$anon$1.class
-      838  1980-01-01 00:00   scala/collection/mutable/FlatHashTable$$anon$2.class
-     2287  1980-01-01 00:00   scala/collection/mutable/FlatHashTable$.class
-     1378  1980-01-01 00:00   scala/collection/mutable/FlatHashTable$Contents.class
-     2444  1980-01-01 00:00   scala/collection/mutable/FlatHashTable$HashUtils.class
-      762  1980-01-01 00:00   scala/collection/mutable/FlatHashTable$NullSentinel$.class
-    21285  1980-01-01 00:00   scala/collection/mutable/FlatHashTable.class
-     5121  1980-01-01 00:00   scala/collection/mutable/GrowingBuilder.class
-     1059  1980-01-01 00:00   scala/collection/mutable/HashEntry.class
-     2474  1980-01-01 00:00   scala/collection/mutable/HashMap$$anon$1.class
-     2505  1980-01-01 00:00   scala/collection/mutable/HashMap$$anon$2.class
-     1442  1980-01-01 00:00   scala/collection/mutable/HashMap$$anon$3.class
-     1446  1980-01-01 00:00   scala/collection/mutable/HashMap$$anon$4.class
-     1695  1980-01-01 00:00   scala/collection/mutable/HashMap$.class
-    28639  1980-01-01 00:00   scala/collection/mutable/HashMap.class
-     1359  1980-01-01 00:00   scala/collection/mutable/HashSet$.class
-    20484  1980-01-01 00:00   scala/collection/mutable/HashSet.class
-     2450  1980-01-01 00:00   scala/collection/mutable/HashTable$$anon$1.class
-     1276  1980-01-01 00:00   scala/collection/mutable/HashTable$.class
-     4341  1980-01-01 00:00   scala/collection/mutable/HashTable$Contents.class
-     1956  1980-01-01 00:00   scala/collection/mutable/HashTable$HashUtils.class
-    19599  1980-01-01 00:00   scala/collection/mutable/HashTable.class
-     4555  1980-01-01 00:00   scala/collection/mutable/History.class
-     9764  1980-01-01 00:00   scala/collection/mutable/ImmutableMapAdaptor.class
-     4819  1980-01-01 00:00   scala/collection/mutable/ImmutableSetAdaptor.class
-     1398  1980-01-01 00:00   scala/collection/mutable/IndexedSeq$.class
-     9050  1980-01-01 00:00   scala/collection/mutable/IndexedSeq.class
-    74993  1980-01-01 00:00   scala/collection/mutable/IndexedSeqLike$$anon$1.class
-     3184  1980-01-01 00:00   scala/collection/mutable/IndexedSeqLike.class
-      787  1980-01-01 00:00   scala/collection/mutable/IndexedSeqOptimized.class
-     5615  1980-01-01 00:00   scala/collection/mutable/IndexedSeqView$$anon$1.class
-     4486  1980-01-01 00:00   scala/collection/mutable/IndexedSeqView$$anon$2.class
-     4717  1980-01-01 00:00   scala/collection/mutable/IndexedSeqView$$anon$3.class
-     5933  1980-01-01 00:00   scala/collection/mutable/IndexedSeqView$$anon$4.class
-     2997  1980-01-01 00:00   scala/collection/mutable/IndexedSeqView$$anon$5.class
-     1793  1980-01-01 00:00   scala/collection/mutable/IndexedSeqView$$anon$6.class
-     1733  1980-01-01 00:00   scala/collection/mutable/IndexedSeqView$$anon$7.class
-     1239  1980-01-01 00:00   scala/collection/mutable/IndexedSeqView$.class
-    32086  1980-01-01 00:00   scala/collection/mutable/IndexedSeqView$AbstractTransformed.class
-     1860  1980-01-01 00:00   scala/collection/mutable/IndexedSeqView$DroppedWhile.class
-     1566  1980-01-01 00:00   scala/collection/mutable/IndexedSeqView$Filtered.class
-     1573  1980-01-01 00:00   scala/collection/mutable/IndexedSeqView$Reversed.class
-     2200  1980-01-01 00:00   scala/collection/mutable/IndexedSeqView$Sliced.class
-     1838  1980-01-01 00:00   scala/collection/mutable/IndexedSeqView$TakenWhile.class
-     1467  1980-01-01 00:00   scala/collection/mutable/IndexedSeqView$Transformed.class
-    11823  1980-01-01 00:00   scala/collection/mutable/IndexedSeqView.class
-     1487  1980-01-01 00:00   scala/collection/mutable/Iterable$.class
-     9572  1980-01-01 00:00   scala/collection/mutable/Iterable.class
-     5767  1980-01-01 00:00   scala/collection/mutable/LazyBuilder.class
-     1391  1980-01-01 00:00   scala/collection/mutable/LinearSeq$.class
-     8895  1980-01-01 00:00   scala/collection/mutable/LinearSeq.class
-     3005  1980-01-01 00:00   scala/collection/mutable/LinkedEntry.class
-     2138  1980-01-01 00:00   scala/collection/mutable/LinkedHashMap$$anon$1.class
-     1908  1980-01-01 00:00   scala/collection/mutable/LinkedHashMap$$anon$2.class
-     1912  1980-01-01 00:00   scala/collection/mutable/LinkedHashMap$$anon$3.class
-     1749  1980-01-01 00:00   scala/collection/mutable/LinkedHashMap$.class
-     1595  1980-01-01 00:00   scala/collection/mutable/LinkedHashMap$DefaultKeySet.class
-     1585  1980-01-01 00:00   scala/collection/mutable/LinkedHashMap$FilteredKeys.class
-     1597  1980-01-01 00:00   scala/collection/mutable/LinkedHashMap$MappedValues.class
-    26306  1980-01-01 00:00   scala/collection/mutable/LinkedHashMap.class
-     1964  1980-01-01 00:00   scala/collection/mutable/LinkedHashSet$$anon$1.class
-     1413  1980-01-01 00:00   scala/collection/mutable/LinkedHashSet$.class
-     2140  1980-01-01 00:00   scala/collection/mutable/LinkedHashSet$Entry.class
-    23368  1980-01-01 00:00   scala/collection/mutable/LinkedHashSet.class
-     3097  1980-01-01 00:00   scala/collection/mutable/LinkedList$.class
-    17855  1980-01-01 00:00   scala/collection/mutable/LinkedList.class
-     1582  1980-01-01 00:00   scala/collection/mutable/LinkedListLike$$anon$1.class
-    10637  1980-01-01 00:00   scala/collection/mutable/LinkedListLike.class
-     2013  1980-01-01 00:00   scala/collection/mutable/ListBuffer$$anon$1.class
-     1648  1980-01-01 00:00   scala/collection/mutable/ListBuffer$.class
-    43891  1980-01-01 00:00   scala/collection/mutable/ListBuffer.class
-     1695  1980-01-01 00:00   scala/collection/mutable/ListMap$.class
-    13513  1980-01-01 00:00   scala/collection/mutable/ListMap.class
-    31378  1980-01-01 00:00   scala/collection/mutable/LongMap$$anon$1.class
-     1721  1980-01-01 00:00   scala/collection/mutable/LongMap$$anon$2.class
-     6521  1980-01-01 00:00   scala/collection/mutable/LongMap$.class
-     4939  1980-01-01 00:00   scala/collection/mutable/LongMap$LongMapBuilder.class
-    28554  1980-01-01 00:00   scala/collection/mutable/LongMap.class
-     1515  1980-01-01 00:00   scala/collection/mutable/Map$.class
-    20627  1980-01-01 00:00   scala/collection/mutable/Map$WithDefault.class
-     5167  1980-01-01 00:00   scala/collection/mutable/Map.class
-     5422  1980-01-01 00:00   scala/collection/mutable/MapBuilder.class
-    16467  1980-01-01 00:00   scala/collection/mutable/MapLike.class
-    61639  1980-01-01 00:00   scala/collection/mutable/MapProxy$$anon$1.class
-    61381  1980-01-01 00:00   scala/collection/mutable/MapProxy$$anon$2.class
-     7002  1980-01-01 00:00   scala/collection/mutable/MapProxy.class
-     3916  1980-01-01 00:00   scala/collection/mutable/MultiMap.class
-     2177  1980-01-01 00:00   scala/collection/mutable/MutableList$$anon$1.class
-     1553  1980-01-01 00:00   scala/collection/mutable/MutableList$.class
-    29118  1980-01-01 00:00   scala/collection/mutable/MutableList.class
-     1077  1980-01-01 00:00   scala/collection/mutable/ObservableBuffer$$anon$1.class
-     1307  1980-01-01 00:00   scala/collection/mutable/ObservableBuffer$$anon$2.class
-     1319  1980-01-01 00:00   scala/collection/mutable/ObservableBuffer$$anon$3.class
-     1351  1980-01-01 00:00   scala/collection/mutable/ObservableBuffer$$anon$4.class
-     1528  1980-01-01 00:00   scala/collection/mutable/ObservableBuffer$$anon$5.class
-     1055  1980-01-01 00:00   scala/collection/mutable/ObservableBuffer$$anon$6.class
-     8305  1980-01-01 00:00   scala/collection/mutable/ObservableBuffer.class
-     1386  1980-01-01 00:00   scala/collection/mutable/ObservableMap$$anon$1.class
-     1383  1980-01-01 00:00   scala/collection/mutable/ObservableMap$$anon$2.class
-     1351  1980-01-01 00:00   scala/collection/mutable/ObservableMap$$anon$3.class
-     1037  1980-01-01 00:00   scala/collection/mutable/ObservableMap$$anon$4.class
-     4183  1980-01-01 00:00   scala/collection/mutable/ObservableMap.class
-     1195  1980-01-01 00:00   scala/collection/mutable/ObservableSet$$anon$1.class
-     1193  1980-01-01 00:00   scala/collection/mutable/ObservableSet$$anon$2.class
-     1034  1980-01-01 00:00   scala/collection/mutable/ObservableSet$$anon$3.class
-     3163  1980-01-01 00:00   scala/collection/mutable/ObservableSet.class
-     2651  1980-01-01 00:00   scala/collection/mutable/OpenHashMap$$anon$1.class
-     1382  1980-01-01 00:00   scala/collection/mutable/OpenHashMap$.class
-     1608  1980-01-01 00:00   scala/collection/mutable/OpenHashMap$OpenEntry.class
-    23453  1980-01-01 00:00   scala/collection/mutable/OpenHashMap.class
-     1774  1980-01-01 00:00   scala/collection/mutable/PriorityQueue$$anon$2.class
-     1780  1980-01-01 00:00   scala/collection/mutable/PriorityQueue$$anon$3.class
-     4873  1980-01-01 00:00   scala/collection/mutable/PriorityQueue$$anon$4.class
-     1782  1980-01-01 00:00   scala/collection/mutable/PriorityQueue$.class
-    21646  1980-01-01 00:00   scala/collection/mutable/PriorityQueue$ResizableArrayAccess.class
-    22129  1980-01-01 00:00   scala/collection/mutable/PriorityQueue.class
-     1279  1980-01-01 00:00   scala/collection/mutable/PriorityQueueProxy$$anon$1.class
-     5294  1980-01-01 00:00   scala/collection/mutable/PriorityQueueProxy.class
-     2626  1980-01-01 00:00   scala/collection/mutable/Publisher$$anon$1.class
-     9020  1980-01-01 00:00   scala/collection/mutable/Publisher.class
-     2716  1980-01-01 00:00   scala/collection/mutable/Queue$.class
-    17876  1980-01-01 00:00   scala/collection/mutable/Queue.class
-     5217  1980-01-01 00:00   scala/collection/mutable/QueueProxy$$anon$1.class
-     5247  1980-01-01 00:00   scala/collection/mutable/QueueProxy.class
-    22180  1980-01-01 00:00   scala/collection/mutable/RedBlackTree$.class
-     1856  1980-01-01 00:00   scala/collection/mutable/RedBlackTree$EntriesIterator.class
-     1549  1980-01-01 00:00   scala/collection/mutable/RedBlackTree$KeysIterator.class
-     2932  1980-01-01 00:00   scala/collection/mutable/RedBlackTree$Node$.class
-     3273  1980-01-01 00:00   scala/collection/mutable/RedBlackTree$Node.class
-     1100  1980-01-01 00:00   scala/collection/mutable/RedBlackTree$Tree$.class
-     1631  1980-01-01 00:00   scala/collection/mutable/RedBlackTree$Tree.class
-    31407  1980-01-01 00:00   scala/collection/mutable/RedBlackTree$TreeIterator.class
-     1557  1980-01-01 00:00   scala/collection/mutable/RedBlackTree$ValuesIterator.class
-    17237  1980-01-01 00:00   scala/collection/mutable/RedBlackTree.class
-     1426  1980-01-01 00:00   scala/collection/mutable/ResizableArray$.class
-    14417  1980-01-01 00:00   scala/collection/mutable/ResizableArray.class
-      811  1980-01-01 00:00   scala/collection/mutable/ReusableBuilder.class
-     2477  1980-01-01 00:00   scala/collection/mutable/RevertibleHistory.class
-     1349  1980-01-01 00:00   scala/collection/mutable/Seq$.class
-     8902  1980-01-01 00:00   scala/collection/mutable/Seq.class
-     4304  1980-01-01 00:00   scala/collection/mutable/SeqLike.class
-     1271  1980-01-01 00:00   scala/collection/mutable/Set$.class
-     2518  1980-01-01 00:00   scala/collection/mutable/Set.class
-     5278  1980-01-01 00:00   scala/collection/mutable/SetBuilder.class
-    13505  1980-01-01 00:00   scala/collection/mutable/SetLike.class
-    55062  1980-01-01 00:00   scala/collection/mutable/SetProxy$$anon$1.class
-     3294  1980-01-01 00:00   scala/collection/mutable/SetProxy.class
-     1919  1980-01-01 00:00   scala/collection/mutable/SortedMap$.class
-     6536  1980-01-01 00:00   scala/collection/mutable/SortedMap.class
-     1971  1980-01-01 00:00   scala/collection/mutable/SortedSet$.class
-     2803  1980-01-01 00:00   scala/collection/mutable/SortedSet.class
-     2054  1980-01-01 00:00   scala/collection/mutable/Stack$.class
-     4777  1980-01-01 00:00   scala/collection/mutable/Stack$StackBuilder.class
-    16498  1980-01-01 00:00   scala/collection/mutable/Stack.class
-     5476  1980-01-01 00:00   scala/collection/mutable/StackProxy$$anon$1.class
-     6141  1980-01-01 00:00   scala/collection/mutable/StackProxy.class
-      753  1980-01-01 00:00   scala/collection/mutable/StringBuilder$.class
-    44319  1980-01-01 00:00   scala/collection/mutable/StringBuilder.class
-      746  1980-01-01 00:00   scala/collection/mutable/Subscriber.class
-    12207  1980-01-01 00:00   scala/collection/mutable/SynchronizedBuffer.class
-    14176  1980-01-01 00:00   scala/collection/mutable/SynchronizedMap.class
-     4363  1980-01-01 00:00   scala/collection/mutable/SynchronizedPriorityQueue.class
-     4621  1980-01-01 00:00   scala/collection/mutable/SynchronizedQueue.class
-    11847  1980-01-01 00:00   scala/collection/mutable/SynchronizedSet.class
-     3982  1980-01-01 00:00   scala/collection/mutable/SynchronizedStack.class
-     1511  1980-01-01 00:00   scala/collection/mutable/Traversable$.class
-     8899  1980-01-01 00:00   scala/collection/mutable/Traversable.class
-     1914  1980-01-01 00:00   scala/collection/mutable/TreeMap$.class
-     9795  1980-01-01 00:00   scala/collection/mutable/TreeMap$TreeMapView.class
-    19534  1980-01-01 00:00   scala/collection/mutable/TreeMap.class
-     1859  1980-01-01 00:00   scala/collection/mutable/TreeSet$.class
-     6689  1980-01-01 00:00   scala/collection/mutable/TreeSet$TreeSetView.class
-    15685  1980-01-01 00:00   scala/collection/mutable/TreeSet.class
-      423  1980-01-01 00:00   scala/collection/mutable/Undoable.class
-     2602  1980-01-01 00:00   scala/collection/mutable/UnrolledBuffer$$anon$1.class
-     2139  1980-01-01 00:00   scala/collection/mutable/UnrolledBuffer$.class
-      741  1980-01-01 00:00   scala/collection/mutable/UnrolledBuffer$Unrolled$.class
-    10729  1980-01-01 00:00   scala/collection/mutable/UnrolledBuffer$Unrolled.class
-    21269  1980-01-01 00:00   scala/collection/mutable/UnrolledBuffer.class
-     1731  1980-01-01 00:00   scala/collection/mutable/WeakHashMap$.class
-     8598  1980-01-01 00:00   scala/collection/mutable/WeakHashMap.class
-     3236  1980-01-01 00:00   scala/collection/mutable/WrappedArray$$anon$1.class
-     3617  1980-01-01 00:00   scala/collection/mutable/WrappedArray$.class
-     2139  1980-01-01 00:00   scala/collection/mutable/WrappedArray$ofBoolean.class
-     2004  1980-01-01 00:00   scala/collection/mutable/WrappedArray$ofByte.class
-     2014  1980-01-01 00:00   scala/collection/mutable/WrappedArray$ofChar.class
-     2132  1980-01-01 00:00   scala/collection/mutable/WrappedArray$ofDouble.class
-     2125  1980-01-01 00:00   scala/collection/mutable/WrappedArray$ofFloat.class
-     2068  1980-01-01 00:00   scala/collection/mutable/WrappedArray$ofInt.class
-     2118  1980-01-01 00:00   scala/collection/mutable/WrappedArray$ofLong.class
-     2309  1980-01-01 00:00   scala/collection/mutable/WrappedArray$ofRef.class
-     2011  1980-01-01 00:00   scala/collection/mutable/WrappedArray$ofShort.class
-     2207  1980-01-01 00:00   scala/collection/mutable/WrappedArray$ofUnit.class
-    27683  1980-01-01 00:00   scala/collection/mutable/WrappedArray.class
-     9317  1980-01-01 00:00   scala/collection/mutable/WrappedArrayBuilder.class
-     1256  1980-01-01 00:00   scala/collection/package$$anon$1.class
-     1006  1980-01-01 00:00   scala/collection/package$.class
-      983  1980-01-01 00:00   scala/collection/package.class
-        0  1980-01-01 00:00   scala/collection/parallel/
-     6528  1980-01-01 00:00   scala/collection/parallel/AdaptiveWorkStealingForkJoinTasks$WrappedTask.class
-     2348  1980-01-01 00:00   scala/collection/parallel/AdaptiveWorkStealingForkJoinTasks.class
-     6057  1980-01-01 00:00   scala/collection/parallel/AdaptiveWorkStealingTasks$WrappedTask.class
-     1782  1980-01-01 00:00   scala/collection/parallel/AdaptiveWorkStealingTasks.class
-     7007  1980-01-01 00:00   scala/collection/parallel/AdaptiveWorkStealingThreadPoolTasks$WrappedTask.class
-     2465  1980-01-01 00:00   scala/collection/parallel/AdaptiveWorkStealingThreadPoolTasks.class
-    25766  1980-01-01 00:00   scala/collection/parallel/AugmentedIterableIterator.class
-     7119  1980-01-01 00:00   scala/collection/parallel/AugmentedSeqIterator.class
-     8086  1980-01-01 00:00   scala/collection/parallel/BucketCombiner.class
-    49970  1980-01-01 00:00   scala/collection/parallel/BufferSplitter.class
-     3680  1980-01-01 00:00   scala/collection/parallel/Combiner.class
-      805  1980-01-01 00:00   scala/collection/parallel/CombinerFactory.class
-     2735  1980-01-01 00:00   scala/collection/parallel/CompositeThrowable$$anonfun$$lessinit$greater$1.class
-     2026  1980-01-01 00:00   scala/collection/parallel/CompositeThrowable$.class
-     6646  1980-01-01 00:00   scala/collection/parallel/CompositeThrowable.class
-      767  1980-01-01 00:00   scala/collection/parallel/ExecutionContextTaskSupport$.class
-     4502  1980-01-01 00:00   scala/collection/parallel/ExecutionContextTaskSupport.class
-     3816  1980-01-01 00:00   scala/collection/parallel/ExecutionContextTasks.class
-      472  1980-01-01 00:00   scala/collection/parallel/FactoryOps$Otherwise.class
-     1756  1980-01-01 00:00   scala/collection/parallel/FactoryOps.class
-      728  1980-01-01 00:00   scala/collection/parallel/ForkJoinTaskSupport$.class
-     5519  1980-01-01 00:00   scala/collection/parallel/ForkJoinTaskSupport.class
-      930  1980-01-01 00:00   scala/collection/parallel/ForkJoinTasks$.class
-     1658  1980-01-01 00:00   scala/collection/parallel/ForkJoinTasks$WrappedTask.class
-     5651  1980-01-01 00:00   scala/collection/parallel/ForkJoinTasks.class
-     2777  1980-01-01 00:00   scala/collection/parallel/FutureTasks$$anonfun$compute$1$1.class
-     9544  1980-01-01 00:00   scala/collection/parallel/FutureTasks.class
-     1205  1980-01-01 00:00   scala/collection/parallel/FutureThreadPoolTasks$.class
-     1099  1980-01-01 00:00   scala/collection/parallel/FutureThreadPoolTasks.class
-      543  1980-01-01 00:00   scala/collection/parallel/HavingForkJoinPool.class
-    48042  1980-01-01 00:00   scala/collection/parallel/IterableSplitter$Appended.class
-    47552  1980-01-01 00:00   scala/collection/parallel/IterableSplitter$Mapped.class
-    50763  1980-01-01 00:00   scala/collection/parallel/IterableSplitter$Taken.class
-    49820  1980-01-01 00:00   scala/collection/parallel/IterableSplitter$Zipped.class
-    49815  1980-01-01 00:00   scala/collection/parallel/IterableSplitter$ZippedAll.class
-    15413  1980-01-01 00:00   scala/collection/parallel/IterableSplitter.class
-     1834  1980-01-01 00:00   scala/collection/parallel/ParIterable$.class
-     9294  1980-01-01 00:00   scala/collection/parallel/ParIterable.class
-      804  1980-01-01 00:00   scala/collection/parallel/ParIterableLike$$anon$10.class
-     2312  1980-01-01 00:00   scala/collection/parallel/ParIterableLike$$anon$11$$anon$1.class
-     2313  1980-01-01 00:00   scala/collection/parallel/ParIterableLike$$anon$11$$anon$2.class
-     1837  1980-01-01 00:00   scala/collection/parallel/ParIterableLike$$anon$11$$anon$3.class
-     4222  1980-01-01 00:00   scala/collection/parallel/ParIterableLike$$anon$11.class
-     1633  1980-01-01 00:00   scala/collection/parallel/ParIterableLike$$anon$12.class
-     2118  1980-01-01 00:00   scala/collection/parallel/ParIterableLike$$anon$13$$anon$14.class
-     2434  1980-01-01 00:00   scala/collection/parallel/ParIterableLike$$anon$13.class
-     1859  1980-01-01 00:00   scala/collection/parallel/ParIterableLike$$anon$15.class
-     1499  1980-01-01 00:00   scala/collection/parallel/ParIterableLike$$anon$16.class
-     1403  1980-01-01 00:00   scala/collection/parallel/ParIterableLike$$anon$17.class
-     1482  1980-01-01 00:00   scala/collection/parallel/ParIterableLike$$anon$18.class
-     1281  1980-01-01 00:00   scala/collection/parallel/ParIterableLike$$anon$19.class
-     4628  1980-01-01 00:00   scala/collection/parallel/ParIterableLike$$anon$4.class
-     2070  1980-01-01 00:00   scala/collection/parallel/ParIterableLike$$anon$5.class
-     2040  1980-01-01 00:00   scala/collection/parallel/ParIterableLike$$anon$6.class
-     2070  1980-01-01 00:00   scala/collection/parallel/ParIterableLike$$anon$7.class
-      791  1980-01-01 00:00   scala/collection/parallel/ParIterableLike$$anon$8.class
-      791  1980-01-01 00:00   scala/collection/parallel/ParIterableLike$$anon$9.class
-     5033  1980-01-01 00:00   scala/collection/parallel/ParIterableLike$Accessor.class
-     6857  1980-01-01 00:00   scala/collection/parallel/ParIterableLike$Aggregate.class
-      644  1980-01-01 00:00   scala/collection/parallel/ParIterableLike$BuilderOps$Otherwise.class
-     1422  1980-01-01 00:00   scala/collection/parallel/ParIterableLike$BuilderOps.class
-     7631  1980-01-01 00:00   scala/collection/parallel/ParIterableLike$Collect.class
-     5585  1980-01-01 00:00   scala/collection/parallel/ParIterableLike$Composite.class
-     7520  1980-01-01 00:00   scala/collection/parallel/ParIterableLike$Copy.class
-    10446  1980-01-01 00:00   scala/collection/parallel/ParIterableLike$CopyToArray.class
-     6645  1980-01-01 00:00   scala/collection/parallel/ParIterableLike$Count.class
-    13048  1980-01-01 00:00   scala/collection/parallel/ParIterableLike$CreateScanTree.class
-    11288  1980-01-01 00:00   scala/collection/parallel/ParIterableLike$Drop.class
-     6775  1980-01-01 00:00   scala/collection/parallel/ParIterableLike$Exists.class
-     7737  1980-01-01 00:00   scala/collection/parallel/ParIterableLike$Filter.class
-     7770  1980-01-01 00:00   scala/collection/parallel/ParIterableLike$FilterNot.class
-     6939  1980-01-01 00:00   scala/collection/parallel/ParIterableLike$Find.class
-     7678  1980-01-01 00:00   scala/collection/parallel/ParIterableLike$FlatMap.class
-     6566  1980-01-01 00:00   scala/collection/parallel/ParIterableLike$Fold.class
-     6771  1980-01-01 00:00   scala/collection/parallel/ParIterableLike$Forall.class
-     6416  1980-01-01 00:00   scala/collection/parallel/ParIterableLike$Foreach.class
-     8518  1980-01-01 00:00   scala/collection/parallel/ParIterableLike$FromScanTree.class
-     8271  1980-01-01 00:00   scala/collection/parallel/ParIterableLike$GroupBy.class
-     7671  1980-01-01 00:00   scala/collection/parallel/ParIterableLike$Map.class
-     6996  1980-01-01 00:00   scala/collection/parallel/ParIterableLike$Max.class
-     6996  1980-01-01 00:00   scala/collection/parallel/ParIterableLike$Min.class
-      614  1980-01-01 00:00   scala/collection/parallel/ParIterableLike$NonDivisible.class
-     1769  1980-01-01 00:00   scala/collection/parallel/ParIterableLike$NonDivisibleTask.class
-     2467  1980-01-01 00:00   scala/collection/parallel/ParIterableLike$ParComposite.class
-     9514  1980-01-01 00:00   scala/collection/parallel/ParIterableLike$Partition.class
-     6509  1980-01-01 00:00   scala/collection/parallel/ParIterableLike$Product.class
-     6998  1980-01-01 00:00   scala/collection/parallel/ParIterableLike$Reduce.class
-     5485  1980-01-01 00:00   scala/collection/parallel/ParIterableLike$ResultMapping.class
-     3053  1980-01-01 00:00   scala/collection/parallel/ParIterableLike$ScanLeaf$.class
-     8259  1980-01-01 00:00   scala/collection/parallel/ParIterableLike$ScanLeaf.class
-     2655  1980-01-01 00:00   scala/collection/parallel/ParIterableLike$ScanNode$.class
-     6510  1980-01-01 00:00   scala/collection/parallel/ParIterableLike$ScanNode.class
-     1282  1980-01-01 00:00   scala/collection/parallel/ParIterableLike$ScanTree.class
-     2279  1980-01-01 00:00   scala/collection/parallel/ParIterableLike$SeqComposite.class
-      586  1980-01-01 00:00   scala/collection/parallel/ParIterableLike$SignallingOps.class
-    11654  1980-01-01 00:00   scala/collection/parallel/ParIterableLike$Slice.class
-    12563  1980-01-01 00:00   scala/collection/parallel/ParIterableLike$Span.class
-    12280  1980-01-01 00:00   scala/collection/parallel/ParIterableLike$SplitAt.class
-     1558  1980-01-01 00:00   scala/collection/parallel/ParIterableLike$StrictSplitterCheckTask.class
-     6464  1980-01-01 00:00   scala/collection/parallel/ParIterableLike$Sum.class
-    11228  1980-01-01 00:00   scala/collection/parallel/ParIterableLike$Take.class
-    12029  1980-01-01 00:00   scala/collection/parallel/ParIterableLike$TakeWhile.class
-     2405  1980-01-01 00:00   scala/collection/parallel/ParIterableLike$TaskOps.class
-     7559  1980-01-01 00:00   scala/collection/parallel/ParIterableLike$ToParCollection.class
-     8050  1980-01-01 00:00   scala/collection/parallel/ParIterableLike$ToParMap.class
-      529  1980-01-01 00:00   scala/collection/parallel/ParIterableLike$Transformer.class
-    10293  1980-01-01 00:00   scala/collection/parallel/ParIterableLike$Zip.class
-    11715  1980-01-01 00:00   scala/collection/parallel/ParIterableLike$ZipAll.class
-   107832  1980-01-01 00:00   scala/collection/parallel/ParIterableLike.class
-     1905  1980-01-01 00:00   scala/collection/parallel/ParMap$.class
-    56228  1980-01-01 00:00   scala/collection/parallel/ParMap$WithDefault.class
-     5036  1980-01-01 00:00   scala/collection/parallel/ParMap.class
-    59748  1980-01-01 00:00   scala/collection/parallel/ParMapLike$$anon$1.class
-    59916  1980-01-01 00:00   scala/collection/parallel/ParMapLike$$anon$2.class
-    48448  1980-01-01 00:00   scala/collection/parallel/ParMapLike$$anon$3.class
-    48456  1980-01-01 00:00   scala/collection/parallel/ParMapLike$$anon$4.class
-    59489  1980-01-01 00:00   scala/collection/parallel/ParMapLike$DefaultKeySet.class
-    51680  1980-01-01 00:00   scala/collection/parallel/ParMapLike$DefaultValuesIterable.class
-     9625  1980-01-01 00:00   scala/collection/parallel/ParMapLike.class
-     1799  1980-01-01 00:00   scala/collection/parallel/ParSeq$.class
-     9703  1980-01-01 00:00   scala/collection/parallel/ParSeq.class
-     2002  1980-01-01 00:00   scala/collection/parallel/ParSeqLike$$anon$3.class
-     1999  1980-01-01 00:00   scala/collection/parallel/ParSeqLike$$anon$4.class
-     2003  1980-01-01 00:00   scala/collection/parallel/ParSeqLike$$anon$5.class
-      769  1980-01-01 00:00   scala/collection/parallel/ParSeqLike$$anon$6.class
-      775  1980-01-01 00:00   scala/collection/parallel/ParSeqLike$$anon$7.class
-      766  1980-01-01 00:00   scala/collection/parallel/ParSeqLike$$anon$8.class
-      786  1980-01-01 00:00   scala/collection/parallel/ParSeqLike$$anon$9.class
-      664  1980-01-01 00:00   scala/collection/parallel/ParSeqLike$Accessor.class
-     9893  1980-01-01 00:00   scala/collection/parallel/ParSeqLike$Corresponds.class
-     1174  1980-01-01 00:00   scala/collection/parallel/ParSeqLike$Elements$$anon$1.class
-     1459  1980-01-01 00:00   scala/collection/parallel/ParSeqLike$Elements$$anon$2.class
-    56472  1980-01-01 00:00   scala/collection/parallel/ParSeqLike$Elements.class
-    10321  1980-01-01 00:00   scala/collection/parallel/ParSeqLike$IndexWhere.class
-    10373  1980-01-01 00:00   scala/collection/parallel/ParSeqLike$LastIndexWhere.class
-     7673  1980-01-01 00:00   scala/collection/parallel/ParSeqLike$Reverse.class
-     7829  1980-01-01 00:00   scala/collection/parallel/ParSeqLike$ReverseMap.class
-     9702  1980-01-01 00:00   scala/collection/parallel/ParSeqLike$SameElements.class
-    10696  1980-01-01 00:00   scala/collection/parallel/ParSeqLike$SegmentLength.class
-      707  1980-01-01 00:00   scala/collection/parallel/ParSeqLike$Transformer.class
-    10820  1980-01-01 00:00   scala/collection/parallel/ParSeqLike$Updated.class
-     8696  1980-01-01 00:00   scala/collection/parallel/ParSeqLike$Zip.class
-    38493  1980-01-01 00:00   scala/collection/parallel/ParSeqLike.class
-     1454  1980-01-01 00:00   scala/collection/parallel/ParSet$.class
-     3587  1980-01-01 00:00   scala/collection/parallel/ParSet.class
-     3820  1980-01-01 00:00   scala/collection/parallel/ParSetLike.class
-     1979  1980-01-01 00:00   scala/collection/parallel/ParallelCollectionImplicits$$anon$1.class
-     1660  1980-01-01 00:00   scala/collection/parallel/ParallelCollectionImplicits$$anon$2$$anon$3.class
-     2328  1980-01-01 00:00   scala/collection/parallel/ParallelCollectionImplicits$$anon$2.class
-     1668  1980-01-01 00:00   scala/collection/parallel/ParallelCollectionImplicits$$anon$4$$anon$5.class
-     1993  1980-01-01 00:00   scala/collection/parallel/ParallelCollectionImplicits$$anon$4.class
-     1891  1980-01-01 00:00   scala/collection/parallel/ParallelCollectionImplicits$.class
-     1847  1980-01-01 00:00   scala/collection/parallel/ParallelCollectionImplicits.class
-     1108  1980-01-01 00:00   scala/collection/parallel/PreciseSplitter.class
-     1281  1980-01-01 00:00   scala/collection/parallel/RemainsIterator.class
-     1637  1980-01-01 00:00   scala/collection/parallel/SeqSplitter$$anon$1.class
-    17030  1980-01-01 00:00   scala/collection/parallel/SeqSplitter$Appended.class
-    13364  1980-01-01 00:00   scala/collection/parallel/SeqSplitter$Mapped.class
-    53615  1980-01-01 00:00   scala/collection/parallel/SeqSplitter$Patched.class
-    13200  1980-01-01 00:00   scala/collection/parallel/SeqSplitter$Taken.class
-    13766  1980-01-01 00:00   scala/collection/parallel/SeqSplitter$Zipped.class
-    13768  1980-01-01 00:00   scala/collection/parallel/SeqSplitter$ZippedAll.class
-    13460  1980-01-01 00:00   scala/collection/parallel/SeqSplitter.class
-    29378  1980-01-01 00:00   scala/collection/parallel/Splitter$$anon$1.class
-      726  1980-01-01 00:00   scala/collection/parallel/Splitter$.class
-     1124  1980-01-01 00:00   scala/collection/parallel/Splitter.class
-     6075  1980-01-01 00:00   scala/collection/parallel/Task.class
-      431  1980-01-01 00:00   scala/collection/parallel/TaskSupport.class
-     1225  1980-01-01 00:00   scala/collection/parallel/Tasks$WrappedTask.class
-     3374  1980-01-01 00:00   scala/collection/parallel/Tasks.class
-      759  1980-01-01 00:00   scala/collection/parallel/ThreadPoolTaskSupport$.class
-     6218  1980-01-01 00:00   scala/collection/parallel/ThreadPoolTaskSupport.class
-     1344  1980-01-01 00:00   scala/collection/parallel/ThreadPoolTasks$$anon$1.class
-     1783  1980-01-01 00:00   scala/collection/parallel/ThreadPoolTasks$.class
-     3229  1980-01-01 00:00   scala/collection/parallel/ThreadPoolTasks$WrappedTask.class
-     7381  1980-01-01 00:00   scala/collection/parallel/ThreadPoolTasks.class
-      713  1980-01-01 00:00   scala/collection/parallel/ThrowableOps.class
-      480  1980-01-01 00:00   scala/collection/parallel/TraversableOps$Otherwise.class
-     1881  1980-01-01 00:00   scala/collection/parallel/TraversableOps.class
-        0  1980-01-01 00:00   scala/collection/parallel/immutable/
-      708  1980-01-01 00:00   scala/collection/parallel/immutable/HashMapCombiner$$anon$1.class
-     1055  1980-01-01 00:00   scala/collection/parallel/immutable/HashMapCombiner$.class
-    10519  1980-01-01 00:00   scala/collection/parallel/immutable/HashMapCombiner$CreateGroupedTrie.class
-     6929  1980-01-01 00:00   scala/collection/parallel/immutable/HashMapCombiner$CreateTrie.class
-    12102  1980-01-01 00:00   scala/collection/parallel/immutable/HashMapCombiner.class
-      705  1980-01-01 00:00   scala/collection/parallel/immutable/HashSetCombiner$$anon$1.class
-     1032  1980-01-01 00:00   scala/collection/parallel/immutable/HashSetCombiner$.class
-     6644  1980-01-01 00:00   scala/collection/parallel/immutable/HashSetCombiner$CreateTrie.class
-     8966  1980-01-01 00:00   scala/collection/parallel/immutable/HashSetCombiner.class
-     9497  1980-01-01 00:00   scala/collection/parallel/immutable/LazyParVectorCombiner.class
-     3069  1980-01-01 00:00   scala/collection/parallel/immutable/ParHashMap$.class
-    51262  1980-01-01 00:00   scala/collection/parallel/immutable/ParHashMap$ParHashMapIterator.class
-    65471  1980-01-01 00:00   scala/collection/parallel/immutable/ParHashMap.class
-     2173  1980-01-01 00:00   scala/collection/parallel/immutable/ParHashSet$.class
-    49972  1980-01-01 00:00   scala/collection/parallel/immutable/ParHashSet$ParHashSetIterator.class
-    62992  1980-01-01 00:00   scala/collection/parallel/immutable/ParHashSet.class
-     1665  1980-01-01 00:00   scala/collection/parallel/immutable/ParIterable$.class
-    10104  1980-01-01 00:00   scala/collection/parallel/immutable/ParIterable.class
-     1984  1980-01-01 00:00   scala/collection/parallel/immutable/ParMap$.class
-    12005  1980-01-01 00:00   scala/collection/parallel/immutable/ParMap$WithDefault.class
-     8484  1980-01-01 00:00   scala/collection/parallel/immutable/ParMap.class
-     1195  1980-01-01 00:00   scala/collection/parallel/immutable/ParRange$.class
-      866  1980-01-01 00:00   scala/collection/parallel/immutable/ParRange$ParRangeIterator$.class
-    56646  1980-01-01 00:00   scala/collection/parallel/immutable/ParRange$ParRangeIterator.class
-    65911  1980-01-01 00:00   scala/collection/parallel/immutable/ParRange.class
-     1630  1980-01-01 00:00   scala/collection/parallel/immutable/ParSeq$.class
-     9149  1980-01-01 00:00   scala/collection/parallel/immutable/ParSeq.class
-     1511  1980-01-01 00:00   scala/collection/parallel/immutable/ParSet$.class
-     3984  1980-01-01 00:00   scala/collection/parallel/immutable/ParSet.class
-     1748  1980-01-01 00:00   scala/collection/parallel/immutable/ParVector$.class
-    31925  1980-01-01 00:00   scala/collection/parallel/immutable/ParVector$ParVectorIterator.class
-    68764  1980-01-01 00:00   scala/collection/parallel/immutable/ParVector.class
-     8696  1980-01-01 00:00   scala/collection/parallel/immutable/Repetition$$anon$1.class
-     1224  1980-01-01 00:00   scala/collection/parallel/immutable/Repetition$ParIterator$.class
-    55657  1980-01-01 00:00   scala/collection/parallel/immutable/Repetition$ParIterator.class
-    64184  1980-01-01 00:00   scala/collection/parallel/immutable/Repetition.class
-      892  1980-01-01 00:00   scala/collection/parallel/immutable/package$.class
-      918  1980-01-01 00:00   scala/collection/parallel/immutable/package.class
-        0  1980-01-01 00:00   scala/collection/parallel/mutable/
-     1849  1980-01-01 00:00   scala/collection/parallel/mutable/ExposedArrayBuffer.class
-     1553  1980-01-01 00:00   scala/collection/parallel/mutable/ExposedArraySeq.class
-     6230  1980-01-01 00:00   scala/collection/parallel/mutable/LazyCombiner.class
-     6002  1980-01-01 00:00   scala/collection/parallel/mutable/ParArray$.class
-     5248  1980-01-01 00:00   scala/collection/parallel/mutable/ParArray$Map.class
-     1177  1980-01-01 00:00   scala/collection/parallel/mutable/ParArray$ParArrayIterator$.class
-    70743  1980-01-01 00:00   scala/collection/parallel/mutable/ParArray$ParArrayIterator.class
-     7266  1980-01-01 00:00   scala/collection/parallel/mutable/ParArray$ScanToArray.class
-    82289  1980-01-01 00:00   scala/collection/parallel/mutable/ParArray.class
-    51302  1980-01-01 00:00   scala/collection/parallel/mutable/ParFlatHashTable$ParFlatHashTableIterator.class
-     2292  1980-01-01 00:00   scala/collection/parallel/mutable/ParFlatHashTable.class
-     2400  1980-01-01 00:00   scala/collection/parallel/mutable/ParHashMap$.class
-     2987  1980-01-01 00:00   scala/collection/parallel/mutable/ParHashMap$ParHashMapIterator.class
-    84379  1980-01-01 00:00   scala/collection/parallel/mutable/ParHashMap.class
-      864  1980-01-01 00:00   scala/collection/parallel/mutable/ParHashMapCombiner$$anon$1.class
-     1317  1980-01-01 00:00   scala/collection/parallel/mutable/ParHashMapCombiner$.class
-    12187  1980-01-01 00:00   scala/collection/parallel/mutable/ParHashMapCombiner$AddingHashTable.class
-     7232  1980-01-01 00:00   scala/collection/parallel/mutable/ParHashMapCombiner$FillBlocks.class
-    11376  1980-01-01 00:00   scala/collection/parallel/mutable/ParHashMapCombiner$table$2$.class
-    11579  1980-01-01 00:00   scala/collection/parallel/mutable/ParHashMapCombiner.class
-     1890  1980-01-01 00:00   scala/collection/parallel/mutable/ParHashSet$.class
-     1930  1980-01-01 00:00   scala/collection/parallel/mutable/ParHashSet$ParHashSetIterator.class
-    76052  1980-01-01 00:00   scala/collection/parallel/mutable/ParHashSet.class
-      869  1980-01-01 00:00   scala/collection/parallel/mutable/ParHashSetCombiner$$anon$1.class
-    12508  1980-01-01 00:00   scala/collection/parallel/mutable/ParHashSetCombiner$$anon$2.class
-     1294  1980-01-01 00:00   scala/collection/parallel/mutable/ParHashSetCombiner$.class
-    10855  1980-01-01 00:00   scala/collection/parallel/mutable/ParHashSetCombiner$AddingFlatHashTable.class
-    10359  1980-01-01 00:00   scala/collection/parallel/mutable/ParHashSetCombiner$FillBlocks.class
-    10574  1980-01-01 00:00   scala/collection/parallel/mutable/ParHashSetCombiner.class
-    54923  1980-01-01 00:00   scala/collection/parallel/mutable/ParHashTable$EntryIterator.class
-     2763  1980-01-01 00:00   scala/collection/parallel/mutable/ParHashTable.class
-     1882  1980-01-01 00:00   scala/collection/parallel/mutable/ParIterable$.class
-    10198  1980-01-01 00:00   scala/collection/parallel/mutable/ParIterable.class
-     1969  1980-01-01 00:00   scala/collection/parallel/mutable/ParMap$.class
-    15599  1980-01-01 00:00   scala/collection/parallel/mutable/ParMap$WithDefault.class
-     7719  1980-01-01 00:00   scala/collection/parallel/mutable/ParMap.class
-     3694  1980-01-01 00:00   scala/collection/parallel/mutable/ParMapLike.class
-     1847  1980-01-01 00:00   scala/collection/parallel/mutable/ParSeq$.class
-     9395  1980-01-01 00:00   scala/collection/parallel/mutable/ParSeq.class
-     1628  1980-01-01 00:00   scala/collection/parallel/mutable/ParSet$.class
-     3640  1980-01-01 00:00   scala/collection/parallel/mutable/ParSet.class
-     2997  1980-01-01 00:00   scala/collection/parallel/mutable/ParSetLike.class
-     1950  1980-01-01 00:00   scala/collection/parallel/mutable/ParTrieMap$.class
-     5164  1980-01-01 00:00   scala/collection/parallel/mutable/ParTrieMap$Size.class
-    72552  1980-01-01 00:00   scala/collection/parallel/mutable/ParTrieMap.class
-     2316  1980-01-01 00:00   scala/collection/parallel/mutable/ParTrieMapCombiner.class
-    25373  1980-01-01 00:00   scala/collection/parallel/mutable/ParTrieMapSplitter.class
-     9527  1980-01-01 00:00   scala/collection/parallel/mutable/ResizableParArrayCombiner$$anon$1.class
-     1592  1980-01-01 00:00   scala/collection/parallel/mutable/ResizableParArrayCombiner$.class
-     6629  1980-01-01 00:00   scala/collection/parallel/mutable/ResizableParArrayCombiner$CopyChainToArray.class
-     6106  1980-01-01 00:00   scala/collection/parallel/mutable/ResizableParArrayCombiner.class
-     2004  1980-01-01 00:00   scala/collection/parallel/mutable/SizeMapUtils.class
-     7482  1980-01-01 00:00   scala/collection/parallel/mutable/UnrolledParArrayCombiner$$anon$1.class
-      862  1980-01-01 00:00   scala/collection/parallel/mutable/UnrolledParArrayCombiner$.class
-     6898  1980-01-01 00:00   scala/collection/parallel/mutable/UnrolledParArrayCombiner$CopyUnrolledToArray.class
-     7185  1980-01-01 00:00   scala/collection/parallel/mutable/UnrolledParArrayCombiner.class
-      771  1980-01-01 00:00   scala/collection/parallel/mutable/package$.class
-      884  1980-01-01 00:00   scala/collection/parallel/mutable/package.class
-     2930  1980-01-01 00:00   scala/collection/parallel/package$.class
-     2305  1980-01-01 00:00   scala/collection/parallel/package$CollectionsHaveToParArray.class
-     2542  1980-01-01 00:00   scala/collection/parallel/package.class
-        0  1980-01-01 00:00   scala/collection/script/
-     1842  1980-01-01 00:00   scala/collection/script/End$.class
-     1559  1980-01-01 00:00   scala/collection/script/End.class
-     1815  1980-01-01 00:00   scala/collection/script/Include$.class
-     5543  1980-01-01 00:00   scala/collection/script/Include.class
-     1749  1980-01-01 00:00   scala/collection/script/Index$.class
-     5373  1980-01-01 00:00   scala/collection/script/Index.class
-      712  1980-01-01 00:00   scala/collection/script/Location.class
-      566  1980-01-01 00:00   scala/collection/script/Message.class
-     1845  1980-01-01 00:00   scala/collection/script/NoLo$.class
-     1565  1980-01-01 00:00   scala/collection/script/NoLo.class
-     1806  1980-01-01 00:00   scala/collection/script/Remove$.class
-     5532  1980-01-01 00:00   scala/collection/script/Remove.class
-     1206  1980-01-01 00:00   scala/collection/script/Reset$.class
-     3627  1980-01-01 00:00   scala/collection/script/Reset.class
-     1873  1980-01-01 00:00   scala/collection/script/Script.class
-      818  1980-01-01 00:00   scala/collection/script/Scriptable.class
-     1848  1980-01-01 00:00   scala/collection/script/Start$.class
-     1570  1980-01-01 00:00   scala/collection/script/Start.class
-     1806  1980-01-01 00:00   scala/collection/script/Update$.class
-     5532  1980-01-01 00:00   scala/collection/script/Update.class
-        0  1980-01-01 00:00   scala/compat/
-     2089  1980-01-01 00:00   scala/compat/Platform$.class
-     2006  1980-01-01 00:00   scala/compat/Platform.class
-        0  1980-01-01 00:00   scala/concurrent/
-     3517  1980-01-01 00:00   scala/concurrent/Await$.class
-     1640  1980-01-01 00:00   scala/concurrent/Await.class
-      460  1980-01-01 00:00   scala/concurrent/AwaitPermission$.class
-      400  1980-01-01 00:00   scala/concurrent/AwaitPermission.class
-     1555  1980-01-01 00:00   scala/concurrent/Awaitable.class
-     5042  1980-01-01 00:00   scala/concurrent/BatchingExecutor$Batch.class
-     3652  1980-01-01 00:00   scala/concurrent/BatchingExecutor.class
-     2058  1980-01-01 00:00   scala/concurrent/BlockContext$.class
-      988  1980-01-01 00:00   scala/concurrent/BlockContext$DefaultBlockContext$.class
-     1827  1980-01-01 00:00   scala/concurrent/BlockContext.class
-      499  1980-01-01 00:00   scala/concurrent/CanAwait.class
-     1621  1980-01-01 00:00   scala/concurrent/Channel$LinkedList.class
-     3056  1980-01-01 00:00   scala/concurrent/Channel.class
-      990  1980-01-01 00:00   scala/concurrent/DelayedLazyVal$$anon$1.class
-     2471  1980-01-01 00:00   scala/concurrent/DelayedLazyVal.class
-     4628  1980-01-01 00:00   scala/concurrent/ExecutionContext$.class
-     1254  1980-01-01 00:00   scala/concurrent/ExecutionContext$Implicits$.class
-     5432  1980-01-01 00:00   scala/concurrent/ExecutionContext.class
-      542  1980-01-01 00:00   scala/concurrent/ExecutionContextExecutor.class
-      589  1980-01-01 00:00   scala/concurrent/ExecutionContextExecutorService.class
-     1801  1980-01-01 00:00   scala/concurrent/Future$$anonfun$fallbackTo$1.class
-     1780  1980-01-01 00:00   scala/concurrent/Future$$anonfun$fallbackTo$2.class
-    21073  1980-01-01 00:00   scala/concurrent/Future$.class
-     2598  1980-01-01 00:00   scala/concurrent/Future$InternalCallbackExecutor$.class
-     9948  1980-01-01 00:00   scala/concurrent/Future$never$.class
-    38915  1980-01-01 00:00   scala/concurrent/Future.class
-     1059  1980-01-01 00:00   scala/concurrent/JavaConversions$.class
-     1004  1980-01-01 00:00   scala/concurrent/JavaConversions.class
-     1315  1980-01-01 00:00   scala/concurrent/Lock.class
-      452  1980-01-01 00:00   scala/concurrent/OnCompleteRunnable.class
-     1813  1980-01-01 00:00   scala/concurrent/Promise$.class
-     7504  1980-01-01 00:00   scala/concurrent/Promise.class
-     4000  1980-01-01 00:00   scala/concurrent/SyncChannel.class
-     3938  1980-01-01 00:00   scala/concurrent/SyncVar.class
-        0  1980-01-01 00:00   scala/concurrent/duration/
-     1878  1980-01-01 00:00   scala/concurrent/duration/Deadline$.class
-     3858  1980-01-01 00:00   scala/concurrent/duration/Deadline$DeadlineIsOrdered$.class
-     6693  1980-01-01 00:00   scala/concurrent/duration/Deadline.class
-     2344  1980-01-01 00:00   scala/concurrent/duration/Duration$$anon$1.class
-     1667  1980-01-01 00:00   scala/concurrent/duration/Duration$$anon$2.class
-     1617  1980-01-01 00:00   scala/concurrent/duration/Duration$$anon$3.class
-    15776  1980-01-01 00:00   scala/concurrent/duration/Duration$.class
-     3840  1980-01-01 00:00   scala/concurrent/duration/Duration$DurationIsOrdered$.class
-     3867  1980-01-01 00:00   scala/concurrent/duration/Duration$Infinite.class
-     8459  1980-01-01 00:00   scala/concurrent/duration/Duration.class
-      469  1980-01-01 00:00   scala/concurrent/duration/DurationConversions$.class
-      491  1980-01-01 00:00   scala/concurrent/duration/DurationConversions$Classifier.class
-     1448  1980-01-01 00:00   scala/concurrent/duration/DurationConversions$fromNowConvert$.class
-     1227  1980-01-01 00:00   scala/concurrent/duration/DurationConversions$spanConvert$.class
-    12746  1980-01-01 00:00   scala/concurrent/duration/DurationConversions.class
-     1916  1980-01-01 00:00   scala/concurrent/duration/FiniteDuration$.class
-     3930  1980-01-01 00:00   scala/concurrent/duration/FiniteDuration$FiniteDurationIsOrdered$.class
-    13313  1980-01-01 00:00   scala/concurrent/duration/FiniteDuration.class
-     3165  1980-01-01 00:00   scala/concurrent/duration/package$.class
-     1517  1980-01-01 00:00   scala/concurrent/duration/package$DoubleMult$.class
-     1461  1980-01-01 00:00   scala/concurrent/duration/package$DoubleMult.class
-     2088  1980-01-01 00:00   scala/concurrent/duration/package$DurationDouble$.class
-     6260  1980-01-01 00:00   scala/concurrent/duration/package$DurationDouble.class
-     1609  1980-01-01 00:00   scala/concurrent/duration/package$DurationInt$.class
-     6233  1980-01-01 00:00   scala/concurrent/duration/package$DurationInt.class
-     1539  1980-01-01 00:00   scala/concurrent/duration/package$DurationLong$.class
-     6246  1980-01-01 00:00   scala/concurrent/duration/package$DurationLong.class
-     1855  1980-01-01 00:00   scala/concurrent/duration/package$IntMult$.class
-     1783  1980-01-01 00:00   scala/concurrent/duration/package$IntMult.class
-     1864  1980-01-01 00:00   scala/concurrent/duration/package$LongMult$.class
-     1796  1980-01-01 00:00   scala/concurrent/duration/package$LongMult.class
-      526  1980-01-01 00:00   scala/concurrent/duration/package$fromNow$.class
-      517  1980-01-01 00:00   scala/concurrent/duration/package$span$.class
-     7250  1980-01-01 00:00   scala/concurrent/duration/package.class
-        0  1980-01-01 00:00   scala/concurrent/forkjoin/
-      433  1980-01-01 00:00   scala/concurrent/forkjoin/package$.class
-     1308  1980-01-01 00:00   scala/concurrent/forkjoin/package$ForkJoinPool$.class
-     3320  1980-01-01 00:00   scala/concurrent/forkjoin/package$ForkJoinTask$.class
-      881  1980-01-01 00:00   scala/concurrent/forkjoin/package$ThreadLocalRandom$.class
-     3219  1980-01-01 00:00   scala/concurrent/forkjoin/package.class
-        0  1980-01-01 00:00   scala/concurrent/impl/
-     3447  1980-01-01 00:00   scala/concurrent/impl/CallbackRunnable.class
-     1424  1980-01-01 00:00   scala/concurrent/impl/ExecutionContextImpl$$anon$1$$anonfun$$lessinit$greater$1.class
-     4930  1980-01-01 00:00   scala/concurrent/impl/ExecutionContextImpl$$anon$1.class
-     2128  1980-01-01 00:00   scala/concurrent/impl/ExecutionContextImpl$$anon$3.class
-     1141  1980-01-01 00:00   scala/concurrent/impl/ExecutionContextImpl$$anon$6.class
-     6406  1980-01-01 00:00   scala/concurrent/impl/ExecutionContextImpl$.class
-     1919  1980-01-01 00:00   scala/concurrent/impl/ExecutionContextImpl$AdaptedForkJoinTask.class
-     2202  1980-01-01 00:00   scala/concurrent/impl/ExecutionContextImpl$DefaultThreadFactory$$anon$2$$anon$5.class
-     2425  1980-01-01 00:00   scala/concurrent/impl/ExecutionContextImpl$DefaultThreadFactory$$anon$2.class
-     1326  1980-01-01 00:00   scala/concurrent/impl/ExecutionContextImpl$DefaultThreadFactory$$anon$4.class
-     4698  1980-01-01 00:00   scala/concurrent/impl/ExecutionContextImpl$DefaultThreadFactory.class
-     7445  1980-01-01 00:00   scala/concurrent/impl/ExecutionContextImpl.class
-     1808  1980-01-01 00:00   scala/concurrent/impl/Promise$.class
-     6999  1980-01-01 00:00   scala/concurrent/impl/Promise$CompletionLatch.class
-    21015  1980-01-01 00:00   scala/concurrent/impl/Promise$DefaultPromise.class
-     1528  1980-01-01 00:00   scala/concurrent/impl/Promise$KeptPromise$.class
-     2079  1980-01-01 00:00   scala/concurrent/impl/Promise$KeptPromise$Failed$$anonfun$fallbackTo$1.class
-    14999  1980-01-01 00:00   scala/concurrent/impl/Promise$KeptPromise$Failed.class
-     3956  1980-01-01 00:00   scala/concurrent/impl/Promise$KeptPromise$Kept.class
-    16065  1980-01-01 00:00   scala/concurrent/impl/Promise$KeptPromise$Successful.class
-    11634  1980-01-01 00:00   scala/concurrent/impl/Promise.class
-     3049  1980-01-01 00:00   scala/concurrent/package$.class
-     2090  1980-01-01 00:00   scala/concurrent/package.class
-      615  1980-01-01 00:00   scala/deprecated$.class
-     1443  1980-01-01 00:00   scala/deprecated.class
-      648  1980-01-01 00:00   scala/deprecatedInheritance$.class
-     1523  1980-01-01 00:00   scala/deprecatedInheritance.class
-     1026  1980-01-01 00:00   scala/deprecatedName$.class
-     1445  1980-01-01 00:00   scala/deprecatedName.class
-      645  1980-01-01 00:00   scala/deprecatedOverriding$.class
-     1516  1980-01-01 00:00   scala/deprecatedOverriding.class
-      592  1980-01-01 00:00   scala/inline.class
-        0  1980-01-01 00:00   scala/io/
-      476  1980-01-01 00:00   scala/io/AnsiColor$.class
-     5548  1980-01-01 00:00   scala/io/AnsiColor.class
-     2084  1980-01-01 00:00   scala/io/BufferedSource$BufferedLineIterator.class
-     7391  1980-01-01 00:00   scala/io/BufferedSource.class
-      913  1980-01-01 00:00   scala/io/Codec$$anon$1.class
-     4310  1980-01-01 00:00   scala/io/Codec$.class
-     8125  1980-01-01 00:00   scala/io/Codec.class
-     1041  1980-01-01 00:00   scala/io/LowPriorityCodecImplicits.class
-     1040  1980-01-01 00:00   scala/io/Position$.class
-     2386  1980-01-01 00:00   scala/io/Position.class
-      943  1980-01-01 00:00   scala/io/Source$$anon$1.class
-    10912  1980-01-01 00:00   scala/io/Source$.class
-     2514  1980-01-01 00:00   scala/io/Source$LineIterator.class
-     1065  1980-01-01 00:00   scala/io/Source$NoPositioner$.class
-     2602  1980-01-01 00:00   scala/io/Source$Positioner.class
-      645  1980-01-01 00:00   scala/io/Source$RelaxedPosition$.class
-      716  1980-01-01 00:00   scala/io/Source$RelaxedPositioner$.class
-    44342  1980-01-01 00:00   scala/io/Source.class
-     3231  1980-01-01 00:00   scala/io/StdIn$.class
-     9143  1980-01-01 00:00   scala/io/StdIn.class
-     3733  1980-01-01 00:00   scala/language$.class
-     1172  1980-01-01 00:00   scala/language$experimental$.class
-     1892  1980-01-01 00:00   scala/language.class
-      417  1980-01-01 00:00   scala/languageFeature$.class
-      558  1980-01-01 00:00   scala/languageFeature$dynamics$.class
-      238  1980-01-01 00:00   scala/languageFeature$dynamics.class
-      578  1980-01-01 00:00   scala/languageFeature$existentials$.class
-      246  1980-01-01 00:00   scala/languageFeature$existentials.class
-      647  1980-01-01 00:00   scala/languageFeature$experimental$.class
-      652  1980-01-01 00:00   scala/languageFeature$experimental$macros$.class
-      312  1980-01-01 00:00   scala/languageFeature$experimental$macros.class
-      573  1980-01-01 00:00   scala/languageFeature$higherKinds$.class
-      244  1980-01-01 00:00   scala/languageFeature$higherKinds.class
-      613  1980-01-01 00:00   scala/languageFeature$implicitConversions$.class
-      260  1980-01-01 00:00   scala/languageFeature$implicitConversions.class
-      568  1980-01-01 00:00   scala/languageFeature$postfixOps$.class
-      242  1980-01-01 00:00   scala/languageFeature$postfixOps.class
-      593  1980-01-01 00:00   scala/languageFeature$reflectiveCalls$.class
-      252  1980-01-01 00:00   scala/languageFeature$reflectiveCalls.class
-     2317  1980-01-01 00:00   scala/languageFeature.class
-        0  1980-01-01 00:00   scala/math/
-     9090  1980-01-01 00:00   scala/math/BigDecimal$.class
-     1712  1980-01-01 00:00   scala/math/BigDecimal$RoundingMode$.class
-    27558  1980-01-01 00:00   scala/math/BigDecimal.class
-     3686  1980-01-01 00:00   scala/math/BigInt$.class
-    17197  1980-01-01 00:00   scala/math/BigInt.class
-      784  1980-01-01 00:00   scala/math/Equiv$$anon$1.class
-      838  1980-01-01 00:00   scala/math/Equiv$$anon$2.class
-     1014  1980-01-01 00:00   scala/math/Equiv$$anon$3.class
-     1061  1980-01-01 00:00   scala/math/Equiv$$anon$4.class
-     4225  1980-01-01 00:00   scala/math/Equiv$.class
-     3902  1980-01-01 00:00   scala/math/Equiv.class
-      540  1980-01-01 00:00   scala/math/Fractional$.class
-     1270  1980-01-01 00:00   scala/math/Fractional$ExtraImplicits.class
-     1239  1980-01-01 00:00   scala/math/Fractional$FractionalOps.class
-     1256  1980-01-01 00:00   scala/math/Fractional$Implicits$.class
-     2200  1980-01-01 00:00   scala/math/Fractional.class
-      534  1980-01-01 00:00   scala/math/Integral$.class
-     1226  1980-01-01 00:00   scala/math/Integral$ExtraImplicits.class
-     1212  1980-01-01 00:00   scala/math/Integral$Implicits$.class
-     1624  1980-01-01 00:00   scala/math/Integral$IntegralOps.class
-     2325  1980-01-01 00:00   scala/math/Integral.class
-     1115  1980-01-01 00:00   scala/math/LowPriorityEquiv.class
-     3846  1980-01-01 00:00   scala/math/LowPriorityOrderingImplicits$$anon$6.class
-     3801  1980-01-01 00:00   scala/math/LowPriorityOrderingImplicits$$anon$7.class
-     2264  1980-01-01 00:00   scala/math/LowPriorityOrderingImplicits.class
-      531  1980-01-01 00:00   scala/math/Numeric$.class
-     8246  1980-01-01 00:00   scala/math/Numeric$BigDecimalAsIfIntegral$.class
-     1583  1980-01-01 00:00   scala/math/Numeric$BigDecimalAsIfIntegral.class
-     3742  1980-01-01 00:00   scala/math/Numeric$BigDecimalIsConflicted.class
-     8023  1980-01-01 00:00   scala/math/Numeric$BigDecimalIsFractional$.class
-     1349  1980-01-01 00:00   scala/math/Numeric$BigDecimalIsFractional.class
-     8118  1980-01-01 00:00   scala/math/Numeric$BigIntIsIntegral$.class
-     4080  1980-01-01 00:00   scala/math/Numeric$BigIntIsIntegral.class
-     7598  1980-01-01 00:00   scala/math/Numeric$ByteIsIntegral$.class
-     3274  1980-01-01 00:00   scala/math/Numeric$ByteIsIntegral.class
-     7608  1980-01-01 00:00   scala/math/Numeric$CharIsIntegral$.class
-     3274  1980-01-01 00:00   scala/math/Numeric$CharIsIntegral.class
-     8864  1980-01-01 00:00   scala/math/Numeric$DoubleAsIfIntegral$.class
-     1604  1980-01-01 00:00   scala/math/Numeric$DoubleAsIfIntegral.class
-     3067  1980-01-01 00:00   scala/math/Numeric$DoubleIsConflicted.class
-     8369  1980-01-01 00:00   scala/math/Numeric$DoubleIsFractional$.class
-     1059  1980-01-01 00:00   scala/math/Numeric$DoubleIsFractional.class
-     1169  1980-01-01 00:00   scala/math/Numeric$ExtraImplicits.class
-     8848  1980-01-01 00:00   scala/math/Numeric$FloatAsIfIntegral$.class
-     1595  1980-01-01 00:00   scala/math/Numeric$FloatAsIfIntegral.class
-     3057  1980-01-01 00:00   scala/math/Numeric$FloatIsConflicted.class
-     8354  1980-01-01 00:00   scala/math/Numeric$FloatIsFractional$.class
-     1051  1980-01-01 00:00   scala/math/Numeric$FloatIsFractional.class
-     1155  1980-01-01 00:00   scala/math/Numeric$Implicits$.class
-     7537  1980-01-01 00:00   scala/math/Numeric$IntIsIntegral$.class
-     3149  1980-01-01 00:00   scala/math/Numeric$IntIsIntegral.class
-     7561  1980-01-01 00:00   scala/math/Numeric$LongIsIntegral$.class
-     3213  1980-01-01 00:00   scala/math/Numeric$LongIsIntegral.class
-     2179  1980-01-01 00:00   scala/math/Numeric$Ops.class
-     7610  1980-01-01 00:00   scala/math/Numeric$ShortIsIntegral$.class
-     3285  1980-01-01 00:00   scala/math/Numeric$ShortIsIntegral.class
-    12181  1980-01-01 00:00   scala/math/Numeric.class
-     1710  1980-01-01 00:00   scala/math/Ordered$$anon$1.class
-      886  1980-01-01 00:00   scala/math/Ordered$.class
-     3095  1980-01-01 00:00   scala/math/Ordered.class
-     4248  1980-01-01 00:00   scala/math/Ordering$$anon$10.class
-     3977  1980-01-01 00:00   scala/math/Ordering$$anon$11.class
-     4161  1980-01-01 00:00   scala/math/Ordering$$anon$12.class
-     4346  1980-01-01 00:00   scala/math/Ordering$$anon$13.class
-     4531  1980-01-01 00:00   scala/math/Ordering$$anon$14.class
-     4716  1980-01-01 00:00   scala/math/Ordering$$anon$15.class
-     4901  1980-01-01 00:00   scala/math/Ordering$$anon$16.class
-     5086  1980-01-01 00:00   scala/math/Ordering$$anon$17.class
-     5271  1980-01-01 00:00   scala/math/Ordering$$anon$18.class
-     4021  1980-01-01 00:00   scala/math/Ordering$$anon$3.class
-     3473  1980-01-01 00:00   scala/math/Ordering$$anon$4.class
-     3633  1980-01-01 00:00   scala/math/Ordering$$anon$5.class
-     3730  1980-01-01 00:00   scala/math/Ordering$$anon$9.class
-    11344  1980-01-01 00:00   scala/math/Ordering$.class
-     3832  1980-01-01 00:00   scala/math/Ordering$BigDecimal$.class
-     1071  1980-01-01 00:00   scala/math/Ordering$BigDecimalOrdering.class
-     3772  1980-01-01 00:00   scala/math/Ordering$BigInt$.class
-     1019  1980-01-01 00:00   scala/math/Ordering$BigIntOrdering.class
-     3747  1980-01-01 00:00   scala/math/Ordering$Boolean$.class
-      903  1980-01-01 00:00   scala/math/Ordering$BooleanOrdering.class
-     3723  1980-01-01 00:00   scala/math/Ordering$Byte$.class
-      885  1980-01-01 00:00   scala/math/Ordering$ByteOrdering.class
-     3723  1980-01-01 00:00   scala/math/Ordering$Char$.class
-      890  1980-01-01 00:00   scala/math/Ordering$CharOrdering.class
-     4682  1980-01-01 00:00   scala/math/Ordering$Double$.class
-     4504  1980-01-01 00:00   scala/math/Ordering$DoubleOrdering$$anon$2.class
-     3190  1980-01-01 00:00   scala/math/Ordering$DoubleOrdering.class
-     4290  1980-01-01 00:00   scala/math/Ordering$ExtraImplicits$$anon$8.class
-     1803  1980-01-01 00:00   scala/math/Ordering$ExtraImplicits.class
-     4669  1980-01-01 00:00   scala/math/Ordering$Float$.class
-     4493  1980-01-01 00:00   scala/math/Ordering$FloatOrdering$$anon$1.class
-     3180  1980-01-01 00:00   scala/math/Ordering$FloatOrdering.class
-     1518  1980-01-01 00:00   scala/math/Ordering$Implicits$.class
-     3715  1980-01-01 00:00   scala/math/Ordering$Int$.class
-      883  1980-01-01 00:00   scala/math/Ordering$IntOrdering.class
-     3723  1980-01-01 00:00   scala/math/Ordering$Long$.class
-      885  1980-01-01 00:00   scala/math/Ordering$LongOrdering.class
-     1923  1980-01-01 00:00   scala/math/Ordering$Ops.class
-     1776  1980-01-01 00:00   scala/math/Ordering$OptionOrdering.class
-     3731  1980-01-01 00:00   scala/math/Ordering$Short$.class
-      891  1980-01-01 00:00   scala/math/Ordering$ShortOrdering.class
-     3764  1980-01-01 00:00   scala/math/Ordering$String$.class
-     1023  1980-01-01 00:00   scala/math/Ordering$StringOrdering.class
-     3806  1980-01-01 00:00   scala/math/Ordering$Unit$.class
-      983  1980-01-01 00:00   scala/math/Ordering$UnitOrdering.class
-    23115  1980-01-01 00:00   scala/math/Ordering.class
-     1984  1980-01-01 00:00   scala/math/PartialOrdering$$anon$1.class
-     2945  1980-01-01 00:00   scala/math/PartialOrdering.class
-     3338  1980-01-01 00:00   scala/math/PartiallyOrdered.class
-      348  1980-01-01 00:00   scala/math/ScalaNumber.class
-     5853  1980-01-01 00:00   scala/math/ScalaNumericAnyConversions.class
-      581  1980-01-01 00:00   scala/math/ScalaNumericConversions.class
-     5697  1980-01-01 00:00   scala/math/package$.class
-     4755  1980-01-01 00:00   scala/math/package.class
-      592  1980-01-01 00:00   scala/native.class
-      600  1980-01-01 00:00   scala/noinline.class
-      545  1980-01-01 00:00   scala/package$$anon$1.class
-     6235  1980-01-01 00:00   scala/package$.class
-     7056  1980-01-01 00:00   scala/package.class
-        0  1980-01-01 00:00   scala/ref/
-     4523  1980-01-01 00:00   scala/ref/PhantomReference.class
-     1854  1980-01-01 00:00   scala/ref/PhantomReferenceWithWrapper.class
-     2426  1980-01-01 00:00   scala/ref/Reference.class
-     2594  1980-01-01 00:00   scala/ref/ReferenceQueue.class
-      625  1980-01-01 00:00   scala/ref/ReferenceWithWrapper.class
-     2906  1980-01-01 00:00   scala/ref/ReferenceWrapper.class
-     1247  1980-01-01 00:00   scala/ref/SoftReference$.class
-     5097  1980-01-01 00:00   scala/ref/SoftReference.class
-     1976  1980-01-01 00:00   scala/ref/SoftReferenceWithWrapper.class
-     1247  1980-01-01 00:00   scala/ref/WeakReference$.class
-     5097  1980-01-01 00:00   scala/ref/WeakReference.class
-     1976  1980-01-01 00:00   scala/ref/WeakReferenceWithWrapper.class
-        0  1980-01-01 00:00   scala/reflect/
-     6629  1980-01-01 00:00   scala/reflect/AnyValManifest.class
-    14887  1980-01-01 00:00   scala/reflect/ClassManifestDeprecatedApis.class
-     8068  1980-01-01 00:00   scala/reflect/ClassManifestFactory$.class
-     6367  1980-01-01 00:00   scala/reflect/ClassManifestFactory$AbstractTypeClassManifest.class
-     7256  1980-01-01 00:00   scala/reflect/ClassManifestFactory.class
-     5728  1980-01-01 00:00   scala/reflect/ClassTag$.class
-     5670  1980-01-01 00:00   scala/reflect/ClassTag$GenericClassTag.class
-     8980  1980-01-01 00:00   scala/reflect/ClassTag.class
-     7315  1980-01-01 00:00   scala/reflect/ClassTypeManifest.class
-     3634  1980-01-01 00:00   scala/reflect/Manifest.class
-     9485  1980-01-01 00:00   scala/reflect/ManifestFactory$.class
-     6505  1980-01-01 00:00   scala/reflect/ManifestFactory$AbstractTypeManifest.class
-     1683  1980-01-01 00:00   scala/reflect/ManifestFactory$AnyManifest.class
-     1743  1980-01-01 00:00   scala/reflect/ManifestFactory$AnyValPhantomManifest.class
-     2114  1980-01-01 00:00   scala/reflect/ManifestFactory$BooleanManifest.class
-     2087  1980-01-01 00:00   scala/reflect/ManifestFactory$ByteManifest.class
-     2097  1980-01-01 00:00   scala/reflect/ManifestFactory$CharManifest.class
-     6716  1980-01-01 00:00   scala/reflect/ManifestFactory$ClassTypeManifest.class
-     2105  1980-01-01 00:00   scala/reflect/ManifestFactory$DoubleManifest.class
-     2096  1980-01-01 00:00   scala/reflect/ManifestFactory$FloatManifest.class
-     2086  1980-01-01 00:00   scala/reflect/ManifestFactory$IntManifest.class
-     6122  1980-01-01 00:00   scala/reflect/ManifestFactory$IntersectionTypeManifest.class
-     2087  1980-01-01 00:00   scala/reflect/ManifestFactory$LongManifest.class
-     1705  1980-01-01 00:00   scala/reflect/ManifestFactory$NothingManifest.class
-     1789  1980-01-01 00:00   scala/reflect/ManifestFactory$NullManifest.class
-     1722  1980-01-01 00:00   scala/reflect/ManifestFactory$ObjectManifest.class
-     1584  1980-01-01 00:00   scala/reflect/ManifestFactory$PhantomManifest.class
-     2096  1980-01-01 00:00   scala/reflect/ManifestFactory$ShortManifest.class
-     6441  1980-01-01 00:00   scala/reflect/ManifestFactory$SingletonTypeManifest.class
-     2659  1980-01-01 00:00   scala/reflect/ManifestFactory$UnitManifest.class
-     6519  1980-01-01 00:00   scala/reflect/ManifestFactory$WildcardManifest.class
-    13935  1980-01-01 00:00   scala/reflect/ManifestFactory.class
-     5416  1980-01-01 00:00   scala/reflect/NameTransformer$.class
-      962  1980-01-01 00:00   scala/reflect/NameTransformer$OpCodes.class
-     2631  1980-01-01 00:00   scala/reflect/NameTransformer.class
-      750  1980-01-01 00:00   scala/reflect/NoManifest$.class
-      706  1980-01-01 00:00   scala/reflect/NoManifest.class
-      530  1980-01-01 00:00   scala/reflect/OptManifest.class
-      441  1980-01-01 00:00   scala/reflect/ScalaLongSignature.class
-      432  1980-01-01 00:00   scala/reflect/ScalaSignature.class
-        0  1980-01-01 00:00   scala/reflect/macros/
-        0  1980-01-01 00:00   scala/reflect/macros/internal/
-     1023  1980-01-01 00:00   scala/reflect/macros/internal/macroImpl.class
-     1738  1980-01-01 00:00   scala/reflect/package$.class
-     1750  1980-01-01 00:00   scala/reflect/package.class
-      762  1980-01-01 00:00   scala/remote.class
-        0  1980-01-01 00:00   scala/runtime/
-      546  1980-01-01 00:00   scala/runtime/AbstractFunction0$mcB$sp.class
-      546  1980-01-01 00:00   scala/runtime/AbstractFunction0$mcC$sp.class
-      546  1980-01-01 00:00   scala/runtime/AbstractFunction0$mcD$sp.class
-      546  1980-01-01 00:00   scala/runtime/AbstractFunction0$mcF$sp.class
-      546  1980-01-01 00:00   scala/runtime/AbstractFunction0$mcI$sp.class
-      546  1980-01-01 00:00   scala/runtime/AbstractFunction0$mcJ$sp.class
-      546  1980-01-01 00:00   scala/runtime/AbstractFunction0$mcS$sp.class
-      553  1980-01-01 00:00   scala/runtime/AbstractFunction0$mcV$sp.class
-      546  1980-01-01 00:00   scala/runtime/AbstractFunction0$mcZ$sp.class
-     2428  1980-01-01 00:00   scala/runtime/AbstractFunction0.class
-      586  1980-01-01 00:00   scala/runtime/AbstractFunction1$mcDD$sp.class
-      586  1980-01-01 00:00   scala/runtime/AbstractFunction1$mcDF$sp.class
-      586  1980-01-01 00:00   scala/runtime/AbstractFunction1$mcDI$sp.class
-      586  1980-01-01 00:00   scala/runtime/AbstractFunction1$mcDJ$sp.class
-      586  1980-01-01 00:00   scala/runtime/AbstractFunction1$mcFD$sp.class
-      586  1980-01-01 00:00   scala/runtime/AbstractFunction1$mcFF$sp.class
-      586  1980-01-01 00:00   scala/runtime/AbstractFunction1$mcFI$sp.class
-      586  1980-01-01 00:00   scala/runtime/AbstractFunction1$mcFJ$sp.class
-      586  1980-01-01 00:00   scala/runtime/AbstractFunction1$mcID$sp.class
-      586  1980-01-01 00:00   scala/runtime/AbstractFunction1$mcIF$sp.class
-      586  1980-01-01 00:00   scala/runtime/AbstractFunction1$mcII$sp.class
-      586  1980-01-01 00:00   scala/runtime/AbstractFunction1$mcIJ$sp.class
-      586  1980-01-01 00:00   scala/runtime/AbstractFunction1$mcJD$sp.class
-      586  1980-01-01 00:00   scala/runtime/AbstractFunction1$mcJF$sp.class
-      586  1980-01-01 00:00   scala/runtime/AbstractFunction1$mcJI$sp.class
-      586  1980-01-01 00:00   scala/runtime/AbstractFunction1$mcJJ$sp.class
-      593  1980-01-01 00:00   scala/runtime/AbstractFunction1$mcVD$sp.class
-      593  1980-01-01 00:00   scala/runtime/AbstractFunction1$mcVF$sp.class
-      593  1980-01-01 00:00   scala/runtime/AbstractFunction1$mcVI$sp.class
-      593  1980-01-01 00:00   scala/runtime/AbstractFunction1$mcVJ$sp.class
-      586  1980-01-01 00:00   scala/runtime/AbstractFunction1$mcZD$sp.class
-      586  1980-01-01 00:00   scala/runtime/AbstractFunction1$mcZF$sp.class
-      586  1980-01-01 00:00   scala/runtime/AbstractFunction1$mcZI$sp.class
-      586  1980-01-01 00:00   scala/runtime/AbstractFunction1$mcZJ$sp.class
-     6676  1980-01-01 00:00   scala/runtime/AbstractFunction1.class
-     3244  1980-01-01 00:00   scala/runtime/AbstractFunction10.class
-     3340  1980-01-01 00:00   scala/runtime/AbstractFunction11.class
-     3437  1980-01-01 00:00   scala/runtime/AbstractFunction12.class
-     3534  1980-01-01 00:00   scala/runtime/AbstractFunction13.class
-     3631  1980-01-01 00:00   scala/runtime/AbstractFunction14.class
-     3728  1980-01-01 00:00   scala/runtime/AbstractFunction15.class
-     3825  1980-01-01 00:00   scala/runtime/AbstractFunction16.class
-     3922  1980-01-01 00:00   scala/runtime/AbstractFunction17.class
-     4018  1980-01-01 00:00   scala/runtime/AbstractFunction18.class
-     4115  1980-01-01 00:00   scala/runtime/AbstractFunction19.class
-      626  1980-01-01 00:00   scala/runtime/AbstractFunction2$mcDDD$sp.class
-      626  1980-01-01 00:00   scala/runtime/AbstractFunction2$mcDDI$sp.class
-      626  1980-01-01 00:00   scala/runtime/AbstractFunction2$mcDDJ$sp.class
-      626  1980-01-01 00:00   scala/runtime/AbstractFunction2$mcDID$sp.class
-      626  1980-01-01 00:00   scala/runtime/AbstractFunction2$mcDII$sp.class
-      626  1980-01-01 00:00   scala/runtime/AbstractFunction2$mcDIJ$sp.class
-      626  1980-01-01 00:00   scala/runtime/AbstractFunction2$mcDJD$sp.class
-      626  1980-01-01 00:00   scala/runtime/AbstractFunction2$mcDJI$sp.class
-      626  1980-01-01 00:00   scala/runtime/AbstractFunction2$mcDJJ$sp.class
-      626  1980-01-01 00:00   scala/runtime/AbstractFunction2$mcFDD$sp.class
-      626  1980-01-01 00:00   scala/runtime/AbstractFunction2$mcFDI$sp.class
-      626  1980-01-01 00:00   scala/runtime/AbstractFunction2$mcFDJ$sp.class
-      626  1980-01-01 00:00   scala/runtime/AbstractFunction2$mcFID$sp.class
-      626  1980-01-01 00:00   scala/runtime/AbstractFunction2$mcFII$sp.class
-      626  1980-01-01 00:00   scala/runtime/AbstractFunction2$mcFIJ$sp.class
-      626  1980-01-01 00:00   scala/runtime/AbstractFunction2$mcFJD$sp.class
-      626  1980-01-01 00:00   scala/runtime/AbstractFunction2$mcFJI$sp.class
-      626  1980-01-01 00:00   scala/runtime/AbstractFunction2$mcFJJ$sp.class
-      626  1980-01-01 00:00   scala/runtime/AbstractFunction2$mcIDD$sp.class
-      626  1980-01-01 00:00   scala/runtime/AbstractFunction2$mcIDI$sp.class
-      626  1980-01-01 00:00   scala/runtime/AbstractFunction2$mcIDJ$sp.class
-      626  1980-01-01 00:00   scala/runtime/AbstractFunction2$mcIID$sp.class
-      626  1980-01-01 00:00   scala/runtime/AbstractFunction2$mcIII$sp.class
-      626  1980-01-01 00:00   scala/runtime/AbstractFunction2$mcIIJ$sp.class
-      626  1980-01-01 00:00   scala/runtime/AbstractFunction2$mcIJD$sp.class
-      626  1980-01-01 00:00   scala/runtime/AbstractFunction2$mcIJI$sp.class
-      626  1980-01-01 00:00   scala/runtime/AbstractFunction2$mcIJJ$sp.class
-      626  1980-01-01 00:00   scala/runtime/AbstractFunction2$mcJDD$sp.class
-      626  1980-01-01 00:00   scala/runtime/AbstractFunction2$mcJDI$sp.class
-      626  1980-01-01 00:00   scala/runtime/AbstractFunction2$mcJDJ$sp.class
-      626  1980-01-01 00:00   scala/runtime/AbstractFunction2$mcJID$sp.class
-      626  1980-01-01 00:00   scala/runtime/AbstractFunction2$mcJII$sp.class
-      626  1980-01-01 00:00   scala/runtime/AbstractFunction2$mcJIJ$sp.class
-      626  1980-01-01 00:00   scala/runtime/AbstractFunction2$mcJJD$sp.class
-      626  1980-01-01 00:00   scala/runtime/AbstractFunction2$mcJJI$sp.class
-      626  1980-01-01 00:00   scala/runtime/AbstractFunction2$mcJJJ$sp.class
-      633  1980-01-01 00:00   scala/runtime/AbstractFunction2$mcVDD$sp.class
-      633  1980-01-01 00:00   scala/runtime/AbstractFunction2$mcVDI$sp.class
-      633  1980-01-01 00:00   scala/runtime/AbstractFunction2$mcVDJ$sp.class
-      633  1980-01-01 00:00   scala/runtime/AbstractFunction2$mcVID$sp.class
-      633  1980-01-01 00:00   scala/runtime/AbstractFunction2$mcVII$sp.class
-      633  1980-01-01 00:00   scala/runtime/AbstractFunction2$mcVIJ$sp.class
-      633  1980-01-01 00:00   scala/runtime/AbstractFunction2$mcVJD$sp.class
-      633  1980-01-01 00:00   scala/runtime/AbstractFunction2$mcVJI$sp.class
-      633  1980-01-01 00:00   scala/runtime/AbstractFunction2$mcVJJ$sp.class
-      626  1980-01-01 00:00   scala/runtime/AbstractFunction2$mcZDD$sp.class
-      626  1980-01-01 00:00   scala/runtime/AbstractFunction2$mcZDI$sp.class
-      626  1980-01-01 00:00   scala/runtime/AbstractFunction2$mcZDJ$sp.class
-      626  1980-01-01 00:00   scala/runtime/AbstractFunction2$mcZID$sp.class
-      626  1980-01-01 00:00   scala/runtime/AbstractFunction2$mcZII$sp.class
-      626  1980-01-01 00:00   scala/runtime/AbstractFunction2$mcZIJ$sp.class
-      626  1980-01-01 00:00   scala/runtime/AbstractFunction2$mcZJD$sp.class
-      626  1980-01-01 00:00   scala/runtime/AbstractFunction2$mcZJI$sp.class
-      626  1980-01-01 00:00   scala/runtime/AbstractFunction2$mcZJJ$sp.class
-    12673  1980-01-01 00:00   scala/runtime/AbstractFunction2.class
-     4212  1980-01-01 00:00   scala/runtime/AbstractFunction20.class
-     4309  1980-01-01 00:00   scala/runtime/AbstractFunction21.class
-     4406  1980-01-01 00:00   scala/runtime/AbstractFunction22.class
-     2582  1980-01-01 00:00   scala/runtime/AbstractFunction3.class
-     2674  1980-01-01 00:00   scala/runtime/AbstractFunction4.class
-     2766  1980-01-01 00:00   scala/runtime/AbstractFunction5.class
-     2857  1980-01-01 00:00   scala/runtime/AbstractFunction6.class
-     2949  1980-01-01 00:00   scala/runtime/AbstractFunction7.class
-     3041  1980-01-01 00:00   scala/runtime/AbstractFunction8.class
-     3132  1980-01-01 00:00   scala/runtime/AbstractFunction9.class
-     1360  1980-01-01 00:00   scala/runtime/AbstractPartialFunction$mcDD$sp.class
-     1455  1980-01-01 00:00   scala/runtime/AbstractPartialFunction$mcDF$sp.class
-     1457  1980-01-01 00:00   scala/runtime/AbstractPartialFunction$mcDI$sp.class
-     1452  1980-01-01 00:00   scala/runtime/AbstractPartialFunction$mcDJ$sp.class
-     1455  1980-01-01 00:00   scala/runtime/AbstractPartialFunction$mcFD$sp.class
-     1357  1980-01-01 00:00   scala/runtime/AbstractPartialFunction$mcFF$sp.class
-     1454  1980-01-01 00:00   scala/runtime/AbstractPartialFunction$mcFI$sp.class
-     1449  1980-01-01 00:00   scala/runtime/AbstractPartialFunction$mcFJ$sp.class
-     1457  1980-01-01 00:00   scala/runtime/AbstractPartialFunction$mcID$sp.class
-     1454  1980-01-01 00:00   scala/runtime/AbstractPartialFunction$mcIF$sp.class
-     1359  1980-01-01 00:00   scala/runtime/AbstractPartialFunction$mcII$sp.class
-     1451  1980-01-01 00:00   scala/runtime/AbstractPartialFunction$mcIJ$sp.class
-     1452  1980-01-01 00:00   scala/runtime/AbstractPartialFunction$mcJD$sp.class
-     1449  1980-01-01 00:00   scala/runtime/AbstractPartialFunction$mcJF$sp.class
-     1451  1980-01-01 00:00   scala/runtime/AbstractPartialFunction$mcJI$sp.class
-     1354  1980-01-01 00:00   scala/runtime/AbstractPartialFunction$mcJJ$sp.class
-     1439  1980-01-01 00:00   scala/runtime/AbstractPartialFunction$mcVD$sp.class
-     1436  1980-01-01 00:00   scala/runtime/AbstractPartialFunction$mcVF$sp.class
-     1438  1980-01-01 00:00   scala/runtime/AbstractPartialFunction$mcVI$sp.class
-     1433  1980-01-01 00:00   scala/runtime/AbstractPartialFunction$mcVJ$sp.class
-     1437  1980-01-01 00:00   scala/runtime/AbstractPartialFunction$mcZD$sp.class
-     1434  1980-01-01 00:00   scala/runtime/AbstractPartialFunction$mcZF$sp.class
-     1436  1980-01-01 00:00   scala/runtime/AbstractPartialFunction$mcZI$sp.class
-     1431  1980-01-01 00:00   scala/runtime/AbstractPartialFunction$mcZJ$sp.class
-     8069  1980-01-01 00:00   scala/runtime/AbstractPartialFunction.class
-     2403  1980-01-01 00:00   scala/runtime/ArrayCharSequence.class
-      795  1980-01-01 00:00   scala/runtime/BooleanRef.class
-     1039  1980-01-01 00:00   scala/runtime/BoxedUnit.class
-    14953  1980-01-01 00:00   scala/runtime/BoxesRunTime.class
-      768  1980-01-01 00:00   scala/runtime/ByteRef.class
-      773  1980-01-01 00:00   scala/runtime/CharRef.class
-      780  1980-01-01 00:00   scala/runtime/DoubleRef.class
-     1543  1980-01-01 00:00   scala/runtime/EmptyMethodCache.class
-      774  1980-01-01 00:00   scala/runtime/FloatRef.class
-     5510  1980-01-01 00:00   scala/runtime/FractionalProxy.class
-      766  1980-01-01 00:00   scala/runtime/IntRef.class
-     4135  1980-01-01 00:00   scala/runtime/IntegralProxy.class
-     3546  1980-01-01 00:00   scala/runtime/LambdaDeserialize.class
-     7531  1980-01-01 00:00   scala/runtime/LambdaDeserializer$.class
-     1560  1980-01-01 00:00   scala/runtime/LambdaDeserializer.class
-     1972  1980-01-01 00:00   scala/runtime/LazyBoolean.class
-     1983  1980-01-01 00:00   scala/runtime/LazyByte.class
-     1993  1980-01-01 00:00   scala/runtime/LazyChar.class
-     1998  1980-01-01 00:00   scala/runtime/LazyDouble.class
-     1990  1980-01-01 00:00   scala/runtime/LazyFloat.class
-     1984  1980-01-01 00:00   scala/runtime/LazyInt.class
-     1983  1980-01-01 00:00   scala/runtime/LazyLong.class
-     2135  1980-01-01 00:00   scala/runtime/LazyRef.class
-     1990  1980-01-01 00:00   scala/runtime/LazyShort.class
-     1624  1980-01-01 00:00   scala/runtime/LazyUnit.class
-      764  1980-01-01 00:00   scala/runtime/LongRef.class
-     2041  1980-01-01 00:00   scala/runtime/MegaMethodCache.class
-     1286  1980-01-01 00:00   scala/runtime/MethodCache.class
-     1070  1980-01-01 00:00   scala/runtime/NonLocalReturnControl$mcB$sp.class
-     1080  1980-01-01 00:00   scala/runtime/NonLocalReturnControl$mcC$sp.class
-     1074  1980-01-01 00:00   scala/runtime/NonLocalReturnControl$mcD$sp.class
-     1072  1980-01-01 00:00   scala/runtime/NonLocalReturnControl$mcF$sp.class
-     1076  1980-01-01 00:00   scala/runtime/NonLocalReturnControl$mcI$sp.class
-     1070  1980-01-01 00:00   scala/runtime/NonLocalReturnControl$mcJ$sp.class
-     1072  1980-01-01 00:00   scala/runtime/NonLocalReturnControl$mcS$sp.class
-     1079  1980-01-01 00:00   scala/runtime/NonLocalReturnControl$mcV$sp.class
-     1070  1980-01-01 00:00   scala/runtime/NonLocalReturnControl$mcZ$sp.class
-     3114  1980-01-01 00:00   scala/runtime/NonLocalReturnControl.class
-      328  1980-01-01 00:00   scala/runtime/Nothing$.class
-      316  1980-01-01 00:00   scala/runtime/Null$.class
-     1228  1980-01-01 00:00   scala/runtime/ObjectRef.class
-     1600  1980-01-01 00:00   scala/runtime/OrderedProxy.class
-     2809  1980-01-01 00:00   scala/runtime/PolyMethodCache.class
-     1206  1980-01-01 00:00   scala/runtime/RangedProxy.class
-     1261  1980-01-01 00:00   scala/runtime/RichBoolean$.class
-     3507  1980-01-01 00:00   scala/runtime/RichBoolean.class
-     2910  1980-01-01 00:00   scala/runtime/RichByte$.class
-     9336  1980-01-01 00:00   scala/runtime/RichByte.class
-     6267  1980-01-01 00:00   scala/runtime/RichChar$.class
-    17173  1980-01-01 00:00   scala/runtime/RichChar.class
-     5023  1980-01-01 00:00   scala/runtime/RichDouble$.class
-    14271  1980-01-01 00:00   scala/runtime/RichDouble.class
-     1667  1980-01-01 00:00   scala/runtime/RichException.class
-     5038  1980-01-01 00:00   scala/runtime/RichFloat$.class
-    14241  1980-01-01 00:00   scala/runtime/RichFloat.class
-     4636  1980-01-01 00:00   scala/runtime/RichInt$.class
-    13026  1980-01-01 00:00   scala/runtime/RichInt.class
-     3980  1980-01-01 00:00   scala/runtime/RichLong$.class
-    13261  1980-01-01 00:00   scala/runtime/RichLong.class
-     2926  1980-01-01 00:00   scala/runtime/RichShort$.class
-     9360  1980-01-01 00:00   scala/runtime/RichShort.class
-     4505  1980-01-01 00:00   scala/runtime/ScalaNumberProxy.class
-     1460  1980-01-01 00:00   scala/runtime/ScalaRunTime$$anon$1.class
-    17209  1980-01-01 00:00   scala/runtime/ScalaRunTime$.class
-     4566  1980-01-01 00:00   scala/runtime/ScalaRunTime.class
-     1125  1980-01-01 00:00   scala/runtime/ScalaWholeNumberProxy.class
-     2485  1980-01-01 00:00   scala/runtime/SeqCharSequence.class
-      774  1980-01-01 00:00   scala/runtime/ShortRef.class
-     1872  1980-01-01 00:00   scala/runtime/Statics.class
-     1473  1980-01-01 00:00   scala/runtime/StringAdd$.class
-     2165  1980-01-01 00:00   scala/runtime/StringAdd.class
-     1604  1980-01-01 00:00   scala/runtime/StringFormat$.class
-     2695  1980-01-01 00:00   scala/runtime/StringFormat.class
-     2720  1980-01-01 00:00   scala/runtime/StructuralCallSite.class
-     2045  1980-01-01 00:00   scala/runtime/SymbolLiteral.class
-      240  1980-01-01 00:00   scala/runtime/TraitSetter.class
-    12719  1980-01-01 00:00   scala/runtime/Tuple2Zipped$.class
-     3748  1980-01-01 00:00   scala/runtime/Tuple2Zipped$Ops$.class
-     3122  1980-01-01 00:00   scala/runtime/Tuple2Zipped$Ops.class
-    20015  1980-01-01 00:00   scala/runtime/Tuple2Zipped.class
-    15451  1980-01-01 00:00   scala/runtime/Tuple3Zipped$.class
-     4343  1980-01-01 00:00   scala/runtime/Tuple3Zipped$Ops$.class
-     3603  1980-01-01 00:00   scala/runtime/Tuple3Zipped$Ops.class
-    22646  1980-01-01 00:00   scala/runtime/Tuple3Zipped.class
-      835  1980-01-01 00:00   scala/runtime/VolatileBooleanRef.class
-      808  1980-01-01 00:00   scala/runtime/VolatileByteRef.class
-      813  1980-01-01 00:00   scala/runtime/VolatileCharRef.class
-      820  1980-01-01 00:00   scala/runtime/VolatileDoubleRef.class
-      814  1980-01-01 00:00   scala/runtime/VolatileFloatRef.class
-      806  1980-01-01 00:00   scala/runtime/VolatileIntRef.class
-      804  1980-01-01 00:00   scala/runtime/VolatileLongRef.class
-     1292  1980-01-01 00:00   scala/runtime/VolatileObjectRef.class
-      814  1980-01-01 00:00   scala/runtime/VolatileShortRef.class
-     2212  1980-01-01 00:00   scala/runtime/ZippedTraversable2$$anon$1.class
-      993  1980-01-01 00:00   scala/runtime/ZippedTraversable2$.class
-     1428  1980-01-01 00:00   scala/runtime/ZippedTraversable2.class
-     2258  1980-01-01 00:00   scala/runtime/ZippedTraversable3$$anon$1.class
-     1025  1980-01-01 00:00   scala/runtime/ZippedTraversable3$.class
-     1525  1980-01-01 00:00   scala/runtime/ZippedTraversable3.class
-        0  1980-01-01 00:00   scala/runtime/java8/
-      567  1980-01-01 00:00   scala/runtime/java8/JFunction0$mcB$sp.class
-      577  1980-01-01 00:00   scala/runtime/java8/JFunction0$mcC$sp.class
-      571  1980-01-01 00:00   scala/runtime/java8/JFunction0$mcD$sp.class
-      569  1980-01-01 00:00   scala/runtime/java8/JFunction0$mcF$sp.class
-      573  1980-01-01 00:00   scala/runtime/java8/JFunction0$mcI$sp.class
-      567  1980-01-01 00:00   scala/runtime/java8/JFunction0$mcJ$sp.class
-      569  1980-01-01 00:00   scala/runtime/java8/JFunction0$mcS$sp.class
-      565  1980-01-01 00:00   scala/runtime/java8/JFunction0$mcV$sp.class
-      573  1980-01-01 00:00   scala/runtime/java8/JFunction0$mcZ$sp.class
-      683  1980-01-01 00:00   scala/runtime/java8/JFunction1$mcDD$sp.class
-      682  1980-01-01 00:00   scala/runtime/java8/JFunction1$mcDF$sp.class
-      680  1980-01-01 00:00   scala/runtime/java8/JFunction1$mcDI$sp.class
-      681  1980-01-01 00:00   scala/runtime/java8/JFunction1$mcDJ$sp.class
-      681  1980-01-01 00:00   scala/runtime/java8/JFunction1$mcFD$sp.class
-      680  1980-01-01 00:00   scala/runtime/java8/JFunction1$mcFF$sp.class
-      678  1980-01-01 00:00   scala/runtime/java8/JFunction1$mcFI$sp.class
-      679  1980-01-01 00:00   scala/runtime/java8/JFunction1$mcFJ$sp.class
-      685  1980-01-01 00:00   scala/runtime/java8/JFunction1$mcID$sp.class
-      684  1980-01-01 00:00   scala/runtime/java8/JFunction1$mcIF$sp.class
-      682  1980-01-01 00:00   scala/runtime/java8/JFunction1$mcII$sp.class
-      683  1980-01-01 00:00   scala/runtime/java8/JFunction1$mcIJ$sp.class
-      679  1980-01-01 00:00   scala/runtime/java8/JFunction1$mcJD$sp.class
-      678  1980-01-01 00:00   scala/runtime/java8/JFunction1$mcJF$sp.class
-      676  1980-01-01 00:00   scala/runtime/java8/JFunction1$mcJI$sp.class
-      677  1980-01-01 00:00   scala/runtime/java8/JFunction1$mcJJ$sp.class
-      709  1980-01-01 00:00   scala/runtime/java8/JFunction1$mcVD$sp.class
-      708  1980-01-01 00:00   scala/runtime/java8/JFunction1$mcVF$sp.class
-      706  1980-01-01 00:00   scala/runtime/java8/JFunction1$mcVI$sp.class
-      707  1980-01-01 00:00   scala/runtime/java8/JFunction1$mcVJ$sp.class
-      685  1980-01-01 00:00   scala/runtime/java8/JFunction1$mcZD$sp.class
-      684  1980-01-01 00:00   scala/runtime/java8/JFunction1$mcZF$sp.class
-      682  1980-01-01 00:00   scala/runtime/java8/JFunction1$mcZI$sp.class
-      683  1980-01-01 00:00   scala/runtime/java8/JFunction1$mcZJ$sp.class
-      726  1980-01-01 00:00   scala/runtime/java8/JFunction2$mcDDD$sp.class
-      773  1980-01-01 00:00   scala/runtime/java8/JFunction2$mcDDI$sp.class
-      774  1980-01-01 00:00   scala/runtime/java8/JFunction2$mcDDJ$sp.class
-      773  1980-01-01 00:00   scala/runtime/java8/JFunction2$mcDID$sp.class
-      723  1980-01-01 00:00   scala/runtime/java8/JFunction2$mcDII$sp.class
-      771  1980-01-01 00:00   scala/runtime/java8/JFunction2$mcDIJ$sp.class
-      774  1980-01-01 00:00   scala/runtime/java8/JFunction2$mcDJD$sp.class
-      771  1980-01-01 00:00   scala/runtime/java8/JFunction2$mcDJI$sp.class
-      724  1980-01-01 00:00   scala/runtime/java8/JFunction2$mcDJJ$sp.class
-      724  1980-01-01 00:00   scala/runtime/java8/JFunction2$mcFDD$sp.class
-      771  1980-01-01 00:00   scala/runtime/java8/JFunction2$mcFDI$sp.class
-      772  1980-01-01 00:00   scala/runtime/java8/JFunction2$mcFDJ$sp.class
-      771  1980-01-01 00:00   scala/runtime/java8/JFunction2$mcFID$sp.class
-      721  1980-01-01 00:00   scala/runtime/java8/JFunction2$mcFII$sp.class
-      769  1980-01-01 00:00   scala/runtime/java8/JFunction2$mcFIJ$sp.class
-      772  1980-01-01 00:00   scala/runtime/java8/JFunction2$mcFJD$sp.class
-      769  1980-01-01 00:00   scala/runtime/java8/JFunction2$mcFJI$sp.class
-      722  1980-01-01 00:00   scala/runtime/java8/JFunction2$mcFJJ$sp.class
-      728  1980-01-01 00:00   scala/runtime/java8/JFunction2$mcIDD$sp.class
-      775  1980-01-01 00:00   scala/runtime/java8/JFunction2$mcIDI$sp.class
-      776  1980-01-01 00:00   scala/runtime/java8/JFunction2$mcIDJ$sp.class
-      775  1980-01-01 00:00   scala/runtime/java8/JFunction2$mcIID$sp.class
-      725  1980-01-01 00:00   scala/runtime/java8/JFunction2$mcIII$sp.class
-      773  1980-01-01 00:00   scala/runtime/java8/JFunction2$mcIIJ$sp.class
-      776  1980-01-01 00:00   scala/runtime/java8/JFunction2$mcIJD$sp.class
-      773  1980-01-01 00:00   scala/runtime/java8/JFunction2$mcIJI$sp.class
-      726  1980-01-01 00:00   scala/runtime/java8/JFunction2$mcIJJ$sp.class
-      722  1980-01-01 00:00   scala/runtime/java8/JFunction2$mcJDD$sp.class
-      769  1980-01-01 00:00   scala/runtime/java8/JFunction2$mcJDI$sp.class
-      770  1980-01-01 00:00   scala/runtime/java8/JFunction2$mcJDJ$sp.class
-      769  1980-01-01 00:00   scala/runtime/java8/JFunction2$mcJID$sp.class
-      719  1980-01-01 00:00   scala/runtime/java8/JFunction2$mcJII$sp.class
-      767  1980-01-01 00:00   scala/runtime/java8/JFunction2$mcJIJ$sp.class
-      770  1980-01-01 00:00   scala/runtime/java8/JFunction2$mcJJD$sp.class
-      767  1980-01-01 00:00   scala/runtime/java8/JFunction2$mcJJI$sp.class
-      720  1980-01-01 00:00   scala/runtime/java8/JFunction2$mcJJJ$sp.class
-      752  1980-01-01 00:00   scala/runtime/java8/JFunction2$mcVDD$sp.class
-      799  1980-01-01 00:00   scala/runtime/java8/JFunction2$mcVDI$sp.class
-      800  1980-01-01 00:00   scala/runtime/java8/JFunction2$mcVDJ$sp.class
-      799  1980-01-01 00:00   scala/runtime/java8/JFunction2$mcVID$sp.class
-      749  1980-01-01 00:00   scala/runtime/java8/JFunction2$mcVII$sp.class
-      797  1980-01-01 00:00   scala/runtime/java8/JFunction2$mcVIJ$sp.class
-      800  1980-01-01 00:00   scala/runtime/java8/JFunction2$mcVJD$sp.class
-      797  1980-01-01 00:00   scala/runtime/java8/JFunction2$mcVJI$sp.class
-      750  1980-01-01 00:00   scala/runtime/java8/JFunction2$mcVJJ$sp.class
-      728  1980-01-01 00:00   scala/runtime/java8/JFunction2$mcZDD$sp.class
-      775  1980-01-01 00:00   scala/runtime/java8/JFunction2$mcZDI$sp.class
-      776  1980-01-01 00:00   scala/runtime/java8/JFunction2$mcZDJ$sp.class
-      775  1980-01-01 00:00   scala/runtime/java8/JFunction2$mcZID$sp.class
-      725  1980-01-01 00:00   scala/runtime/java8/JFunction2$mcZII$sp.class
-      773  1980-01-01 00:00   scala/runtime/java8/JFunction2$mcZIJ$sp.class
-      776  1980-01-01 00:00   scala/runtime/java8/JFunction2$mcZJD$sp.class
-      773  1980-01-01 00:00   scala/runtime/java8/JFunction2$mcZJI$sp.class
-      726  1980-01-01 00:00   scala/runtime/java8/JFunction2$mcZJJ$sp.class
-      405  1980-01-01 00:00   scala/runtime/package$.class
-      343  1980-01-01 00:00   scala/runtime/package.class
-     1646  1980-01-01 00:00   scala/specialized.class
-        0  1980-01-01 00:00   scala/sys/
-     3214  1980-01-01 00:00   scala/sys/BooleanProp$.class
-     1743  1980-01-01 00:00   scala/sys/BooleanProp$BooleanPropImpl.class
-     2602  1980-01-01 00:00   scala/sys/BooleanProp$ConstantImpl.class
-     2479  1980-01-01 00:00   scala/sys/BooleanProp.class
-     1487  1980-01-01 00:00   scala/sys/CreatorImpl.class
-      986  1980-01-01 00:00   scala/sys/Prop$.class
-      426  1980-01-01 00:00   scala/sys/Prop$Creator.class
-     1393  1980-01-01 00:00   scala/sys/Prop$DoubleProp$$anonfun$$lessinit$greater$4.class
-      654  1980-01-01 00:00   scala/sys/Prop$DoubleProp$.class
-     1147  1980-01-01 00:00   scala/sys/Prop$FileProp$$anonfun$$lessinit$greater$1.class
-      642  1980-01-01 00:00   scala/sys/Prop$FileProp$.class
-     1380  1980-01-01 00:00   scala/sys/Prop$IntProp$$anonfun$$lessinit$greater$3.class
-      642  1980-01-01 00:00   scala/sys/Prop$IntProp$.class
-     1104  1980-01-01 00:00   scala/sys/Prop$StringProp$$anonfun$$lessinit$greater$2.class
-      654  1980-01-01 00:00   scala/sys/Prop$StringProp$.class
-     2743  1980-01-01 00:00   scala/sys/Prop.class
-     5680  1980-01-01 00:00   scala/sys/PropImpl.class
-      934  1980-01-01 00:00   scala/sys/ShutdownHookThread$$anon$1.class
-     1682  1980-01-01 00:00   scala/sys/ShutdownHookThread$.class
-     1897  1980-01-01 00:00   scala/sys/ShutdownHookThread.class
-     3508  1980-01-01 00:00   scala/sys/SystemProperties$.class
-    11784  1980-01-01 00:00   scala/sys/SystemProperties.class
-     3540  1980-01-01 00:00   scala/sys/package$.class
-     1927  1980-01-01 00:00   scala/sys/package.class
-        0  1980-01-01 00:00   scala/sys/process/
-    13558  1980-01-01 00:00   scala/sys/process/BasicIO$.class
-     5088  1980-01-01 00:00   scala/sys/process/BasicIO$Streamed$.class
-     1592  1980-01-01 00:00   scala/sys/process/BasicIO$Streamed.class
-      929  1980-01-01 00:00   scala/sys/process/BasicIO$Uncloseable$$anon$1.class
-      923  1980-01-01 00:00   scala/sys/process/BasicIO$Uncloseable$$anon$2.class
-     1532  1980-01-01 00:00   scala/sys/process/BasicIO$Uncloseable$.class
-      690  1980-01-01 00:00   scala/sys/process/BasicIO$Uncloseable.class
-     5512  1980-01-01 00:00   scala/sys/process/BasicIO.class
-     2520  1980-01-01 00:00   scala/sys/process/FileProcessLogger.class
-     8209  1980-01-01 00:00   scala/sys/process/Process$.class
-     5202  1980-01-01 00:00   scala/sys/process/Process.class
-      545  1980-01-01 00:00   scala/sys/process/ProcessBuilder$.class
-      872  1980-01-01 00:00   scala/sys/process/ProcessBuilder$FileBuilder.class
-     3048  1980-01-01 00:00   scala/sys/process/ProcessBuilder$Sink.class
-     3255  1980-01-01 00:00   scala/sys/process/ProcessBuilder$Source.class
-      327  1980-01-01 00:00   scala/sys/process/ProcessBuilder$URLBuilder.class
-     5608  1980-01-01 00:00   scala/sys/process/ProcessBuilder.class
-    15470  1980-01-01 00:00   scala/sys/process/ProcessBuilderImpl$AbstractBuilder.class
-     1986  1980-01-01 00:00   scala/sys/process/ProcessBuilderImpl$AndBuilder.class
-     2830  1980-01-01 00:00   scala/sys/process/ProcessBuilderImpl$BasicBuilder.class
-     1342  1980-01-01 00:00   scala/sys/process/ProcessBuilderImpl$DaemonBuilder.class
-     1809  1980-01-01 00:00   scala/sys/process/ProcessBuilderImpl$Dummy.class
-     5202  1980-01-01 00:00   scala/sys/process/ProcessBuilderImpl$FileImpl.class
-     1301  1980-01-01 00:00   scala/sys/process/ProcessBuilderImpl$FileInput$$anonfun$$lessinit$greater$2.class
-     1133  1980-01-01 00:00   scala/sys/process/ProcessBuilderImpl$FileInput.class
-     1366  1980-01-01 00:00   scala/sys/process/ProcessBuilderImpl$FileOutput$$anonfun$$lessinit$greater$3.class
-     1167  1980-01-01 00:00   scala/sys/process/ProcessBuilderImpl$FileOutput.class
-     2025  1980-01-01 00:00   scala/sys/process/ProcessBuilderImpl$IStreamBuilder$$anonfun$$lessinit$greater$5.class
-     1418  1980-01-01 00:00   scala/sys/process/ProcessBuilderImpl$IStreamBuilder.class
-     2025  1980-01-01 00:00   scala/sys/process/ProcessBuilderImpl$OStreamBuilder$$anonfun$$lessinit$greater$4.class
-     1419  1980-01-01 00:00   scala/sys/process/ProcessBuilderImpl$OStreamBuilder.class
-     1979  1980-01-01 00:00   scala/sys/process/ProcessBuilderImpl$OrBuilder.class
-     2268  1980-01-01 00:00   scala/sys/process/ProcessBuilderImpl$PipedBuilder.class
-     2021  1980-01-01 00:00   scala/sys/process/ProcessBuilderImpl$SequenceBuilder.class
-     1625  1980-01-01 00:00   scala/sys/process/ProcessBuilderImpl$SequentialBuilder.class
-     5135  1980-01-01 00:00   scala/sys/process/ProcessBuilderImpl$Simple.class
-     4310  1980-01-01 00:00   scala/sys/process/ProcessBuilderImpl$ThreadBuilder.class
-     2949  1980-01-01 00:00   scala/sys/process/ProcessBuilderImpl$URLImpl.class
-     1266  1980-01-01 00:00   scala/sys/process/ProcessBuilderImpl$URLInput$$anonfun$$lessinit$greater$1.class
-     1120  1980-01-01 00:00   scala/sys/process/ProcessBuilderImpl$URLInput.class
-     6318  1980-01-01 00:00   scala/sys/process/ProcessBuilderImpl.class
-    14850  1980-01-01 00:00   scala/sys/process/ProcessCreation.class
-     3564  1980-01-01 00:00   scala/sys/process/ProcessIO.class
-     1501  1980-01-01 00:00   scala/sys/process/ProcessImpl$AndProcess$$anonfun$$lessinit$greater$1.class
-     1283  1980-01-01 00:00   scala/sys/process/ProcessImpl$AndProcess.class
-      823  1980-01-01 00:00   scala/sys/process/ProcessImpl$BasicProcess.class
-     9301  1980-01-01 00:00   scala/sys/process/ProcessImpl$CompoundProcess.class
-     2005  1980-01-01 00:00   scala/sys/process/ProcessImpl$DummyProcess.class
-     3879  1980-01-01 00:00   scala/sys/process/ProcessImpl$Future$.class
-     1497  1980-01-01 00:00   scala/sys/process/ProcessImpl$OrProcess$$anonfun$$lessinit$greater$2.class
-     1278  1980-01-01 00:00   scala/sys/process/ProcessImpl$OrProcess.class
-     4291  1980-01-01 00:00   scala/sys/process/ProcessImpl$PipeSink.class
-     4407  1980-01-01 00:00   scala/sys/process/ProcessImpl$PipeSource.class
-     4261  1980-01-01 00:00   scala/sys/process/ProcessImpl$PipeThread.class
-    10156  1980-01-01 00:00   scala/sys/process/ProcessImpl$PipedProcesses.class
-     1489  1980-01-01 00:00   scala/sys/process/ProcessImpl$ProcessSequence$$anonfun$$lessinit$greater$3.class
-     1308  1980-01-01 00:00   scala/sys/process/ProcessImpl$ProcessSequence.class
-     4651  1980-01-01 00:00   scala/sys/process/ProcessImpl$SequentialProcess.class
-     3108  1980-01-01 00:00   scala/sys/process/ProcessImpl$SimpleProcess.class
-      918  1980-01-01 00:00   scala/sys/process/ProcessImpl$Spawn$$anon$1.class
-     1375  1980-01-01 00:00   scala/sys/process/ProcessImpl$Spawn$.class
-     1452  1980-01-01 00:00   scala/sys/process/ProcessImpl$ThreadProcess.class
-     5636  1980-01-01 00:00   scala/sys/process/ProcessImpl.class
-     4884  1980-01-01 00:00   scala/sys/process/ProcessImplicits.class
-     1423  1980-01-01 00:00   scala/sys/process/ProcessLogger$$anon$1.class
-     1484  1980-01-01 00:00   scala/sys/process/ProcessLogger$.class
-     2117  1980-01-01 00:00   scala/sys/process/ProcessLogger.class
-     4449  1980-01-01 00:00   scala/sys/process/package$.class
-     2357  1980-01-01 00:00   scala/sys/process/package.class
-     1965  1980-01-01 00:00   scala/sys/process/processInternal$$anonfun$ioFailure$1.class
-     1777  1980-01-01 00:00   scala/sys/process/processInternal$$anonfun$onError$1.class
-     2046  1980-01-01 00:00   scala/sys/process/processInternal$$anonfun$onIOInterrupt$1.class
-     2040  1980-01-01 00:00   scala/sys/process/processInternal$$anonfun$onInterrupt$1.class
-     2943  1980-01-01 00:00   scala/sys/process/processInternal$.class
-     2647  1980-01-01 00:00   scala/sys/process/processInternal.class
-        0  1980-01-01 00:00   scala/text/
-     1818  1980-01-01 00:00   scala/text/DocBreak$.class
-     1927  1980-01-01 00:00   scala/text/DocBreak.class
-     1895  1980-01-01 00:00   scala/text/DocCons$.class
-     4772  1980-01-01 00:00   scala/text/DocCons.class
-     1653  1980-01-01 00:00   scala/text/DocGroup$.class
-     5393  1980-01-01 00:00   scala/text/DocGroup.class
-     1996  1980-01-01 00:00   scala/text/DocNest$.class
-     4804  1980-01-01 00:00   scala/text/DocNest.class
-     1812  1980-01-01 00:00   scala/text/DocNil$.class
-     1917  1980-01-01 00:00   scala/text/DocNil.class
-     1600  1980-01-01 00:00   scala/text/DocText$.class
-     5393  1980-01-01 00:00   scala/text/DocText.class
-     1452  1980-01-01 00:00   scala/text/Document$.class
-     7300  1980-01-01 00:00   scala/text/Document.class
-      577  1980-01-01 00:00   scala/throws$.class
-     1628  1980-01-01 00:00   scala/throws.class
-      641  1980-01-01 00:00   scala/transient.class
-      533  1980-01-01 00:00   scala/unchecked.class
-        0  1980-01-01 00:00   scala/util/
-      921  1980-01-01 00:00   scala/util/DynamicVariable$$anon$1.class
-     2870  1980-01-01 00:00   scala/util/DynamicVariable.class
-     1346  1980-01-01 00:00   scala/util/Either$.class
-     1663  1980-01-01 00:00   scala/util/Either$LeftProjection$.class
-     6554  1980-01-01 00:00   scala/util/Either$LeftProjection.class
-     1784  1980-01-01 00:00   scala/util/Either$MergeableEither$.class
-     1538  1980-01-01 00:00   scala/util/Either$MergeableEither.class
-     1673  1980-01-01 00:00   scala/util/Either$RightProjection$.class
-     6559  1980-01-01 00:00   scala/util/Either$RightProjection.class
-    13913  1980-01-01 00:00   scala/util/Either.class
-     1419  1980-01-01 00:00   scala/util/Failure$.class
-    10549  1980-01-01 00:00   scala/util/Failure.class
-     1337  1980-01-01 00:00   scala/util/Left$.class
-     4868  1980-01-01 00:00   scala/util/Left.class
-    10014  1980-01-01 00:00   scala/util/MurmurHash$.class
-     1804  1980-01-01 00:00   scala/util/MurmurHash$mcD$sp.class
-     1802  1980-01-01 00:00   scala/util/MurmurHash$mcF$sp.class
-     1730  1980-01-01 00:00   scala/util/MurmurHash$mcI$sp.class
-     1800  1980-01-01 00:00   scala/util/MurmurHash$mcJ$sp.class
-    12744  1980-01-01 00:00   scala/util/MurmurHash.class
-     9547  1980-01-01 00:00   scala/util/Properties$.class
-     4620  1980-01-01 00:00   scala/util/Properties.class
-    24088  1980-01-01 00:00   scala/util/PropertiesTrait.class
-      731  1980-01-01 00:00   scala/util/Random$.class
-     9259  1980-01-01 00:00   scala/util/Random.class
-     1346  1980-01-01 00:00   scala/util/Right$.class
-     4879  1980-01-01 00:00   scala/util/Right.class
-   211558  1980-01-01 00:00   scala/util/Sorting$.class
-     3810  1980-01-01 00:00   scala/util/Sorting.class
-     1315  1980-01-01 00:00   scala/util/Success$.class
-    11815  1980-01-01 00:00   scala/util/Success.class
-     1324  1980-01-01 00:00   scala/util/Try$.class
-     3387  1980-01-01 00:00   scala/util/Try$WithFilter.class
-     7228  1980-01-01 00:00   scala/util/Try.class
-        0  1980-01-01 00:00   scala/util/control/
-     1095  1980-01-01 00:00   scala/util/control/BreakControl.class
-     1393  1980-01-01 00:00   scala/util/control/Breaks$$anon$1.class
-      421  1980-01-01 00:00   scala/util/control/Breaks$.class
-      444  1980-01-01 00:00   scala/util/control/Breaks$TryBlock.class
-     2272  1980-01-01 00:00   scala/util/control/Breaks.class
-      467  1980-01-01 00:00   scala/util/control/ControlThrowable.class
-     9425  1980-01-01 00:00   scala/util/control/Exception$$anon$1.class
-     2109  1980-01-01 00:00   scala/util/control/Exception$$anonfun$pfFromExceptions$1.class
-    14808  1980-01-01 00:00   scala/util/control/Exception$.class
-      912  1980-01-01 00:00   scala/util/control/Exception$By.class
-     8775  1980-01-01 00:00   scala/util/control/Exception$Catch$$anon$2.class
-     2364  1980-01-01 00:00   scala/util/control/Exception$Catch$.class
-     9851  1980-01-01 00:00   scala/util/control/Exception$Catch.class
-     1751  1980-01-01 00:00   scala/util/control/Exception$Described.class
-     3269  1980-01-01 00:00   scala/util/control/Exception$Finally.class
-     9018  1980-01-01 00:00   scala/util/control/Exception.class
-     1123  1980-01-01 00:00   scala/util/control/NoStackTrace$.class
-     1679  1980-01-01 00:00   scala/util/control/NoStackTrace.class
-     1255  1980-01-01 00:00   scala/util/control/NonFatal$.class
-      861  1980-01-01 00:00   scala/util/control/NonFatal.class
-     1347  1980-01-01 00:00   scala/util/control/TailCalls$.class
-     1684  1980-01-01 00:00   scala/util/control/TailCalls$Call$.class
-     3175  1980-01-01 00:00   scala/util/control/TailCalls$Call.class
-     2165  1980-01-01 00:00   scala/util/control/TailCalls$Cont$.class
-     3989  1980-01-01 00:00   scala/util/control/TailCalls$Cont.class
-     1519  1980-01-01 00:00   scala/util/control/TailCalls$Done$.class
-     2849  1980-01-01 00:00   scala/util/control/TailCalls$Done.class
-     7531  1980-01-01 00:00   scala/util/control/TailCalls$TailRec.class
-     4606  1980-01-01 00:00   scala/util/control/TailCalls.class
-        0  1980-01-01 00:00   scala/util/hashing/
-     1071  1980-01-01 00:00   scala/util/hashing/ByteswapHashing$.class
-     1103  1980-01-01 00:00   scala/util/hashing/ByteswapHashing$Chained.class
-     1982  1980-01-01 00:00   scala/util/hashing/ByteswapHashing.class
-     1034  1980-01-01 00:00   scala/util/hashing/Hashing$$anon$1.class
-     1261  1980-01-01 00:00   scala/util/hashing/Hashing$.class
-      753  1980-01-01 00:00   scala/util/hashing/Hashing$Default.class
-     1873  1980-01-01 00:00   scala/util/hashing/Hashing.class
-      983  1980-01-01 00:00   scala/util/hashing/MurmurHash3$$anon$1.class
-     1204  1980-01-01 00:00   scala/util/hashing/MurmurHash3$$anon$2.class
-     1035  1980-01-01 00:00   scala/util/hashing/MurmurHash3$$anon$3.class
-     1045  1980-01-01 00:00   scala/util/hashing/MurmurHash3$$anon$4.class
-     1208  1980-01-01 00:00   scala/util/hashing/MurmurHash3$$anon$5.class
-     7419  1980-01-01 00:00   scala/util/hashing/MurmurHash3$.class
-     1097  1980-01-01 00:00   scala/util/hashing/MurmurHash3$ArrayHashing$mcB$sp.class
-     1097  1980-01-01 00:00   scala/util/hashing/MurmurHash3$ArrayHashing$mcC$sp.class
-     1097  1980-01-01 00:00   scala/util/hashing/MurmurHash3$ArrayHashing$mcD$sp.class
-     1097  1980-01-01 00:00   scala/util/hashing/MurmurHash3$ArrayHashing$mcF$sp.class
-     1097  1980-01-01 00:00   scala/util/hashing/MurmurHash3$ArrayHashing$mcI$sp.class
-     1097  1980-01-01 00:00   scala/util/hashing/MurmurHash3$ArrayHashing$mcJ$sp.class
-     1097  1980-01-01 00:00   scala/util/hashing/MurmurHash3$ArrayHashing$mcS$sp.class
-     1152  1980-01-01 00:00   scala/util/hashing/MurmurHash3$ArrayHashing$mcV$sp.class
-     1097  1980-01-01 00:00   scala/util/hashing/MurmurHash3$ArrayHashing$mcZ$sp.class
-     1986  1980-01-01 00:00   scala/util/hashing/MurmurHash3$ArrayHashing.class
-    13528  1980-01-01 00:00   scala/util/hashing/MurmurHash3.class
-      786  1980-01-01 00:00   scala/util/hashing/package$.class
-      682  1980-01-01 00:00   scala/util/hashing/package.class
-        0  1980-01-01 00:00   scala/util/matching/
-     1461  1980-01-01 00:00   scala/util/matching/Regex$$anon$2.class
-    30543  1980-01-01 00:00   scala/util/matching/Regex$$anon$4.class
-      910  1980-01-01 00:00   scala/util/matching/Regex$.class
-     3395  1980-01-01 00:00   scala/util/matching/Regex$Groups$.class
-      947  1980-01-01 00:00   scala/util/matching/Regex$Match$.class
-     7495  1980-01-01 00:00   scala/util/matching/Regex$Match.class
-     8432  1980-01-01 00:00   scala/util/matching/Regex$MatchData.class
-     2666  1980-01-01 00:00   scala/util/matching/Regex$MatchIterator$$anon$1.class
-     1563  1980-01-01 00:00   scala/util/matching/Regex$MatchIterator$$anon$3.class
-     6448  1980-01-01 00:00   scala/util/matching/Regex$MatchIterator.class
-     1875  1980-01-01 00:00   scala/util/matching/Regex$Replacement.class
-    18855  1980-01-01 00:00   scala/util/matching/Regex.class
-     1478  1980-01-01 00:00   scala/util/matching/UnanchoredRegex.class
-      637  1980-01-01 00:00   scala/volatile.class
-      815  1980-01-01 00:00   foo/TestClass.class
----------                     -------
- 14377922                     2551 files
+-rw----     2.0 fat        0 bx  0% stor 19800101.000000 META-INF/
+-rw----     2.0 fat       48 b-  0% stor 19800101.000000 META-INF/MANIFEST.MF
+-rw----     1.0 fat        0 b-  0% stor 19800101.000000 foo/
+-rw----     2.0 fat      838 b-  0% stor 19800101.000002 foo/TestBinary$.class
+-rw----     2.0 fat      615 b-  0% stor 19800101.000002 foo/TestBinary.class
+-rw----     2.0 fat      207 b-  0% stor 19800101.000000 library.properties
+-rw----     2.0 fat     3956 b-  0% stor 19800101.000000 rootdoc.txt
+-rw----     2.0 fat        0 bl  0% defN 19800101.000000 scala/
+-rw----     2.0 fat      658 b-  0% stor 19800101.000002 scala/AnyVal.class
+-rw----     2.0 fat      384 b-  0% stor 19800101.000002 scala/AnyValCompanion.class
+-rw----     2.0 fat     5238 b-  0% stor 19800101.000002 scala/App.class
+-rw----     2.0 fat     1678 b-  0% stor 19800101.000002 scala/Array$$anon$2.class
+-rw----     2.0 fat    35320 b-  0% stor 19800101.000002 scala/Array$.class
+-rw----     2.0 fat    15429 b-  0% stor 19800101.000002 scala/Array.class
+-rw----     2.0 fat      938 b-  0% stor 19800101.000002 scala/Boolean$.class
+-rw----     2.0 fat     1632 b-  0% stor 19800101.000002 scala/Boolean.class
+-rw----     2.0 fat     1576 b-  0% stor 19800101.000002 scala/Byte$.class
+-rw----     2.0 fat     7332 b-  0% stor 19800101.000002 scala/Byte.class
+-rw----     2.0 fat     1481 b-  0% stor 19800101.000002 scala/Char$.class
+-rw----     2.0 fat     7250 b-  0% stor 19800101.000002 scala/Char.class
+-rw----     2.0 fat      369 b-  0% stor 19800101.000002 scala/Cloneable.class
+-rw----     2.0 fat     5009 b-  0% stor 19800101.000002 scala/Console$.class
+-rw----     2.0 fat     6127 b-  0% stor 19800101.000002 scala/Console.class
+-rw----     2.0 fat      813 b-  0% stor 19800101.000002 scala/DelayedInit.class
+-rw----     2.0 fat     5523 b-  0% stor 19800101.000002 scala/DeprecatedConsole.class
+-rw----     2.0 fat     9093 b-  0% stor 19800101.000002 scala/DeprecatedPredef.class
+-rw----     2.0 fat     1434 b-  0% stor 19800101.000002 scala/Double$.class
+-rw----     2.0 fat     6244 b-  0% stor 19800101.000002 scala/Double.class
+-rw----     2.0 fat      300 b-  0% stor 19800101.000002 scala/Dynamic.class
+-rw----     2.0 fat     3735 b-  0% stor 19800101.000002 scala/Enumeration$Val.class
+-rw----     2.0 fat     2824 b-  0% stor 19800101.000002 scala/Enumeration$Value.class
+-rw----     2.0 fat     3652 b-  0% stor 19800101.000002 scala/Enumeration$ValueOrdering$.class
+-rw----     2.0 fat     4923 b-  0% stor 19800101.000002 scala/Enumeration$ValueSet$$anon$1.class
+-rw----     2.0 fat     1725 b-  0% stor 19800101.000002 scala/Enumeration$ValueSet$$anon$2.class
+-rw----     2.0 fat     2496 b-  0% stor 19800101.000002 scala/Enumeration$ValueSet$.class
+-rw----     2.0 fat    15943 b-  0% stor 19800101.000002 scala/Enumeration$ValueSet.class
+-rw----     2.0 fat    16749 b-  0% stor 19800101.000002 scala/Enumeration.class
+-rw----     2.0 fat      507 b-  0% stor 19800101.000002 scala/Equals.class
+-rw----     2.0 fat     1457 b-  0% stor 19800101.000002 scala/FallbackArrayBuilding$$anon$1.class
+-rw----     2.0 fat     1474 b-  0% stor 19800101.000002 scala/FallbackArrayBuilding.class
+-rw----     2.0 fat     1510 b-  0% stor 19800101.000002 scala/Float$.class
+-rw----     2.0 fat     6321 b-  0% stor 19800101.000002 scala/Float.class
+-rw----     2.0 fat    11715 b-  0% stor 19800101.000002 scala/Function$.class
+-rw----     2.0 fat     6646 b-  0% stor 19800101.000002 scala/Function.class
+-rw----     2.0 fat      291 b-  0% stor 19800101.000002 scala/Function0$mcB$sp.class
+-rw----     2.0 fat      291 b-  0% stor 19800101.000002 scala/Function0$mcC$sp.class
+-rw----     2.0 fat      291 b-  0% stor 19800101.000002 scala/Function0$mcD$sp.class
+-rw----     2.0 fat      291 b-  0% stor 19800101.000002 scala/Function0$mcF$sp.class
+-rw----     2.0 fat      291 b-  0% stor 19800101.000002 scala/Function0$mcI$sp.class
+-rw----     2.0 fat      291 b-  0% stor 19800101.000002 scala/Function0$mcJ$sp.class
+-rw----     2.0 fat      291 b-  0% stor 19800101.000002 scala/Function0$mcS$sp.class
+-rw----     2.0 fat      298 b-  0% stor 19800101.000002 scala/Function0$mcV$sp.class
+-rw----     2.0 fat      291 b-  0% stor 19800101.000002 scala/Function0$mcZ$sp.class
+-rw----     2.0 fat     3726 b-  0% stor 19800101.000002 scala/Function0.class
+-rw----     2.0 fat      328 b-  0% stor 19800101.000002 scala/Function1$mcDD$sp.class
+-rw----     2.0 fat      328 b-  0% stor 19800101.000002 scala/Function1$mcDF$sp.class
+-rw----     2.0 fat      328 b-  0% stor 19800101.000002 scala/Function1$mcDI$sp.class
+-rw----     2.0 fat      328 b-  0% stor 19800101.000002 scala/Function1$mcDJ$sp.class
+-rw----     2.0 fat      328 b-  0% stor 19800101.000002 scala/Function1$mcFD$sp.class
+-rw----     2.0 fat      328 b-  0% stor 19800101.000002 scala/Function1$mcFF$sp.class
+-rw----     2.0 fat      328 b-  0% stor 19800101.000002 scala/Function1$mcFI$sp.class
+-rw----     2.0 fat      328 b-  0% stor 19800101.000002 scala/Function1$mcFJ$sp.class
+-rw----     2.0 fat      328 b-  0% stor 19800101.000002 scala/Function1$mcID$sp.class
+-rw----     2.0 fat      328 b-  0% stor 19800101.000002 scala/Function1$mcIF$sp.class
+-rw----     2.0 fat      328 b-  0% stor 19800101.000002 scala/Function1$mcII$sp.class
+-rw----     2.0 fat      328 b-  0% stor 19800101.000002 scala/Function1$mcIJ$sp.class
+-rw----     2.0 fat      328 b-  0% stor 19800101.000002 scala/Function1$mcJD$sp.class
+-rw----     2.0 fat      328 b-  0% stor 19800101.000002 scala/Function1$mcJF$sp.class
+-rw----     2.0 fat      328 b-  0% stor 19800101.000002 scala/Function1$mcJI$sp.class
+-rw----     2.0 fat      328 b-  0% stor 19800101.000002 scala/Function1$mcJJ$sp.class
+-rw----     2.0 fat      335 b-  0% stor 19800101.000002 scala/Function1$mcVD$sp.class
+-rw----     2.0 fat      335 b-  0% stor 19800101.000002 scala/Function1$mcVF$sp.class
+-rw----     2.0 fat      335 b-  0% stor 19800101.000002 scala/Function1$mcVI$sp.class
+-rw----     2.0 fat      335 b-  0% stor 19800101.000002 scala/Function1$mcVJ$sp.class
+-rw----     2.0 fat      328 b-  0% stor 19800101.000002 scala/Function1$mcZD$sp.class
+-rw----     2.0 fat      328 b-  0% stor 19800101.000002 scala/Function1$mcZF$sp.class
+-rw----     2.0 fat      328 b-  0% stor 19800101.000002 scala/Function1$mcZI$sp.class
+-rw----     2.0 fat      328 b-  0% stor 19800101.000002 scala/Function1$mcZJ$sp.class
+-rw----     2.0 fat    10435 b-  0% stor 19800101.000002 scala/Function1.class
+-rw----     2.0 fat     5643 b-  0% stor 19800101.000002 scala/Function10.class
+-rw----     2.0 fat     5868 b-  0% stor 19800101.000002 scala/Function11.class
+-rw----     2.0 fat     6100 b-  0% stor 19800101.000002 scala/Function12.class
+-rw----     2.0 fat     6326 b-  0% stor 19800101.000002 scala/Function13.class
+-rw----     2.0 fat     6555 b-  0% stor 19800101.000002 scala/Function14.class
+-rw----     2.0 fat     6785 b-  0% stor 19800101.000002 scala/Function15.class
+-rw----     2.0 fat     7015 b-  0% stor 19800101.000002 scala/Function16.class
+-rw----     2.0 fat     7245 b-  0% stor 19800101.000002 scala/Function17.class
+-rw----     2.0 fat     7474 b-  0% stor 19800101.000002 scala/Function18.class
+-rw----     2.0 fat     7724 b-  0% stor 19800101.000002 scala/Function19.class
+-rw----     2.0 fat      365 b-  0% stor 19800101.000002 scala/Function2$mcDDD$sp.class
+-rw----     2.0 fat      365 b-  0% stor 19800101.000002 scala/Function2$mcDDI$sp.class
+-rw----     2.0 fat      365 b-  0% stor 19800101.000002 scala/Function2$mcDDJ$sp.class
+-rw----     2.0 fat      365 b-  0% stor 19800101.000002 scala/Function2$mcDID$sp.class
+-rw----     2.0 fat      365 b-  0% stor 19800101.000002 scala/Function2$mcDII$sp.class
+-rw----     2.0 fat      365 b-  0% stor 19800101.000002 scala/Function2$mcDIJ$sp.class
+-rw----     2.0 fat      365 b-  0% stor 19800101.000002 scala/Function2$mcDJD$sp.class
+-rw----     2.0 fat      365 b-  0% stor 19800101.000002 scala/Function2$mcDJI$sp.class
+-rw----     2.0 fat      365 b-  0% stor 19800101.000002 scala/Function2$mcDJJ$sp.class
+-rw----     2.0 fat      365 b-  0% stor 19800101.000002 scala/Function2$mcFDD$sp.class
+-rw----     2.0 fat      365 b-  0% stor 19800101.000002 scala/Function2$mcFDI$sp.class
+-rw----     2.0 fat      365 b-  0% stor 19800101.000002 scala/Function2$mcFDJ$sp.class
+-rw----     2.0 fat      365 b-  0% stor 19800101.000002 scala/Function2$mcFID$sp.class
+-rw----     2.0 fat      365 b-  0% stor 19800101.000002 scala/Function2$mcFII$sp.class
+-rw----     2.0 fat      365 b-  0% stor 19800101.000002 scala/Function2$mcFIJ$sp.class
+-rw----     2.0 fat      365 b-  0% stor 19800101.000002 scala/Function2$mcFJD$sp.class
+-rw----     2.0 fat      365 b-  0% stor 19800101.000002 scala/Function2$mcFJI$sp.class
+-rw----     2.0 fat      365 b-  0% stor 19800101.000002 scala/Function2$mcFJJ$sp.class
+-rw----     2.0 fat      365 b-  0% stor 19800101.000002 scala/Function2$mcIDD$sp.class
+-rw----     2.0 fat      365 b-  0% stor 19800101.000002 scala/Function2$mcIDI$sp.class
+-rw----     2.0 fat      365 b-  0% stor 19800101.000002 scala/Function2$mcIDJ$sp.class
+-rw----     2.0 fat      365 b-  0% stor 19800101.000002 scala/Function2$mcIID$sp.class
+-rw----     2.0 fat      365 b-  0% stor 19800101.000002 scala/Function2$mcIII$sp.class
+-rw----     2.0 fat      365 b-  0% stor 19800101.000002 scala/Function2$mcIIJ$sp.class
+-rw----     2.0 fat      365 b-  0% stor 19800101.000002 scala/Function2$mcIJD$sp.class
+-rw----     2.0 fat      365 b-  0% stor 19800101.000002 scala/Function2$mcIJI$sp.class
+-rw----     2.0 fat      365 b-  0% stor 19800101.000002 scala/Function2$mcIJJ$sp.class
+-rw----     2.0 fat      365 b-  0% stor 19800101.000002 scala/Function2$mcJDD$sp.class
+-rw----     2.0 fat      365 b-  0% stor 19800101.000002 scala/Function2$mcJDI$sp.class
+-rw----     2.0 fat      365 b-  0% stor 19800101.000002 scala/Function2$mcJDJ$sp.class
+-rw----     2.0 fat      365 b-  0% stor 19800101.000002 scala/Function2$mcJID$sp.class
+-rw----     2.0 fat      365 b-  0% stor 19800101.000002 scala/Function2$mcJII$sp.class
+-rw----     2.0 fat      365 b-  0% stor 19800101.000002 scala/Function2$mcJIJ$sp.class
+-rw----     2.0 fat      365 b-  0% stor 19800101.000002 scala/Function2$mcJJD$sp.class
+-rw----     2.0 fat      365 b-  0% stor 19800101.000002 scala/Function2$mcJJI$sp.class
+-rw----     2.0 fat      365 b-  0% stor 19800101.000002 scala/Function2$mcJJJ$sp.class
+-rw----     2.0 fat      372 b-  0% stor 19800101.000002 scala/Function2$mcVDD$sp.class
+-rw----     2.0 fat      372 b-  0% stor 19800101.000002 scala/Function2$mcVDI$sp.class
+-rw----     2.0 fat      372 b-  0% stor 19800101.000002 scala/Function2$mcVDJ$sp.class
+-rw----     2.0 fat      372 b-  0% stor 19800101.000002 scala/Function2$mcVID$sp.class
+-rw----     2.0 fat      372 b-  0% stor 19800101.000002 scala/Function2$mcVII$sp.class
+-rw----     2.0 fat      372 b-  0% stor 19800101.000002 scala/Function2$mcVIJ$sp.class
+-rw----     2.0 fat      372 b-  0% stor 19800101.000002 scala/Function2$mcVJD$sp.class
+-rw----     2.0 fat      372 b-  0% stor 19800101.000002 scala/Function2$mcVJI$sp.class
+-rw----     2.0 fat      372 b-  0% stor 19800101.000002 scala/Function2$mcVJJ$sp.class
+-rw----     2.0 fat      365 b-  0% stor 19800101.000002 scala/Function2$mcZDD$sp.class
+-rw----     2.0 fat      365 b-  0% stor 19800101.000002 scala/Function2$mcZDI$sp.class
+-rw----     2.0 fat      365 b-  0% stor 19800101.000002 scala/Function2$mcZDJ$sp.class
+-rw----     2.0 fat      365 b-  0% stor 19800101.000002 scala/Function2$mcZID$sp.class
+-rw----     2.0 fat      365 b-  0% stor 19800101.000002 scala/Function2$mcZII$sp.class
+-rw----     2.0 fat      365 b-  0% stor 19800101.000002 scala/Function2$mcZIJ$sp.class
+-rw----     2.0 fat      365 b-  0% stor 19800101.000002 scala/Function2$mcZJD$sp.class
+-rw----     2.0 fat      365 b-  0% stor 19800101.000002 scala/Function2$mcZJI$sp.class
+-rw----     2.0 fat      365 b-  0% stor 19800101.000002 scala/Function2$mcZJJ$sp.class
+-rw----     2.0 fat    20688 b-  0% stor 19800101.000002 scala/Function2.class
+-rw----     2.0 fat     7958 b-  0% stor 19800101.000002 scala/Function20.class
+-rw----     2.0 fat     8192 b-  0% stor 19800101.000002 scala/Function21.class
+-rw----     2.0 fat     8426 b-  0% stor 19800101.000002 scala/Function22.class
+-rw----     2.0 fat     4220 b-  0% stor 19800101.000002 scala/Function3.class
+-rw----     2.0 fat     4702 b-  0% stor 19800101.000002 scala/Function4.class
+-rw----     2.0 fat     4547 b-  0% stor 19800101.000002 scala/Function5.class
+-rw----     2.0 fat     4760 b-  0% stor 19800101.000002 scala/Function6.class
+-rw----     2.0 fat     4976 b-  0% stor 19800101.000002 scala/Function7.class
+-rw----     2.0 fat     5189 b-  0% stor 19800101.000002 scala/Function8.class
+-rw----     2.0 fat     5402 b-  0% stor 19800101.000002 scala/Function9.class
+-rw----     2.0 fat      310 b-  0% stor 19800101.000002 scala/Immutable.class
+-rw----     2.0 fat     1376 b-  0% stor 19800101.000002 scala/Int$.class
+-rw----     2.0 fat     7147 b-  0% stor 19800101.000002 scala/Int.class
+-rw----     2.0 fat     1286 b-  0% stor 19800101.000002 scala/Long$.class
+-rw----     2.0 fat     7050 b-  0% stor 19800101.000002 scala/Long.class
+-rw----     2.0 fat     1652 b-  0% stor 19800101.000002 scala/LowPriorityImplicits$$anon$4.class
+-rw----     2.0 fat     8361 b-  0% stor 19800101.000002 scala/LowPriorityImplicits.class
+-rw----     2.0 fat     1913 b-  0% stor 19800101.000002 scala/MatchError.class
+-rw----     2.0 fat      303 b-  0% stor 19800101.000002 scala/Mutable.class
+-rw----     2.0 fat     2110 b-  0% stor 19800101.000002 scala/None$.class
+-rw----     2.0 fat     5063 b-  0% stor 19800101.000002 scala/None.class
+-rw----     2.0 fat      858 b-  0% stor 19800101.000002 scala/NotImplementedError.class
+-rw----     2.0 fat      397 b-  0% stor 19800101.000002 scala/NotNull.class
+-rw----     2.0 fat     1373 b-  0% stor 19800101.000002 scala/Option$.class
+-rw----     2.0 fat     3711 b-  0% stor 19800101.000002 scala/Option$WithFilter.class
+-rw----     2.0 fat    10570 b-  0% stor 19800101.000002 scala/Option.class
+-rw----     2.0 fat     8333 b-  0% stor 19800101.000002 scala/PartialFunction$$anon$1.class
+-rw----     2.0 fat     1254 b-  0% stor 19800101.000002 scala/PartialFunction$$anonfun$1.class
+-rw----     2.0 fat     1325 b-  0% stor 19800101.000002 scala/PartialFunction$$anonfun$apply$1.class
+-rw----     2.0 fat     4257 b-  0% stor 19800101.000002 scala/PartialFunction$.class
+-rw----     2.0 fat     8437 b-  0% stor 19800101.000002 scala/PartialFunction$AndThen.class
+-rw----     2.0 fat     1776 b-  0% stor 19800101.000002 scala/PartialFunction$Lifted.class
+-rw----     2.0 fat     2909 b-  0% stor 19800101.000002 scala/PartialFunction$OrElse.class
+-rw----     2.0 fat     1680 b-  0% stor 19800101.000002 scala/PartialFunction$Unlifted.class
+-rw----     2.0 fat     8283 b-  0% stor 19800101.000002 scala/PartialFunction.class
+-rw----     2.0 fat      724 b-  0% stor 19800101.000002 scala/Predef$$anon$1.class
+-rw----     2.0 fat      712 b-  0% stor 19800101.000002 scala/Predef$$anon$2.class
+-rw----     2.0 fat     1344 b-  0% stor 19800101.000002 scala/Predef$$anon$3.class
+-rw----     2.0 fat      982 b-  0% stor 19800101.000002 scala/Predef$$eq$colon$eq$.class
+-rw----     2.0 fat     6075 b-  0% stor 19800101.000002 scala/Predef$$eq$colon$eq.class
+-rw----     2.0 fat     6087 b-  0% stor 19800101.000002 scala/Predef$$less$colon$less.class
+-rw----     2.0 fat    19181 b-  0% stor 19800101.000002 scala/Predef$.class
+-rw----     2.0 fat     1653 b-  0% stor 19800101.000002 scala/Predef$ArrayCharSequence.class
+-rw----     2.0 fat     1694 b-  0% stor 19800101.000002 scala/Predef$ArrowAssoc$.class
+-rw----     2.0 fat     1757 b-  0% stor 19800101.000002 scala/Predef$ArrowAssoc.class
+-rw----     2.0 fat      663 b-  0% stor 19800101.000002 scala/Predef$DummyImplicit$.class
+-rw----     2.0 fat      396 b-  0% stor 19800101.000002 scala/Predef$DummyImplicit.class
+-rw----     2.0 fat     3041 b-  0% stor 19800101.000002 scala/Predef$Ensuring$.class
+-rw----     2.0 fat     2748 b-  0% stor 19800101.000002 scala/Predef$Ensuring.class
+-rw----     2.0 fat     1174 b-  0% stor 19800101.000002 scala/Predef$Pair$.class
+-rw----     2.0 fat     1966 b-  0% stor 19800101.000002 scala/Predef$RichException$.class
+-rw----     2.0 fat     1361 b-  0% stor 19800101.000002 scala/Predef$RichException.class
+-rw----     2.0 fat     1894 b-  0% stor 19800101.000002 scala/Predef$SeqCharSequence.class
+-rw----     2.0 fat     1873 b-  0% stor 19800101.000002 scala/Predef$StringFormat$.class
+-rw----     2.0 fat     1812 b-  0% stor 19800101.000002 scala/Predef$StringFormat.class
+-rw----     2.0 fat     1287 b-  0% stor 19800101.000002 scala/Predef$Triple$.class
+-rw----     2.0 fat     1760 b-  0% stor 19800101.000002 scala/Predef$any2stringadd$.class
+-rw----     2.0 fat     1472 b-  0% stor 19800101.000002 scala/Predef$any2stringadd.class
+-rw----     2.0 fat    24873 b-  0% stor 19800101.000002 scala/Predef.class
+-rw----     2.0 fat     1381 b-  0% stor 19800101.000002 scala/Product$$anon$1.class
+-rw----     2.0 fat     1586 b-  0% stor 19800101.000002 scala/Product.class
+-rw----     2.0 fat      732 b-  0% stor 19800101.000002 scala/Product1$.class
+-rw----     2.0 fat      252 b-  0% stor 19800101.000002 scala/Product1$mcD$sp.class
+-rw----     2.0 fat      252 b-  0% stor 19800101.000002 scala/Product1$mcI$sp.class
+-rw----     2.0 fat      252 b-  0% stor 19800101.000002 scala/Product1$mcJ$sp.class
+-rw----     2.0 fat     3046 b-  0% stor 19800101.000002 scala/Product1.class
+-rw----     2.0 fat     1003 b-  0% stor 19800101.000002 scala/Product10$.class
+-rw----     2.0 fat     3701 b-  0% stor 19800101.000002 scala/Product10.class
+-rw----     2.0 fat     1035 b-  0% stor 19800101.000002 scala/Product11$.class
+-rw----     2.0 fat     3883 b-  0% stor 19800101.000002 scala/Product11.class
+-rw----     2.0 fat     1067 b-  0% stor 19800101.000002 scala/Product12$.class
+-rw----     2.0 fat     4066 b-  0% stor 19800101.000002 scala/Product12.class
+-rw----     2.0 fat     1099 b-  0% stor 19800101.000002 scala/Product13$.class
+-rw----     2.0 fat     4247 b-  0% stor 19800101.000002 scala/Product13.class
+-rw----     2.0 fat     1131 b-  0% stor 19800101.000002 scala/Product14$.class
+-rw----     2.0 fat     4428 b-  0% stor 19800101.000002 scala/Product14.class
+-rw----     2.0 fat     1163 b-  0% stor 19800101.000002 scala/Product15$.class
+-rw----     2.0 fat     4609 b-  0% stor 19800101.000002 scala/Product15.class
+-rw----     2.0 fat     1195 b-  0% stor 19800101.000002 scala/Product16$.class
+-rw----     2.0 fat     4790 b-  0% stor 19800101.000002 scala/Product16.class
+-rw----     2.0 fat     1227 b-  0% stor 19800101.000002 scala/Product17$.class
+-rw----     2.0 fat     4971 b-  0% stor 19800101.000002 scala/Product17.class
+-rw----     2.0 fat     1259 b-  0% stor 19800101.000002 scala/Product18$.class
+-rw----     2.0 fat     5152 b-  0% stor 19800101.000002 scala/Product18.class
+-rw----     2.0 fat     1291 b-  0% stor 19800101.000002 scala/Product19$.class
+-rw----     2.0 fat     5333 b-  0% stor 19800101.000002 scala/Product19.class
+-rw----     2.0 fat      761 b-  0% stor 19800101.000002 scala/Product2$.class
+-rw----     2.0 fat      271 b-  0% stor 19800101.000002 scala/Product2$mcDD$sp.class
+-rw----     2.0 fat      271 b-  0% stor 19800101.000002 scala/Product2$mcDI$sp.class
+-rw----     2.0 fat      271 b-  0% stor 19800101.000002 scala/Product2$mcDJ$sp.class
+-rw----     2.0 fat      271 b-  0% stor 19800101.000002 scala/Product2$mcID$sp.class
+-rw----     2.0 fat      271 b-  0% stor 19800101.000002 scala/Product2$mcII$sp.class
+-rw----     2.0 fat      271 b-  0% stor 19800101.000002 scala/Product2$mcIJ$sp.class
+-rw----     2.0 fat      271 b-  0% stor 19800101.000002 scala/Product2$mcJD$sp.class
+-rw----     2.0 fat      271 b-  0% stor 19800101.000002 scala/Product2$mcJI$sp.class
+-rw----     2.0 fat      271 b-  0% stor 19800101.000002 scala/Product2$mcJJ$sp.class
+-rw----     2.0 fat     3788 b-  0% stor 19800101.000002 scala/Product2.class
+-rw----     2.0 fat     1323 b-  0% stor 19800101.000002 scala/Product20$.class
+-rw----     2.0 fat     5514 b-  0% stor 19800101.000002 scala/Product20.class
+-rw----     2.0 fat     1355 b-  0% stor 19800101.000002 scala/Product21$.class
+-rw----     2.0 fat     5695 b-  0% stor 19800101.000002 scala/Product21.class
+-rw----     2.0 fat     1387 b-  0% stor 19800101.000002 scala/Product22$.class
+-rw----     2.0 fat     5876 b-  0% stor 19800101.000002 scala/Product22.class
+-rw----     2.0 fat      790 b-  0% stor 19800101.000002 scala/Product3$.class
+-rw----     2.0 fat     2513 b-  0% stor 19800101.000002 scala/Product3.class
+-rw----     2.0 fat      819 b-  0% stor 19800101.000002 scala/Product4$.class
+-rw----     2.0 fat     2674 b-  0% stor 19800101.000002 scala/Product4.class
+-rw----     2.0 fat      848 b-  0% stor 19800101.000002 scala/Product5$.class
+-rw----     2.0 fat     2836 b-  0% stor 19800101.000002 scala/Product5.class
+-rw----     2.0 fat      877 b-  0% stor 19800101.000002 scala/Product6$.class
+-rw----     2.0 fat     2998 b-  0% stor 19800101.000002 scala/Product6.class
+-rw----     2.0 fat      906 b-  0% stor 19800101.000002 scala/Product7$.class
+-rw----     2.0 fat     3159 b-  0% stor 19800101.000002 scala/Product7.class
+-rw----     2.0 fat      935 b-  0% stor 19800101.000002 scala/Product8$.class
+-rw----     2.0 fat     3330 b-  0% stor 19800101.000002 scala/Product8.class
+-rw----     2.0 fat      964 b-  0% stor 19800101.000002 scala/Product9$.class
+-rw----     2.0 fat     3505 b-  0% stor 19800101.000002 scala/Product9.class
+-rw----     2.0 fat      387 b-  0% stor 19800101.000002 scala/Proxy$.class
+-rw----     2.0 fat      339 b-  0% stor 19800101.000002 scala/Proxy$Typed.class
+-rw----     2.0 fat     1892 b-  0% stor 19800101.000002 scala/Proxy.class
+-rw----     2.0 fat      915 b-  0% stor 19800101.000002 scala/Responder$$anon$1.class
+-rw----     2.0 fat     2417 b-  0% stor 19800101.000002 scala/Responder$$anon$2.class
+-rw----     2.0 fat     2413 b-  0% stor 19800101.000002 scala/Responder$$anon$3.class
+-rw----     2.0 fat     2514 b-  0% stor 19800101.000002 scala/Responder$$anon$4.class
+-rw----     2.0 fat     5141 b-  0% stor 19800101.000002 scala/Responder$.class
+-rw----     2.0 fat     5028 b-  0% stor 19800101.000002 scala/Responder.class
+-rw----     2.0 fat     1693 b-  0% stor 19800101.000002 scala/ScalaReflectionException$.class
+-rw----     2.0 fat     5306 b-  0% stor 19800101.000002 scala/ScalaReflectionException.class
+-rw----     2.0 fat      744 b-  0% stor 19800101.000002 scala/SerialVersionUID.class
+-rw----     2.0 fat      377 b-  0% stor 19800101.000002 scala/Serializable.class
+-rw----     2.0 fat     1483 b-  0% stor 19800101.000002 scala/Short$.class
+-rw----     2.0 fat     7246 b-  0% stor 19800101.000002 scala/Short.class
+-rw----     2.0 fat     1230 b-  0% stor 19800101.000002 scala/Some$.class
+-rw----     2.0 fat     4725 b-  0% stor 19800101.000002 scala/Some.class
+-rw----     2.0 fat     4548 b-  0% stor 19800101.000002 scala/Specializable$.class
+-rw----     2.0 fat      682 b-  0% stor 19800101.000002 scala/Specializable$Group.class
+-rw----     2.0 fat      248 b-  0% stor 19800101.000002 scala/Specializable$SpecializedGroup.class
+-rw----     2.0 fat     2760 b-  0% stor 19800101.000002 scala/Specializable.class
+-rw----     2.0 fat     3889 b-  0% stor 19800101.000002 scala/StringContext$.class
+-rw----     2.0 fat     2023 b-  0% stor 19800101.000002 scala/StringContext$InvalidEscapeException.class
+-rw----     2.0 fat     7956 b-  0% stor 19800101.000002 scala/StringContext.class
+-rw----     2.0 fat     1711 b-  0% stor 19800101.000002 scala/Symbol$.class
+-rw----     2.0 fat     2358 b-  0% stor 19800101.000002 scala/Symbol.class
+-rw----     2.0 fat     2680 b-  0% stor 19800101.000002 scala/Tuple1$.class
+-rw----     2.0 fat     1242 b-  0% stor 19800101.000002 scala/Tuple1$mcD$sp.class
+-rw----     2.0 fat     1244 b-  0% stor 19800101.000002 scala/Tuple1$mcI$sp.class
+-rw----     2.0 fat     1238 b-  0% stor 19800101.000002 scala/Tuple1$mcJ$sp.class
+-rw----     2.0 fat     6023 b-  0% stor 19800101.000002 scala/Tuple1.class
+-rw----     2.0 fat     2501 b-  0% stor 19800101.000002 scala/Tuple10$.class
+-rw----     2.0 fat    13153 b-  0% stor 19800101.000002 scala/Tuple10.class
+-rw----     2.0 fat     2637 b-  0% stor 19800101.000002 scala/Tuple11$.class
+-rw----     2.0 fat    14500 b-  0% stor 19800101.000002 scala/Tuple11.class
+-rw----     2.0 fat     2773 b-  0% stor 19800101.000002 scala/Tuple12$.class
+-rw----     2.0 fat    15915 b-  0% stor 19800101.000002 scala/Tuple12.class
+-rw----     2.0 fat     2909 b-  0% stor 19800101.000002 scala/Tuple13$.class
+-rw----     2.0 fat    17406 b-  0% stor 19800101.000002 scala/Tuple13.class
+-rw----     2.0 fat     3045 b-  0% stor 19800101.000002 scala/Tuple14$.class
+-rw----     2.0 fat    18947 b-  0% stor 19800101.000002 scala/Tuple14.class
+-rw----     2.0 fat     3181 b-  0% stor 19800101.000002 scala/Tuple15$.class
+-rw----     2.0 fat    20568 b-  0% stor 19800101.000002 scala/Tuple15.class
+-rw----     2.0 fat     3317 b-  0% stor 19800101.000002 scala/Tuple16$.class
+-rw----     2.0 fat    22236 b-  0% stor 19800101.000002 scala/Tuple16.class
+-rw----     2.0 fat     3453 b-  0% stor 19800101.000002 scala/Tuple17$.class
+-rw----     2.0 fat    23984 b-  0% stor 19800101.000002 scala/Tuple17.class
+-rw----     2.0 fat     3589 b-  0% stor 19800101.000002 scala/Tuple18$.class
+-rw----     2.0 fat    25800 b-  0% stor 19800101.000002 scala/Tuple18.class
+-rw----     2.0 fat     3725 b-  0% stor 19800101.000002 scala/Tuple19$.class
+-rw----     2.0 fat    27672 b-  0% stor 19800101.000002 scala/Tuple19.class
+-rw----     2.0 fat    11897 b-  0% stor 19800101.000002 scala/Tuple2$.class
+-rw----     2.0 fat     2075 b-  0% stor 19800101.000002 scala/Tuple2$mcCC$sp.class
+-rw----     2.0 fat     2217 b-  0% stor 19800101.000002 scala/Tuple2$mcCD$sp.class
+-rw----     2.0 fat     2219 b-  0% stor 19800101.000002 scala/Tuple2$mcCI$sp.class
+-rw----     2.0 fat     2213 b-  0% stor 19800101.000002 scala/Tuple2$mcCJ$sp.class
+-rw----     2.0 fat     2213 b-  0% stor 19800101.000002 scala/Tuple2$mcCZ$sp.class
+-rw----     2.0 fat     2217 b-  0% stor 19800101.000002 scala/Tuple2$mcDC$sp.class
+-rw----     2.0 fat     2123 b-  0% stor 19800101.000002 scala/Tuple2$mcDD$sp.class
+-rw----     2.0 fat     2267 b-  0% stor 19800101.000002 scala/Tuple2$mcDI$sp.class
+-rw----     2.0 fat     2261 b-  0% stor 19800101.000002 scala/Tuple2$mcDJ$sp.class
+-rw----     2.0 fat     2207 b-  0% stor 19800101.000002 scala/Tuple2$mcDZ$sp.class
+-rw----     2.0 fat     2219 b-  0% stor 19800101.000002 scala/Tuple2$mcIC$sp.class
+-rw----     2.0 fat     2267 b-  0% stor 19800101.000002 scala/Tuple2$mcID$sp.class
+-rw----     2.0 fat     2125 b-  0% stor 19800101.000002 scala/Tuple2$mcII$sp.class
+-rw----     2.0 fat     2263 b-  0% stor 19800101.000002 scala/Tuple2$mcIJ$sp.class
+-rw----     2.0 fat     2209 b-  0% stor 19800101.000002 scala/Tuple2$mcIZ$sp.class
+-rw----     2.0 fat     2213 b-  0% stor 19800101.000002 scala/Tuple2$mcJC$sp.class
+-rw----     2.0 fat     2261 b-  0% stor 19800101.000002 scala/Tuple2$mcJD$sp.class
+-rw----     2.0 fat     2263 b-  0% stor 19800101.000002 scala/Tuple2$mcJI$sp.class
+-rw----     2.0 fat     2119 b-  0% stor 19800101.000002 scala/Tuple2$mcJJ$sp.class
+-rw----     2.0 fat     2203 b-  0% stor 19800101.000002 scala/Tuple2$mcJZ$sp.class
+-rw----     2.0 fat     2213 b-  0% stor 19800101.000002 scala/Tuple2$mcZC$sp.class
+-rw----     2.0 fat     2207 b-  0% stor 19800101.000002 scala/Tuple2$mcZD$sp.class
+-rw----     2.0 fat     2209 b-  0% stor 19800101.000002 scala/Tuple2$mcZI$sp.class
+-rw----     2.0 fat     2203 b-  0% stor 19800101.000002 scala/Tuple2$mcZJ$sp.class
+-rw----     2.0 fat     2065 b-  0% stor 19800101.000002 scala/Tuple2$mcZZ$sp.class
+-rw----     2.0 fat    16966 b-  0% stor 19800101.000002 scala/Tuple2.class
+-rw----     2.0 fat     3861 b-  0% stor 19800101.000002 scala/Tuple20$.class
+-rw----     2.0 fat    29624 b-  0% stor 19800101.000002 scala/Tuple20.class
+-rw----     2.0 fat     3997 b-  0% stor 19800101.000002 scala/Tuple21$.class
+-rw----     2.0 fat    31632 b-  0% stor 19800101.000002 scala/Tuple21.class
+-rw----     2.0 fat     4133 b-  0% stor 19800101.000002 scala/Tuple22$.class
+-rw----     2.0 fat    33714 b-  0% stor 19800101.000002 scala/Tuple22.class
+-rw----     2.0 fat     1580 b-  0% stor 19800101.000002 scala/Tuple3$.class
+-rw----     2.0 fat     5729 b-  0% stor 19800101.000002 scala/Tuple3.class
+-rw----     2.0 fat     1709 b-  0% stor 19800101.000002 scala/Tuple4$.class
+-rw----     2.0 fat     6574 b-  0% stor 19800101.000002 scala/Tuple4.class
+-rw----     2.0 fat     1838 b-  0% stor 19800101.000002 scala/Tuple5$.class
+-rw----     2.0 fat     7490 b-  0% stor 19800101.000002 scala/Tuple5.class
+-rw----     2.0 fat     1967 b-  0% stor 19800101.000002 scala/Tuple6$.class
+-rw----     2.0 fat     8475 b-  0% stor 19800101.000002 scala/Tuple6.class
+-rw----     2.0 fat     2096 b-  0% stor 19800101.000002 scala/Tuple7$.class
+-rw----     2.0 fat     9532 b-  0% stor 19800101.000002 scala/Tuple7.class
+-rw----     2.0 fat     2225 b-  0% stor 19800101.000002 scala/Tuple8$.class
+-rw----     2.0 fat    10654 b-  0% stor 19800101.000002 scala/Tuple8.class
+-rw----     2.0 fat     2354 b-  0% stor 19800101.000002 scala/Tuple9$.class
+-rw----     2.0 fat    11841 b-  0% stor 19800101.000002 scala/Tuple9.class
+-rw----     2.0 fat      629 b-  0% stor 19800101.000002 scala/UninitializedError.class
+-rw----     2.0 fat     1700 b-  0% stor 19800101.000002 scala/UninitializedFieldError$.class
+-rw----     2.0 fat     5519 b-  0% stor 19800101.000002 scala/UninitializedFieldError.class
+-rw----     2.0 fat     4084 b-  0% stor 19800101.000002 scala/UniquenessCache.class
+-rw----     2.0 fat      915 b-  0% stor 19800101.000002 scala/Unit$.class
+-rw----     2.0 fat     1185 b-  0% stor 19800101.000002 scala/Unit.class
+-rw----     2.0 fat     1079 b-  0% stor 19800101.000002 scala/ValueOf$.class
+-rw----     2.0 fat     1933 b-  0% stor 19800101.000002 scala/ValueOf.class
+-rw----     2.0 fat        0 bl  0% defN 19800101.000000 scala/annotation/
+-rw----     2.0 fat      544 b-  0% stor 19800101.000002 scala/annotation/Annotation.class
+-rw----     2.0 fat      447 b-  0% stor 19800101.000002 scala/annotation/ClassfileAnnotation.class
+-rw----     2.0 fat      366 b-  0% stor 19800101.000002 scala/annotation/StaticAnnotation.class
+-rw----     2.0 fat      359 b-  0% stor 19800101.000002 scala/annotation/TypeConstraint.class
+-rw----     2.0 fat      757 b-  0% stor 19800101.000002 scala/annotation/bridge.class
+-rw----     2.0 fat     1017 b-  0% stor 19800101.000002 scala/annotation/compileTimeOnly.class
+-rw----     2.0 fat     3984 b-  0% stor 19800101.000002 scala/annotation/elidable$.class
+-rw----     2.0 fat     2505 b-  0% stor 19800101.000002 scala/annotation/elidable.class
+-rw----     2.0 fat      836 b-  0% stor 19800101.000002 scala/annotation/implicitAmbiguous.class
+-rw----     2.0 fat      832 b-  0% stor 19800101.000002 scala/annotation/implicitNotFound.class
+-rw----     2.0 fat      623 b-  0% stor 19800101.000002 scala/annotation/inductive.class
+-rw----     2.0 fat        0 bl  0% defN 19800101.000000 scala/annotation/meta/
+-rw----     2.0 fat      652 b-  0% stor 19800101.000002 scala/annotation/meta/beanGetter.class
+-rw----     2.0 fat      652 b-  0% stor 19800101.000002 scala/annotation/meta/beanSetter.class
+-rw----     2.0 fat      669 b-  0% stor 19800101.000002 scala/annotation/meta/companionClass.class
+-rw----     2.0 fat      673 b-  0% stor 19800101.000002 scala/annotation/meta/companionMethod.class
+-rw----     2.0 fat      673 b-  0% stor 19800101.000002 scala/annotation/meta/companionObject.class
+-rw----     2.0 fat      631 b-  0% stor 19800101.000002 scala/annotation/meta/field.class
+-rw----     2.0 fat      636 b-  0% stor 19800101.000002 scala/annotation/meta/getter.class
+-rw----     2.0 fat      959 b-  0% stor 19800101.000002 scala/annotation/meta/languageFeature.class
+-rw----     2.0 fat      421 b-  0% stor 19800101.000002 scala/annotation/meta/package$.class
+-rw----     2.0 fat      366 b-  0% stor 19800101.000002 scala/annotation/meta/package.class
+-rw----     2.0 fat      631 b-  0% stor 19800101.000002 scala/annotation/meta/param.class
+-rw----     2.0 fat      636 b-  0% stor 19800101.000002 scala/annotation/meta/setter.class
+-rw----     2.0 fat      890 b-  0% stor 19800101.000002 scala/annotation/migration.class
+-rw----     2.0 fat      522 b-  0% stor 19800101.000002 scala/annotation/showAsInfix$.class
+-rw----     2.0 fat     1097 b-  0% stor 19800101.000002 scala/annotation/showAsInfix.class
+-rw----     2.0 fat      619 b-  0% stor 19800101.000002 scala/annotation/strictfp.class
+-rw----     2.0 fat      611 b-  0% stor 19800101.000002 scala/annotation/switch.class
+-rw----     2.0 fat      615 b-  0% stor 19800101.000002 scala/annotation/tailrec.class
+-rw----     2.0 fat        0 bl  0% defN 19800101.000000 scala/annotation/unchecked/
+-rw----     2.0 fat      689 b-  0% stor 19800101.000002 scala/annotation/unchecked/uncheckedStable.class
+-rw----     2.0 fat      697 b-  0% stor 19800101.000002 scala/annotation/unchecked/uncheckedVariance.class
+-rw----     2.0 fat      640 b-  0% stor 19800101.000002 scala/annotation/unspecialized.class
+-rw----     2.0 fat      615 b-  0% stor 19800101.000002 scala/annotation/varargs.class
+-rw----     2.0 fat        0 bl  0% defN 19800101.000000 scala/beans/
+-rw----     2.0 fat      922 b-  0% stor 19800101.000002 scala/beans/BeanDescription.class
+-rw----     2.0 fat      899 b-  0% stor 19800101.000002 scala/beans/BeanDisplayName.class
+-rw----     2.0 fat      689 b-  0% stor 19800101.000002 scala/beans/BeanInfo.class
+-rw----     2.0 fat      570 b-  0% stor 19800101.000002 scala/beans/BeanInfoSkip.class
+-rw----     2.0 fat      678 b-  0% stor 19800101.000002 scala/beans/BeanProperty.class
+-rw----     2.0 fat      707 b-  0% stor 19800101.000002 scala/beans/BooleanBeanProperty.class
+-rw----     2.0 fat     6138 b-  0% stor 19800101.000002 scala/beans/ScalaBeanInfo.class
+-rw----     2.0 fat        0 bl  0% defN 19800101.000000 scala/collection/
+-rw----     2.0 fat     1489 b-  0% stor 19800101.000002 scala/collection/$colon$plus$.class
+-rw----     2.0 fat      912 b-  0% stor 19800101.000002 scala/collection/$colon$plus.class
+-rw----     2.0 fat     1489 b-  0% stor 19800101.000002 scala/collection/$plus$colon$.class
+-rw----     2.0 fat      912 b-  0% stor 19800101.000002 scala/collection/$plus$colon.class
+-rw----     2.0 fat    10474 b-  0% stor 19800101.000002 scala/collection/AbstractIterable.class
+-rw----     2.0 fat    28653 b-  0% stor 19800101.000002 scala/collection/AbstractIterator.class
+-rw----     2.0 fat    18850 b-  0% stor 19800101.000002 scala/collection/AbstractMap.class
+-rw----     2.0 fat    22450 b-  0% stor 19800101.000002 scala/collection/AbstractSeq.class
+-rw----     2.0 fat    15774 b-  0% stor 19800101.000002 scala/collection/AbstractSet.class
+-rw----     2.0 fat    33564 b-  0% stor 19800101.000002 scala/collection/AbstractTraversable.class
+-rw----     2.0 fat     2029 b-  0% stor 19800101.000002 scala/collection/BitSet$.class
+-rw----     2.0 fat     1811 b-  0% stor 19800101.000002 scala/collection/BitSet.class
+-rw----     2.0 fat     1963 b-  0% stor 19800101.000002 scala/collection/BitSetLike$$anon$1.class
+-rw----     2.0 fat     1265 b-  0% stor 19800101.000002 scala/collection/BitSetLike$.class
+-rw----     2.0 fat    14363 b-  0% stor 19800101.000002 scala/collection/BitSetLike.class
+-rw----     2.0 fat     1825 b-  0% stor 19800101.000002 scala/collection/BufferedIterator.class
+-rw----     2.0 fat     1598 b-  0% stor 19800101.000002 scala/collection/CustomParallelizable.class
+-rw----     2.0 fat     5109 b-  0% stor 19800101.000002 scala/collection/DebugUtils$.class
+-rw----     2.0 fat     1693 b-  0% stor 19800101.000002 scala/collection/DebugUtils.class
+-rw----     2.0 fat     4014 b-  0% stor 19800101.000002 scala/collection/DefaultMap.class
+-rw----     2.0 fat     1308 b-  0% stor 19800101.000002 scala/collection/GenIterable$.class
+-rw----     2.0 fat     8538 b-  0% stor 19800101.000002 scala/collection/GenIterable.class
+-rw----     2.0 fat     2473 b-  0% stor 19800101.000002 scala/collection/GenIterableLike.class
+-rw----     2.0 fat     1396 b-  0% stor 19800101.000002 scala/collection/GenMap$.class
+-rw----     2.0 fat     2055 b-  0% stor 19800101.000002 scala/collection/GenMap.class
+-rw----     2.0 fat     6509 b-  0% stor 19800101.000002 scala/collection/GenMapLike.class
+-rw----     2.0 fat     1268 b-  0% stor 19800101.000002 scala/collection/GenSeq$.class
+-rw----     2.0 fat     8443 b-  0% stor 19800101.000002 scala/collection/GenSeq.class
+-rw----     2.0 fat    11885 b-  0% stor 19800101.000002 scala/collection/GenSeqLike.class
+-rw----     2.0 fat     1278 b-  0% stor 19800101.000002 scala/collection/GenSet$.class
+-rw----     2.0 fat     8476 b-  0% stor 19800101.000002 scala/collection/GenSet.class
+-rw----     2.0 fat     4935 b-  0% stor 19800101.000002 scala/collection/GenSetLike.class
+-rw----     2.0 fat     1332 b-  0% stor 19800101.000002 scala/collection/GenTraversable$.class
+-rw----     2.0 fat    11244 b-  0% stor 19800101.000002 scala/collection/GenTraversable.class
+-rw----     2.0 fat     6211 b-  0% stor 19800101.000002 scala/collection/GenTraversableLike.class
+-rw----     2.0 fat    10338 b-  0% stor 19800101.000002 scala/collection/GenTraversableOnce.class
+-rw----     2.0 fat     1102 b-  0% stor 19800101.000002 scala/collection/IndexedSeq$$anon$1.class
+-rw----     2.0 fat     1925 b-  0% stor 19800101.000002 scala/collection/IndexedSeq$.class
+-rw----     2.0 fat     8946 b-  0% stor 19800101.000002 scala/collection/IndexedSeq.class
+-rw----     2.0 fat     3604 b-  0% stor 19800101.000002 scala/collection/IndexedSeqLike$Elements.class
+-rw----     2.0 fat     4240 b-  0% stor 19800101.000002 scala/collection/IndexedSeqLike.class
+-rw----     2.0 fat     1585 b-  0% stor 19800101.000002 scala/collection/IndexedSeqOptimized$$anon$1.class
+-rw----     2.0 fat    24319 b-  0% stor 19800101.000002 scala/collection/IndexedSeqOptimized.class
+-rw----     2.0 fat     1486 b-  0% stor 19800101.000002 scala/collection/Iterable$.class
+-rw----     2.0 fat     8893 b-  0% stor 19800101.000002 scala/collection/Iterable.class
+-rw----     2.0 fat    45922 b-  0% stor 19800101.000002 scala/collection/IterableLike$$anon$1.class
+-rw----     2.0 fat    20245 b-  0% stor 19800101.000002 scala/collection/IterableLike.class
+-rw----     2.0 fat      863 b-  0% stor 19800101.000002 scala/collection/IterableProxy.class
+-rw----     2.0 fat     7655 b-  0% stor 19800101.000002 scala/collection/IterableProxyLike.class
+-rw----     2.0 fat     1747 b-  0% stor 19800101.000002 scala/collection/IterableView$$anon$1.class
+-rw----     2.0 fat      865 b-  0% stor 19800101.000002 scala/collection/IterableView$.class
+-rw----     2.0 fat     1482 b-  0% stor 19800101.000002 scala/collection/IterableView.class
+-rw----     2.0 fat     2784 b-  0% stor 19800101.000002 scala/collection/IterableViewLike$$anon$1.class
+-rw----     2.0 fat     2177 b-  0% stor 19800101.000002 scala/collection/IterableViewLike$$anon$10.class
+-rw----     2.0 fat     2662 b-  0% stor 19800101.000002 scala/collection/IterableViewLike$$anon$11.class
+-rw----     2.0 fat     2803 b-  0% stor 19800101.000002 scala/collection/IterableViewLike$$anon$2.class
+-rw----     2.0 fat     2813 b-  0% stor 19800101.000002 scala/collection/IterableViewLike$$anon$3.class
+-rw----     2.0 fat     3640 b-  0% stor 19800101.000002 scala/collection/IterableViewLike$$anon$4.class
+-rw----     2.0 fat     3778 b-  0% stor 19800101.000002 scala/collection/IterableViewLike$$anon$5.class
+-rw----     2.0 fat     3703 b-  0% stor 19800101.000002 scala/collection/IterableViewLike$$anon$6.class
+-rw----     2.0 fat     2969 b-  0% stor 19800101.000002 scala/collection/IterableViewLike$$anon$7.class
+-rw----     2.0 fat     2778 b-  0% stor 19800101.000002 scala/collection/IterableViewLike$$anon$8.class
+-rw----     2.0 fat     4067 b-  0% stor 19800101.000002 scala/collection/IterableViewLike$$anon$9.class
+-rw----     2.0 fat    46300 b-  0% stor 19800101.000002 scala/collection/IterableViewLike$AbstractTransformed.class
+-rw----     2.0 fat     2655 b-  0% stor 19800101.000002 scala/collection/IterableViewLike$Appended.class
+-rw----     2.0 fat     1594 b-  0% stor 19800101.000002 scala/collection/IterableViewLike$DroppedWhile.class
+-rw----     2.0 fat     1538 b-  0% stor 19800101.000002 scala/collection/IterableViewLike$EmptyView.class
+-rw----     2.0 fat     1555 b-  0% stor 19800101.000002 scala/collection/IterableViewLike$Filtered.class
+-rw----     2.0 fat     1604 b-  0% stor 19800101.000002 scala/collection/IterableViewLike$FlatMapped.class
+-rw----     2.0 fat     1483 b-  0% stor 19800101.000002 scala/collection/IterableViewLike$Forced.class
+-rw----     2.0 fat     1564 b-  0% stor 19800101.000002 scala/collection/IterableViewLike$Mapped.class
+-rw----     2.0 fat     2722 b-  0% stor 19800101.000002 scala/collection/IterableViewLike$Prepended.class
+-rw----     2.0 fat     1529 b-  0% stor 19800101.000002 scala/collection/IterableViewLike$Sliced.class
+-rw----     2.0 fat     1576 b-  0% stor 19800101.000002 scala/collection/IterableViewLike$TakenWhile.class
+-rw----     2.0 fat     2173 b-  0% stor 19800101.000002 scala/collection/IterableViewLike$Transformed.class
+-rw----     2.0 fat     1841 b-  0% stor 19800101.000002 scala/collection/IterableViewLike$Zipped.class
+-rw----     2.0 fat     2063 b-  0% stor 19800101.000002 scala/collection/IterableViewLike$ZippedAll.class
+-rw----     2.0 fat    20233 b-  0% stor 19800101.000002 scala/collection/IterableViewLike.class
+-rw----     2.0 fat     2306 b-  0% stor 19800101.000002 scala/collection/Iterator$$anon$1.class
+-rw----     2.0 fat     1184 b-  0% stor 19800101.000002 scala/collection/Iterator$$anon$10.class
+-rw----     2.0 fat     1973 b-  0% stor 19800101.000002 scala/collection/Iterator$$anon$11.class
+-rw----     2.0 fat     2055 b-  0% stor 19800101.000002 scala/collection/Iterator$$anon$12.class
+-rw----     2.0 fat     1632 b-  0% stor 19800101.000002 scala/collection/Iterator$$anon$13.class
+-rw----     2.0 fat     1989 b-  0% stor 19800101.000002 scala/collection/Iterator$$anon$14.class
+-rw----     2.0 fat     2378 b-  0% stor 19800101.000002 scala/collection/Iterator$$anon$15.class
+-rw----     2.0 fat     1776 b-  0% stor 19800101.000002 scala/collection/Iterator$$anon$16.class
+-rw----     2.0 fat     1704 b-  0% stor 19800101.000002 scala/collection/Iterator$$anon$17.class
+-rw----     2.0 fat     1344 b-  0% stor 19800101.000002 scala/collection/Iterator$$anon$18.class
+-rw----     2.0 fat     1632 b-  0% stor 19800101.000002 scala/collection/Iterator$$anon$19.class
+-rw----     2.0 fat      924 b-  0% stor 19800101.000002 scala/collection/Iterator$$anon$2.class
+-rw----     2.0 fat     1633 b-  0% stor 19800101.000002 scala/collection/Iterator$$anon$20.class
+-rw----     2.0 fat     1799 b-  0% stor 19800101.000002 scala/collection/Iterator$$anon$21.class
+-rw----     2.0 fat     2116 b-  0% stor 19800101.000002 scala/collection/Iterator$$anon$22.class
+-rw----     2.0 fat     1919 b-  0% stor 19800101.000002 scala/collection/Iterator$$anon$23.class
+-rw----     2.0 fat     1334 b-  0% stor 19800101.000002 scala/collection/Iterator$$anon$3.class
+-rw----     2.0 fat     1448 b-  0% stor 19800101.000002 scala/collection/Iterator$$anon$4.class
+-rw----     2.0 fat     1621 b-  0% stor 19800101.000002 scala/collection/Iterator$$anon$5.class
+-rw----     2.0 fat     1771 b-  0% stor 19800101.000002 scala/collection/Iterator$$anon$6.class
+-rw----     2.0 fat     1202 b-  0% stor 19800101.000002 scala/collection/Iterator$$anon$7.class
+-rw----     2.0 fat     1293 b-  0% stor 19800101.000002 scala/collection/Iterator$$anon$8.class
+-rw----     2.0 fat      936 b-  0% stor 19800101.000002 scala/collection/Iterator$$anon$9.class
+-rw----     2.0 fat     4278 b-  0% stor 19800101.000002 scala/collection/Iterator$.class
+-rw----     2.0 fat    30807 b-  0% stor 19800101.000002 scala/collection/Iterator$ConcatIterator.class
+-rw----     2.0 fat     1686 b-  0% stor 19800101.000002 scala/collection/Iterator$ConcatIteratorCell.class
+-rw----     2.0 fat     9246 b-  0% stor 19800101.000002 scala/collection/Iterator$GroupedIterator.class
+-rw----     2.0 fat     2668 b-  0% stor 19800101.000002 scala/collection/Iterator$Leading$1.class
+-rw----     2.0 fat     2545 b-  0% stor 19800101.000002 scala/collection/Iterator$PartitionIterator$1.class
+-rw----     2.0 fat     2363 b-  0% stor 19800101.000002 scala/collection/Iterator$Partner$1.class
+-rw----     2.0 fat     3071 b-  0% stor 19800101.000002 scala/collection/Iterator$SliceIterator.class
+-rw----     2.0 fat    34873 b-  0% stor 19800101.000002 scala/collection/Iterator.class
+-rw----     2.0 fat    16869 b-  0% stor 19800101.000002 scala/collection/JavaConversions$.class
+-rw----     2.0 fat     7722 b-  0% stor 19800101.000002 scala/collection/JavaConversions.class
+-rw----     2.0 fat    22368 b-  0% stor 19800101.000002 scala/collection/JavaConverters$.class
+-rw----     2.0 fat    12862 b-  0% stor 19800101.000002 scala/collection/JavaConverters.class
+-rw----     2.0 fat     1400 b-  0% stor 19800101.000002 scala/collection/LinearSeq$.class
+-rw----     2.0 fat     8797 b-  0% stor 19800101.000002 scala/collection/LinearSeq.class
+-rw----     2.0 fat     1872 b-  0% stor 19800101.000002 scala/collection/LinearSeqLike$$anon$1.class
+-rw----     2.0 fat     3845 b-  0% stor 19800101.000002 scala/collection/LinearSeqLike.class
+-rw----     2.0 fat    15936 b-  0% stor 19800101.000002 scala/collection/LinearSeqOptimized.class
+-rw----     2.0 fat     1509 b-  0% stor 19800101.000002 scala/collection/Map$.class
+-rw----     2.0 fat     1617 b-  0% stor 19800101.000002 scala/collection/Map$WithDefault.class
+-rw----     2.0 fat     2780 b-  0% stor 19800101.000002 scala/collection/Map.class
+-rw----     2.0 fat     1319 b-  0% stor 19800101.000002 scala/collection/MapLike$$anon$1.class
+-rw----     2.0 fat     1321 b-  0% stor 19800101.000002 scala/collection/MapLike$$anon$2.class
+-rw----     2.0 fat     2748 b-  0% stor 19800101.000002 scala/collection/MapLike$DefaultKeySet.class
+-rw----     2.0 fat     1502 b-  0% stor 19800101.000002 scala/collection/MapLike$DefaultValuesIterable.class
+-rw----     2.0 fat     5165 b-  0% stor 19800101.000002 scala/collection/MapLike$FilteredKeys.class
+-rw----     2.0 fat     6241 b-  0% stor 19800101.000002 scala/collection/MapLike$MappedValues.class
+-rw----     2.0 fat    20848 b-  0% stor 19800101.000002 scala/collection/MapLike.class
+-rw----     2.0 fat      859 b-  0% stor 19800101.000002 scala/collection/MapProxy.class
+-rw----     2.0 fat    11152 b-  0% stor 19800101.000002 scala/collection/MapProxyLike.class
+-rw----     2.0 fat      336 b-  0% stor 19800101.000002 scala/collection/Parallel.class
+-rw----     2.0 fat     3071 b-  0% stor 19800101.000002 scala/collection/Parallelizable.class
+-rw----     2.0 fat     1279 b-  0% stor 19800101.000002 scala/collection/Searching$.class
+-rw----     2.0 fat     1844 b-  0% stor 19800101.000002 scala/collection/Searching$Found$.class
+-rw----     2.0 fat     2602 b-  0% stor 19800101.000002 scala/collection/Searching$Found.class
+-rw----     2.0 fat     1938 b-  0% stor 19800101.000002 scala/collection/Searching$InsertionPoint$.class
+-rw----     2.0 fat     2559 b-  0% stor 19800101.000002 scala/collection/Searching$InsertionPoint.class
+-rw----     2.0 fat     4662 b-  0% stor 19800101.000002 scala/collection/Searching$SearchImpl.class
+-rw----     2.0 fat      478 b-  0% stor 19800101.000002 scala/collection/Searching$SearchResult.class
+-rw----     2.0 fat     3663 b-  0% stor 19800101.000002 scala/collection/Searching.class
+-rw----     2.0 fat     1346 b-  0% stor 19800101.000002 scala/collection/Seq$.class
+-rw----     2.0 fat     8991 b-  0% stor 19800101.000002 scala/collection/Seq.class
+-rw----     2.0 fat      557 b-  0% stor 19800101.000002 scala/collection/SeqExtractors.class
+-rw----     2.0 fat     1154 b-  0% stor 19800101.000002 scala/collection/SeqLike$$anon$1.class
+-rw----     2.0 fat    66364 b-  0% stor 19800101.000002 scala/collection/SeqLike$$anon$2.class
+-rw----     2.0 fat     7975 b-  0% stor 19800101.000002 scala/collection/SeqLike$$anon$3.class
+-rw----     2.0 fat     7972 b-  0% stor 19800101.000002 scala/collection/SeqLike$$anon$4.class
+-rw----     2.0 fat     8843 b-  0% stor 19800101.000002 scala/collection/SeqLike$$anon$5.class
+-rw----     2.0 fat     5678 b-  0% stor 19800101.000002 scala/collection/SeqLike$.class
+-rw----     2.0 fat    11393 b-  0% stor 19800101.000002 scala/collection/SeqLike$CombinationsItr.class
+-rw----     2.0 fat     6942 b-  0% stor 19800101.000002 scala/collection/SeqLike$PermutationsItr.class
+-rw----     2.0 fat    32822 b-  0% stor 19800101.000002 scala/collection/SeqLike.class
+-rw----     2.0 fat      811 b-  0% stor 19800101.000002 scala/collection/SeqProxy.class
+-rw----     2.0 fat    21800 b-  0% stor 19800101.000002 scala/collection/SeqProxyLike.class
+-rw----     2.0 fat     1717 b-  0% stor 19800101.000002 scala/collection/SeqView$$anon$1.class
+-rw----     2.0 fat      835 b-  0% stor 19800101.000002 scala/collection/SeqView$.class
+-rw----     2.0 fat     1414 b-  0% stor 19800101.000002 scala/collection/SeqView.class
+-rw----     2.0 fat     3626 b-  0% stor 19800101.000002 scala/collection/SeqViewLike$$anon$1.class
+-rw----     2.0 fat     3695 b-  0% stor 19800101.000002 scala/collection/SeqViewLike$$anon$10.class
+-rw----     2.0 fat     4178 b-  0% stor 19800101.000002 scala/collection/SeqViewLike$$anon$11.class
+-rw----     2.0 fat     2304 b-  0% stor 19800101.000002 scala/collection/SeqViewLike$$anon$12.class
+-rw----     2.0 fat     3370 b-  0% stor 19800101.000002 scala/collection/SeqViewLike$$anon$13.class
+-rw----     2.0 fat     4225 b-  0% stor 19800101.000002 scala/collection/SeqViewLike$$anon$2.class
+-rw----     2.0 fat     4238 b-  0% stor 19800101.000002 scala/collection/SeqViewLike$$anon$3.class
+-rw----     2.0 fat     4441 b-  0% stor 19800101.000002 scala/collection/SeqViewLike$$anon$4.class
+-rw----     2.0 fat     5214 b-  0% stor 19800101.000002 scala/collection/SeqViewLike$$anon$5.class
+-rw----     2.0 fat     4924 b-  0% stor 19800101.000002 scala/collection/SeqViewLike$$anon$6.class
+-rw----     2.0 fat     3762 b-  0% stor 19800101.000002 scala/collection/SeqViewLike$$anon$7.class
+-rw----     2.0 fat     4010 b-  0% stor 19800101.000002 scala/collection/SeqViewLike$$anon$8.class
+-rw----     2.0 fat     5234 b-  0% stor 19800101.000002 scala/collection/SeqViewLike$$anon$9.class
+-rw----     2.0 fat    66682 b-  0% stor 19800101.000002 scala/collection/SeqViewLike$AbstractTransformed.class
+-rw----     2.0 fat     2150 b-  0% stor 19800101.000002 scala/collection/SeqViewLike$Appended.class
+-rw----     2.0 fat     2157 b-  0% stor 19800101.000002 scala/collection/SeqViewLike$DroppedWhile.class
+-rw----     2.0 fat     1721 b-  0% stor 19800101.000002 scala/collection/SeqViewLike$EmptyView.class
+-rw----     2.0 fat     3658 b-  0% stor 19800101.000002 scala/collection/SeqViewLike$Filtered.class
+-rw----     2.0 fat     4223 b-  0% stor 19800101.000002 scala/collection/SeqViewLike$FlatMapped.class
+-rw----     2.0 fat     1649 b-  0% stor 19800101.000002 scala/collection/SeqViewLike$Forced.class
+-rw----     2.0 fat     1706 b-  0% stor 19800101.000002 scala/collection/SeqViewLike$Mapped.class
+-rw----     2.0 fat     3049 b-  0% stor 19800101.000002 scala/collection/SeqViewLike$Patched.class
+-rw----     2.0 fat     2162 b-  0% stor 19800101.000002 scala/collection/SeqViewLike$Prepended.class
+-rw----     2.0 fat     3953 b-  0% stor 19800101.000002 scala/collection/SeqViewLike$Reversed.class
+-rw----     2.0 fat     2863 b-  0% stor 19800101.000002 scala/collection/SeqViewLike$Sliced.class
+-rw----     2.0 fat     2114 b-  0% stor 19800101.000002 scala/collection/SeqViewLike$TakenWhile.class
+-rw----     2.0 fat     1380 b-  0% stor 19800101.000002 scala/collection/SeqViewLike$Transformed.class
+-rw----     2.0 fat     2371 b-  0% stor 19800101.000002 scala/collection/SeqViewLike$Zipped.class
+-rw----     2.0 fat     2761 b-  0% stor 19800101.000002 scala/collection/SeqViewLike$ZippedAll.class
+-rw----     2.0 fat    28923 b-  0% stor 19800101.000002 scala/collection/SeqViewLike.class
+-rw----     2.0 fat     1436 b-  0% stor 19800101.000002 scala/collection/Set$.class
+-rw----     2.0 fat     2521 b-  0% stor 19800101.000002 scala/collection/Set.class
+-rw----     2.0 fat     2607 b-  0% stor 19800101.000002 scala/collection/SetLike$$anon$1.class
+-rw----     2.0 fat     5003 b-  0% stor 19800101.000002 scala/collection/SetLike$SubsetsItr.class
+-rw----     2.0 fat    12171 b-  0% stor 19800101.000002 scala/collection/SetLike.class
+-rw----     2.0 fat      809 b-  0% stor 19800101.000002 scala/collection/SetProxy.class
+-rw----     2.0 fat     5308 b-  0% stor 19800101.000002 scala/collection/SetProxyLike.class
+-rw----     2.0 fat     1750 b-  0% stor 19800101.000002 scala/collection/SortedMap$.class
+-rw----     2.0 fat     4233 b-  0% stor 19800101.000002 scala/collection/SortedMap$Default.class
+-rw----     2.0 fat     3468 b-  0% stor 19800101.000002 scala/collection/SortedMap.class
+-rw----     2.0 fat     2280 b-  0% stor 19800101.000002 scala/collection/SortedMapLike$$anon$1$$anonfun$valuesIteratorFrom$1.class
+-rw----     2.0 fat    15219 b-  0% stor 19800101.000002 scala/collection/SortedMapLike$$anon$1.class
+-rw----     2.0 fat    14803 b-  0% stor 19800101.000002 scala/collection/SortedMapLike$$anon$2.class
+-rw----     2.0 fat     9430 b-  0% stor 19800101.000002 scala/collection/SortedMapLike$DefaultKeySortedSet.class
+-rw----     2.0 fat     9177 b-  0% stor 19800101.000002 scala/collection/SortedMapLike.class
+-rw----     2.0 fat     1993 b-  0% stor 19800101.000002 scala/collection/SortedSet$.class
+-rw----     2.0 fat     2681 b-  0% stor 19800101.000002 scala/collection/SortedSet.class
+-rw----     2.0 fat     5155 b-  0% stor 19800101.000002 scala/collection/SortedSetLike.class
+-rw----     2.0 fat     1726 b-  0% stor 19800101.000002 scala/collection/Traversable$.class
+-rw----     2.0 fat     8955 b-  0% stor 19800101.000002 scala/collection/Traversable.class
+-rw----     2.0 fat    39768 b-  0% stor 19800101.000002 scala/collection/TraversableLike$$anon$1.class
+-rw----     2.0 fat     5694 b-  0% stor 19800101.000002 scala/collection/TraversableLike$WithFilter.class
+-rw----     2.0 fat    50212 b-  0% stor 19800101.000002 scala/collection/TraversableLike.class
+-rw----     2.0 fat     1184 b-  0% stor 19800101.000002 scala/collection/TraversableOnce$$anon$2.class
+-rw----     2.0 fat     2362 b-  0% stor 19800101.000002 scala/collection/TraversableOnce$.class
+-rw----     2.0 fat     3768 b-  0% stor 19800101.000002 scala/collection/TraversableOnce$BufferedCanBuildFrom.class
+-rw----     2.0 fat     2227 b-  0% stor 19800101.000002 scala/collection/TraversableOnce$FlattenOps$$anon$1.class
+-rw----     2.0 fat     1186 b-  0% stor 19800101.000002 scala/collection/TraversableOnce$FlattenOps.class
+-rw----     2.0 fat      492 b-  0% stor 19800101.000002 scala/collection/TraversableOnce$ForceImplicitAmbiguity.class
+-rw----     2.0 fat     1864 b-  0% stor 19800101.000002 scala/collection/TraversableOnce$MonadOps.class
+-rw----     2.0 fat     1891 b-  0% stor 19800101.000002 scala/collection/TraversableOnce$OnceCanBuildFrom.class
+-rw----     2.0 fat    38660 b-  0% stor 19800101.000002 scala/collection/TraversableOnce.class
+-rw----     2.0 fat      894 b-  0% stor 19800101.000002 scala/collection/TraversableProxy.class
+-rw----     2.0 fat    30943 b-  0% stor 19800101.000002 scala/collection/TraversableProxyLike.class
+-rw----     2.0 fat     1765 b-  0% stor 19800101.000002 scala/collection/TraversableView$$anon$1.class
+-rw----     2.0 fat      883 b-  0% stor 19800101.000002 scala/collection/TraversableView$.class
+-rw----     2.0 fat     4515 b-  0% stor 19800101.000002 scala/collection/TraversableView$NoBuilder.class
+-rw----     2.0 fat     1813 b-  0% stor 19800101.000002 scala/collection/TraversableView.class
+-rw----     2.0 fat     2255 b-  0% stor 19800101.000002 scala/collection/TraversableViewLike$$anon$1.class
+-rw----     2.0 fat     2270 b-  0% stor 19800101.000002 scala/collection/TraversableViewLike$$anon$2.class
+-rw----     2.0 fat     2276 b-  0% stor 19800101.000002 scala/collection/TraversableViewLike$$anon$3.class
+-rw----     2.0 fat     3111 b-  0% stor 19800101.000002 scala/collection/TraversableViewLike$$anon$4.class
+-rw----     2.0 fat     3233 b-  0% stor 19800101.000002 scala/collection/TraversableViewLike$$anon$5.class
+-rw----     2.0 fat     3151 b-  0% stor 19800101.000002 scala/collection/TraversableViewLike$$anon$6.class
+-rw----     2.0 fat     2425 b-  0% stor 19800101.000002 scala/collection/TraversableViewLike$$anon$7.class
+-rw----     2.0 fat     2210 b-  0% stor 19800101.000002 scala/collection/TraversableViewLike$$anon$8.class
+-rw----     2.0 fat     3511 b-  0% stor 19800101.000002 scala/collection/TraversableViewLike$$anon$9.class
+-rw----     2.0 fat    39734 b-  0% stor 19800101.000002 scala/collection/TraversableViewLike$AbstractTransformed.class
+-rw----     2.0 fat     1832 b-  0% stor 19800101.000002 scala/collection/TraversableViewLike$Appended.class
+-rw----     2.0 fat     3424 b-  0% stor 19800101.000002 scala/collection/TraversableViewLike$DroppedWhile.class
+-rw----     2.0 fat     1567 b-  0% stor 19800101.000002 scala/collection/TraversableViewLike$EmptyView.class
+-rw----     2.0 fat     3139 b-  0% stor 19800101.000002 scala/collection/TraversableViewLike$Filtered.class
+-rw----     2.0 fat     3753 b-  0% stor 19800101.000002 scala/collection/TraversableViewLike$FlatMapped.class
+-rw----     2.0 fat     1747 b-  0% stor 19800101.000002 scala/collection/TraversableViewLike$Forced.class
+-rw----     2.0 fat     2936 b-  0% stor 19800101.000002 scala/collection/TraversableViewLike$Mapped.class
+-rw----     2.0 fat     1839 b-  0% stor 19800101.000002 scala/collection/TraversableViewLike$Prepended.class
+-rw----     2.0 fat     4468 b-  0% stor 19800101.000002 scala/collection/TraversableViewLike$Sliced.class
+-rw----     2.0 fat     3699 b-  0% stor 19800101.000002 scala/collection/TraversableViewLike$TakenWhile.class
+-rw----     2.0 fat     5288 b-  0% stor 19800101.000002 scala/collection/TraversableViewLike$Transformed.class
+-rw----     2.0 fat    33825 b-  0% stor 19800101.000002 scala/collection/TraversableViewLike.class
+-rw----     2.0 fat     5350 b-  0% stor 19800101.000002 scala/collection/ViewMkString.class
+-rw----     2.0 fat        0 bl  0% defN 19800101.000000 scala/collection/concurrent/
+-rw----     2.0 fat      349 b-  0% stor 19800101.000002 scala/collection/concurrent/BasicNode.class
+-rw----     2.0 fat     2101 b-  0% stor 19800101.000002 scala/collection/concurrent/CNode$.class
+-rw----     2.0 fat    14002 b-  0% stor 19800101.000002 scala/collection/concurrent/CNode.class
+-rw----     2.0 fat     1501 b-  0% stor 19800101.000002 scala/collection/concurrent/CNodeBase.class
+-rw----     2.0 fat     3338 b-  0% stor 19800101.000002 scala/collection/concurrent/Debug$.class
+-rw----     2.0 fat     1050 b-  0% stor 19800101.000002 scala/collection/concurrent/Debug.class
+-rw----     2.0 fat     2315 b-  0% stor 19800101.000002 scala/collection/concurrent/FailedNode.class
+-rw----     2.0 fat      290 b-  0% stor 19800101.000002 scala/collection/concurrent/Gen.class
+-rw----     2.0 fat     1412 b-  0% stor 19800101.000002 scala/collection/concurrent/INode$.class
+-rw----     2.0 fat    22363 b-  0% stor 19800101.000002 scala/collection/concurrent/INode.class
+-rw----     2.0 fat     1558 b-  0% stor 19800101.000002 scala/collection/concurrent/INodeBase.class
+-rw----     2.0 fat      640 b-  0% stor 19800101.000002 scala/collection/concurrent/KVNode.class
+-rw----     2.0 fat     5579 b-  0% stor 19800101.000002 scala/collection/concurrent/LNode.class
+-rw----     2.0 fat     2161 b-  0% stor 19800101.000002 scala/collection/concurrent/MainNode.class
+-rw----     2.0 fat     2995 b-  0% stor 19800101.000002 scala/collection/concurrent/Map.class
+-rw----     2.0 fat     2377 b-  0% stor 19800101.000002 scala/collection/concurrent/RDCSS_Descriptor$.class
+-rw----     2.0 fat     7099 b-  0% stor 19800101.000002 scala/collection/concurrent/RDCSS_Descriptor.class
+-rw----     2.0 fat     1032 b-  0% stor 19800101.000002 scala/collection/concurrent/RestartException$.class
+-rw----     2.0 fat     1713 b-  0% stor 19800101.000002 scala/collection/concurrent/RestartException.class
+-rw----     2.0 fat     3443 b-  0% stor 19800101.000002 scala/collection/concurrent/SNode.class
+-rw----     2.0 fat     3636 b-  0% stor 19800101.000002 scala/collection/concurrent/TNode.class
+-rw----     2.0 fat     2570 b-  0% stor 19800101.000002 scala/collection/concurrent/TrieMap$.class
+-rw----     2.0 fat      954 b-  0% stor 19800101.000002 scala/collection/concurrent/TrieMap$MangledHashing.class
+-rw----     2.0 fat    78520 b-  0% stor 19800101.000002 scala/collection/concurrent/TrieMap.class
+-rw----     2.0 fat      616 b-  0% stor 19800101.000002 scala/collection/concurrent/TrieMapIterator$.class
+-rw----     2.0 fat    38860 b-  0% stor 19800101.000002 scala/collection/concurrent/TrieMapIterator.class
+-rw----     2.0 fat     1920 b-  0% stor 19800101.000002 scala/collection/concurrent/TrieMapSerializationEnd$.class
+-rw----     2.0 fat     1662 b-  0% stor 19800101.000002 scala/collection/concurrent/TrieMapSerializationEnd.class
+-rw----     2.0 fat        0 bl  0% defN 19800101.000000 scala/collection/convert/
+-rw----     2.0 fat    13467 b-  0% stor 19800101.000002 scala/collection/convert/AsJavaConverters.class
+-rw----     2.0 fat    11210 b-  0% stor 19800101.000002 scala/collection/convert/AsScalaConverters.class
+-rw----     2.0 fat    16521 b-  0% stor 19800101.000002 scala/collection/convert/DecorateAsJava.class
+-rw----     2.0 fat    14195 b-  0% stor 19800101.000002 scala/collection/convert/DecorateAsScala.class
+-rw----     2.0 fat      440 b-  0% stor 19800101.000002 scala/collection/convert/Decorators$.class
+-rw----     2.0 fat      857 b-  0% stor 19800101.000002 scala/collection/convert/Decorators$AsJava.class
+-rw----     2.0 fat     1085 b-  0% stor 19800101.000002 scala/collection/convert/Decorators$AsJavaCollection.class
+-rw----     2.0 fat     1129 b-  0% stor 19800101.000002 scala/collection/convert/Decorators$AsJavaDictionary.class
+-rw----     2.0 fat     1092 b-  0% stor 19800101.000002 scala/collection/convert/Decorators$AsJavaEnumeration.class
+-rw----     2.0 fat      861 b-  0% stor 19800101.000002 scala/collection/convert/Decorators$AsScala.class
+-rw----     2.0 fat     1653 b-  0% stor 19800101.000002 scala/collection/convert/Decorators.class
+-rw----     2.0 fat    10573 b-  0% stor 19800101.000002 scala/collection/convert/ImplicitConversions$.class
+-rw----     2.0 fat     5812 b-  0% stor 19800101.000002 scala/collection/convert/ImplicitConversions.class
+-rw----     2.0 fat     6097 b-  0% stor 19800101.000002 scala/collection/convert/ImplicitConversionsToJava$.class
+-rw----     2.0 fat     3500 b-  0% stor 19800101.000002 scala/collection/convert/ImplicitConversionsToJava.class
+-rw----     2.0 fat     5022 b-  0% stor 19800101.000002 scala/collection/convert/ImplicitConversionsToScala$.class
+-rw----     2.0 fat     2944 b-  0% stor 19800101.000002 scala/collection/convert/ImplicitConversionsToScala.class
+-rw----     2.0 fat    13572 b-  0% stor 19800101.000002 scala/collection/convert/LowPriorityWrapAsJava.class
+-rw----     2.0 fat    11287 b-  0% stor 19800101.000002 scala/collection/convert/LowPriorityWrapAsScala.class
+-rw----     2.0 fat     9430 b-  0% stor 19800101.000002 scala/collection/convert/ToJavaImplicits.class
+-rw----     2.0 fat     7777 b-  0% stor 19800101.000002 scala/collection/convert/ToScalaImplicits.class
+-rw----     2.0 fat     9571 b-  0% stor 19800101.000002 scala/collection/convert/WrapAsJava$.class
+-rw----     2.0 fat    10058 b-  0% stor 19800101.000002 scala/collection/convert/WrapAsJava.class
+-rw----     2.0 fat     7814 b-  0% stor 19800101.000002 scala/collection/convert/WrapAsScala$.class
+-rw----     2.0 fat     8332 b-  0% stor 19800101.000002 scala/collection/convert/WrapAsScala.class
+-rw----     2.0 fat     9868 b-  0% stor 19800101.000002 scala/collection/convert/Wrappers$.class
+-rw----     2.0 fat     5799 b-  0% stor 19800101.000002 scala/collection/convert/Wrappers$ConcurrentMapWrapper.class
+-rw----     2.0 fat     1927 b-  0% stor 19800101.000002 scala/collection/convert/Wrappers$DictionaryWrapper$.class
+-rw----     2.0 fat     5439 b-  0% stor 19800101.000002 scala/collection/convert/Wrappers$DictionaryWrapper.class
+-rw----     2.0 fat     1837 b-  0% stor 19800101.000002 scala/collection/convert/Wrappers$IterableWrapper$.class
+-rw----     2.0 fat     4557 b-  0% stor 19800101.000002 scala/collection/convert/Wrappers$IterableWrapper.class
+-rw----     2.0 fat     2042 b-  0% stor 19800101.000002 scala/collection/convert/Wrappers$IterableWrapperTrait.class
+-rw----     2.0 fat     1837 b-  0% stor 19800101.000002 scala/collection/convert/Wrappers$IteratorWrapper$.class
+-rw----     2.0 fat     4587 b-  0% stor 19800101.000002 scala/collection/convert/Wrappers$IteratorWrapper.class
+-rw----     2.0 fat     1837 b-  0% stor 19800101.000002 scala/collection/convert/Wrappers$JCollectionWrapper$.class
+-rw----     2.0 fat     4045 b-  0% stor 19800101.000002 scala/collection/convert/Wrappers$JCollectionWrapper.class
+-rw----     2.0 fat     2003 b-  0% stor 19800101.000002 scala/collection/convert/Wrappers$JConcurrentMapWrapper$.class
+-rw----     2.0 fat    13969 b-  0% stor 19800101.000002 scala/collection/convert/Wrappers$JConcurrentMapWrapper.class
+-rw----     2.0 fat     1889 b-  0% stor 19800101.000002 scala/collection/convert/Wrappers$JDictionaryWrapper$.class
+-rw----     2.0 fat     7116 b-  0% stor 19800101.000002 scala/collection/convert/Wrappers$JDictionaryWrapper.class
+-rw----     2.0 fat     1853 b-  0% stor 19800101.000002 scala/collection/convert/Wrappers$JEnumerationWrapper$.class
+-rw----     2.0 fat     3610 b-  0% stor 19800101.000002 scala/collection/convert/Wrappers$JEnumerationWrapper.class
+-rw----     2.0 fat     1805 b-  0% stor 19800101.000002 scala/collection/convert/Wrappers$JIterableWrapper$.class
+-rw----     2.0 fat     3828 b-  0% stor 19800101.000002 scala/collection/convert/Wrappers$JIterableWrapper.class
+-rw----     2.0 fat     1805 b-  0% stor 19800101.000002 scala/collection/convert/Wrappers$JIteratorWrapper$.class
+-rw----     2.0 fat     3530 b-  0% stor 19800101.000002 scala/collection/convert/Wrappers$JIteratorWrapper.class
+-rw----     2.0 fat     1741 b-  0% stor 19800101.000002 scala/collection/convert/Wrappers$JListWrapper$.class
+-rw----     2.0 fat     7095 b-  0% stor 19800101.000002 scala/collection/convert/Wrappers$JListWrapper.class
+-rw----     2.0 fat     1777 b-  0% stor 19800101.000002 scala/collection/convert/Wrappers$JMapWrapper$.class
+-rw----     2.0 fat    11809 b-  0% stor 19800101.000002 scala/collection/convert/Wrappers$JMapWrapper.class
+-rw----     2.0 fat     1967 b-  0% stor 19800101.000002 scala/collection/convert/Wrappers$JMapWrapperLike$$anon$2.class
+-rw----     2.0 fat     5250 b-  0% stor 19800101.000002 scala/collection/convert/Wrappers$JMapWrapperLike.class
+-rw----     2.0 fat     2087 b-  0% stor 19800101.000002 scala/collection/convert/Wrappers$JPropertiesWrapper$$anon$3.class
+-rw----     2.0 fat     2035 b-  0% stor 19800101.000002 scala/collection/convert/Wrappers$JPropertiesWrapper$.class
+-rw----     2.0 fat    11857 b-  0% stor 19800101.000002 scala/collection/convert/Wrappers$JPropertiesWrapper.class
+-rw----     2.0 fat     1725 b-  0% stor 19800101.000002 scala/collection/convert/Wrappers$JSetWrapper$.class
+-rw----     2.0 fat     9489 b-  0% stor 19800101.000002 scala/collection/convert/Wrappers$JSetWrapper.class
+-rw----     2.0 fat     2691 b-  0% stor 19800101.000002 scala/collection/convert/Wrappers$MapWrapper$$anon$1$$anon$5$$anon$6.class
+-rw----     2.0 fat     4111 b-  0% stor 19800101.000002 scala/collection/convert/Wrappers$MapWrapper$$anon$1$$anon$5.class
+-rw----     2.0 fat     1528 b-  0% stor 19800101.000002 scala/collection/convert/Wrappers$MapWrapper$$anon$1.class
+-rw----     2.0 fat     2494 b-  0% stor 19800101.000002 scala/collection/convert/Wrappers$MapWrapper.class
+-rw----     2.0 fat     1923 b-  0% stor 19800101.000002 scala/collection/convert/Wrappers$MutableBufferWrapper$.class
+-rw----     2.0 fat     5185 b-  0% stor 19800101.000002 scala/collection/convert/Wrappers$MutableBufferWrapper.class
+-rw----     2.0 fat     1927 b-  0% stor 19800101.000002 scala/collection/convert/Wrappers$MutableMapWrapper$.class
+-rw----     2.0 fat     4174 b-  0% stor 19800101.000002 scala/collection/convert/Wrappers$MutableMapWrapper.class
+-rw----     2.0 fat     1875 b-  0% stor 19800101.000002 scala/collection/convert/Wrappers$MutableSeqWrapper$.class
+-rw----     2.0 fat     4710 b-  0% stor 19800101.000002 scala/collection/convert/Wrappers$MutableSeqWrapper.class
+-rw----     2.0 fat     1875 b-  0% stor 19800101.000002 scala/collection/convert/Wrappers$MutableSetWrapper$.class
+-rw----     2.0 fat     3614 b-  0% stor 19800101.000002 scala/collection/convert/Wrappers$MutableSetWrapper.class
+-rw----     2.0 fat     1757 b-  0% stor 19800101.000002 scala/collection/convert/Wrappers$SeqWrapper$.class
+-rw----     2.0 fat     4327 b-  0% stor 19800101.000002 scala/collection/convert/Wrappers$SeqWrapper.class
+-rw----     2.0 fat     3037 b-  0% stor 19800101.000002 scala/collection/convert/Wrappers$SetWrapper$$anon$4.class
+-rw----     2.0 fat     1966 b-  0% stor 19800101.000002 scala/collection/convert/Wrappers$SetWrapper.class
+-rw----     2.0 fat     1437 b-  0% stor 19800101.000002 scala/collection/convert/Wrappers$ToIteratorWrapper.class
+-rw----     2.0 fat    22532 b-  0% stor 19800101.000002 scala/collection/convert/Wrappers.class
+-rw----     2.0 fat    16873 b-  0% stor 19800101.000002 scala/collection/convert/package$$anon$1.class
+-rw----     2.0 fat    12861 b-  0% stor 19800101.000002 scala/collection/convert/package$$anon$2.class
+-rw----     2.0 fat    10061 b-  0% stor 19800101.000002 scala/collection/convert/package$$anon$3.class
+-rw----     2.0 fat     9574 b-  0% stor 19800101.000002 scala/collection/convert/package$$anon$4.class
+-rw----     2.0 fat     7814 b-  0% stor 19800101.000002 scala/collection/convert/package$$anon$5.class
+-rw----     2.0 fat     1946 b-  0% stor 19800101.000002 scala/collection/convert/package$.class
+-rw----     2.0 fat     1884 b-  0% stor 19800101.000002 scala/collection/convert/package.class
+-rw----     2.0 fat        0 bl  0% defN 19800101.000000 scala/collection/generic/
+-rw----     2.0 fat     2713 b-  0% stor 19800101.000002 scala/collection/generic/AtomicIndexFlag.class
+-rw----     2.0 fat      449 b-  0% stor 19800101.000002 scala/collection/generic/BitOperations$.class
+-rw----     2.0 fat     2761 b-  0% stor 19800101.000002 scala/collection/generic/BitOperations$Int$.class
+-rw----     2.0 fat     6124 b-  0% stor 19800101.000002 scala/collection/generic/BitOperations$Int.class
+-rw----     2.0 fat     2775 b-  0% stor 19800101.000002 scala/collection/generic/BitOperations$Long$.class
+-rw----     2.0 fat     6260 b-  0% stor 19800101.000002 scala/collection/generic/BitOperations$Long.class
+-rw----     2.0 fat     1928 b-  0% stor 19800101.000002 scala/collection/generic/BitOperations.class
+-rw----     2.0 fat     1654 b-  0% stor 19800101.000002 scala/collection/generic/BitSetFactory$$anon$1.class
+-rw----     2.0 fat     3958 b-  0% stor 19800101.000002 scala/collection/generic/BitSetFactory.class
+-rw----     2.0 fat     1157 b-  0% stor 19800101.000002 scala/collection/generic/CanBuildFrom.class
+-rw----     2.0 fat     1203 b-  0% stor 19800101.000002 scala/collection/generic/CanCombineFrom.class
+-rw----     2.0 fat     2221 b-  0% stor 19800101.000002 scala/collection/generic/ClassTagTraversableFactory$GenericCanBuildFrom.class
+-rw----     2.0 fat     1521 b-  0% stor 19800101.000002 scala/collection/generic/ClassTagTraversableFactory.class
+-rw----     2.0 fat      428 b-  0% stor 19800101.000002 scala/collection/generic/Clearable.class
+-rw----     2.0 fat     2002 b-  0% stor 19800101.000002 scala/collection/generic/DefaultSignalling.class
+-rw----     2.0 fat     2296 b-  0% stor 19800101.000002 scala/collection/generic/DelegatedContext.class
+-rw----     2.0 fat     2924 b-  0% stor 19800101.000002 scala/collection/generic/DelegatedSignalling.class
+-rw----     2.0 fat     1775 b-  0% stor 19800101.000002 scala/collection/generic/FilterMonadic.class
+-rw----     2.0 fat     1814 b-  0% stor 19800101.000002 scala/collection/generic/GenMapFactory$MapCanBuildFrom.class
+-rw----     2.0 fat     2529 b-  0% stor 19800101.000002 scala/collection/generic/GenMapFactory.class
+-rw----     2.0 fat      955 b-  0% stor 19800101.000002 scala/collection/generic/GenSeqFactory.class
+-rw----     2.0 fat     1719 b-  0% stor 19800101.000002 scala/collection/generic/GenSetFactory$$anon$1.class
+-rw----     2.0 fat     1807 b-  0% stor 19800101.000002 scala/collection/generic/GenSetFactory.class
+-rw----     2.0 fat     1203 b-  0% stor 19800101.000002 scala/collection/generic/GenTraversableFactory$$anon$1.class
+-rw----     2.0 fat     1875 b-  0% stor 19800101.000002 scala/collection/generic/GenTraversableFactory$GenericCanBuildFrom.class
+-rw----     2.0 fat    22262 b-  0% stor 19800101.000002 scala/collection/generic/GenTraversableFactory.class
+-rw----     2.0 fat     2354 b-  0% stor 19800101.000002 scala/collection/generic/GenericClassTagCompanion.class
+-rw----     2.0 fat     3444 b-  0% stor 19800101.000002 scala/collection/generic/GenericClassTagTraversableTemplate.class
+-rw----     2.0 fat     2085 b-  0% stor 19800101.000002 scala/collection/generic/GenericCompanion.class
+-rw----     2.0 fat     2335 b-  0% stor 19800101.000002 scala/collection/generic/GenericOrderedCompanion.class
+-rw----     2.0 fat     2358 b-  0% stor 19800101.000002 scala/collection/generic/GenericOrderedTraversableTemplate.class
+-rw----     2.0 fat      941 b-  0% stor 19800101.000002 scala/collection/generic/GenericParCompanion.class
+-rw----     2.0 fat      955 b-  0% stor 19800101.000002 scala/collection/generic/GenericParMapCompanion.class
+-rw----     2.0 fat     2442 b-  0% stor 19800101.000002 scala/collection/generic/GenericParMapTemplate.class
+-rw----     2.0 fat     3128 b-  0% stor 19800101.000002 scala/collection/generic/GenericParTemplate.class
+-rw----     2.0 fat      623 b-  0% stor 19800101.000002 scala/collection/generic/GenericSeqCompanion.class
+-rw----     2.0 fat     1617 b-  0% stor 19800101.000002 scala/collection/generic/GenericSetTemplate.class
+-rw----     2.0 fat    12300 b-  0% stor 19800101.000002 scala/collection/generic/GenericTraversableTemplate.class
+-rw----     2.0 fat     4080 b-  0% stor 19800101.000002 scala/collection/generic/Growable.class
+-rw----     2.0 fat      716 b-  0% stor 19800101.000002 scala/collection/generic/HasNewBuilder.class
+-rw----     2.0 fat      746 b-  0% stor 19800101.000002 scala/collection/generic/HasNewCombiner.class
+-rw----     2.0 fat      470 b-  0% stor 19800101.000002 scala/collection/generic/IdleSignalling$.class
+-rw----     2.0 fat      954 b-  0% stor 19800101.000002 scala/collection/generic/IdleSignalling.class
+-rw----     2.0 fat      990 b-  0% stor 19800101.000002 scala/collection/generic/ImmutableMapFactory.class
+-rw----     2.0 fat     1725 b-  0% stor 19800101.000002 scala/collection/generic/ImmutableSetFactory.class
+-rw----     2.0 fat     1055 b-  0% stor 19800101.000002 scala/collection/generic/ImmutableSortedMapFactory.class
+-rw----     2.0 fat     1017 b-  0% stor 19800101.000002 scala/collection/generic/ImmutableSortedSetFactory.class
+-rw----     2.0 fat     1582 b-  0% stor 19800101.000002 scala/collection/generic/IndexedSeqFactory.class
+-rw----     2.0 fat     2380 b-  0% stor 19800101.000002 scala/collection/generic/IsSeqLike$$anon$1.class
+-rw----     2.0 fat     1029 b-  0% stor 19800101.000002 scala/collection/generic/IsSeqLike$$anon$2.class
+-rw----     2.0 fat     1321 b-  0% stor 19800101.000002 scala/collection/generic/IsSeqLike$.class
+-rw----     2.0 fat     1814 b-  0% stor 19800101.000002 scala/collection/generic/IsSeqLike.class
+-rw----     2.0 fat     2450 b-  0% stor 19800101.000002 scala/collection/generic/IsTraversableLike$$anon$1.class
+-rw----     2.0 fat     1118 b-  0% stor 19800101.000002 scala/collection/generic/IsTraversableLike$$anon$2.class
+-rw----     2.0 fat     1431 b-  0% stor 19800101.000002 scala/collection/generic/IsTraversableLike$.class
+-rw----     2.0 fat     1962 b-  0% stor 19800101.000002 scala/collection/generic/IsTraversableLike.class
+-rw----     2.0 fat     2414 b-  0% stor 19800101.000002 scala/collection/generic/IsTraversableOnce$$anon$1.class
+-rw----     2.0 fat     1112 b-  0% stor 19800101.000002 scala/collection/generic/IsTraversableOnce$$anon$2.class
+-rw----     2.0 fat     1428 b-  0% stor 19800101.000002 scala/collection/generic/IsTraversableOnce$.class
+-rw----     2.0 fat     1951 b-  0% stor 19800101.000002 scala/collection/generic/IsTraversableOnce.class
+-rw----     2.0 fat     2311 b-  0% stor 19800101.000002 scala/collection/generic/IterableForwarder.class
+-rw----     2.0 fat     1098 b-  0% stor 19800101.000002 scala/collection/generic/MapFactory.class
+-rw----     2.0 fat     1402 b-  0% stor 19800101.000002 scala/collection/generic/MutableMapFactory.class
+-rw----     2.0 fat     1408 b-  0% stor 19800101.000002 scala/collection/generic/MutableSetFactory.class
+-rw----     2.0 fat     1043 b-  0% stor 19800101.000002 scala/collection/generic/MutableSortedMapFactory.class
+-rw----     2.0 fat     1706 b-  0% stor 19800101.000002 scala/collection/generic/MutableSortedSetFactory.class
+-rw----     2.0 fat     2195 b-  0% stor 19800101.000002 scala/collection/generic/OrderedTraversableFactory$GenericCanBuildFrom.class
+-rw----     2.0 fat     1518 b-  0% stor 19800101.000002 scala/collection/generic/OrderedTraversableFactory.class
+-rw----     2.0 fat     2531 b-  0% stor 19800101.000002 scala/collection/generic/ParFactory$GenericCanCombineFrom.class
+-rw----     2.0 fat     1521 b-  0% stor 19800101.000002 scala/collection/generic/ParFactory.class
+-rw----     2.0 fat     2157 b-  0% stor 19800101.000002 scala/collection/generic/ParMapFactory$CanCombineFromMap.class
+-rw----     2.0 fat     2285 b-  0% stor 19800101.000002 scala/collection/generic/ParMapFactory.class
+-rw----     2.0 fat     2093 b-  0% stor 19800101.000002 scala/collection/generic/ParSetFactory$GenericCanCombineFrom.class
+-rw----     2.0 fat     2016 b-  0% stor 19800101.000002 scala/collection/generic/ParSetFactory.class
+-rw----     2.0 fat     1426 b-  0% stor 19800101.000002 scala/collection/generic/SeqFactory.class
+-rw----     2.0 fat    11156 b-  0% stor 19800101.000002 scala/collection/generic/SeqForwarder.class
+-rw----     2.0 fat     1034 b-  0% stor 19800101.000002 scala/collection/generic/SetFactory.class
+-rw----     2.0 fat     3624 b-  0% stor 19800101.000002 scala/collection/generic/Shrinkable.class
+-rw----     2.0 fat      901 b-  0% stor 19800101.000002 scala/collection/generic/Signalling.class
+-rw----     2.0 fat      412 b-  0% stor 19800101.000002 scala/collection/generic/Sizing.class
+-rw----     2.0 fat      998 b-  0% stor 19800101.000002 scala/collection/generic/SliceInterval$.class
+-rw----     2.0 fat     2231 b-  0% stor 19800101.000002 scala/collection/generic/SliceInterval.class
+-rw----     2.0 fat     4968 b-  0% stor 19800101.000002 scala/collection/generic/Sorted.class
+-rw----     2.0 fat     2093 b-  0% stor 19800101.000002 scala/collection/generic/SortedMapFactory$SortedMapCanBuildFrom.class
+-rw----     2.0 fat     2950 b-  0% stor 19800101.000002 scala/collection/generic/SortedMapFactory.class
+-rw----     2.0 fat     2016 b-  0% stor 19800101.000002 scala/collection/generic/SortedSetFactory$SortedSetCanBuildFrom.class
+-rw----     2.0 fat     3119 b-  0% stor 19800101.000002 scala/collection/generic/SortedSetFactory.class
+-rw----     2.0 fat     3841 b-  0% stor 19800101.000002 scala/collection/generic/Subtractable.class
+-rw----     2.0 fat     1052 b-  0% stor 19800101.000002 scala/collection/generic/TaggedDelegatedContext.class
+-rw----     2.0 fat      836 b-  0% stor 19800101.000002 scala/collection/generic/TraversableFactory.class
+-rw----     2.0 fat    20156 b-  0% stor 19800101.000002 scala/collection/generic/TraversableForwarder.class
+-rw----     2.0 fat     1485 b-  0% stor 19800101.000002 scala/collection/generic/VolatileAbort.class
+-rw----     2.0 fat      431 b-  0% stor 19800101.000002 scala/collection/generic/package$.class
+-rw----     2.0 fat     1214 b-  0% stor 19800101.000002 scala/collection/generic/package.class
+-rw----     2.0 fat        0 bl  0% defN 19800101.000000 scala/collection/immutable/
+-rw----     2.0 fat     1850 b-  0% stor 19800101.000002 scala/collection/immutable/$colon$colon$.class
+-rw----     2.0 fat     4828 b-  0% stor 19800101.000002 scala/collection/immutable/$colon$colon.class
+-rw----     2.0 fat    12101 b-  0% stor 19800101.000002 scala/collection/immutable/AbstractMap.class
+-rw----     2.0 fat     4406 b-  0% stor 19800101.000002 scala/collection/immutable/BitSet$$anon$1.class
+-rw----     2.0 fat     3339 b-  0% stor 19800101.000002 scala/collection/immutable/BitSet$.class
+-rw----     2.0 fat     2196 b-  0% stor 19800101.000002 scala/collection/immutable/BitSet$BitSet1.class
+-rw----     2.0 fat     2280 b-  0% stor 19800101.000002 scala/collection/immutable/BitSet$BitSet2.class
+-rw----     2.0 fat     1709 b-  0% stor 19800101.000002 scala/collection/immutable/BitSet$BitSetN.class
+-rw----     2.0 fat    18665 b-  0% stor 19800101.000002 scala/collection/immutable/BitSet.class
+-rw----     2.0 fat     4612 b-  0% stor 19800101.000002 scala/collection/immutable/DefaultMap.class
+-rw----     2.0 fat     1474 b-  0% stor 19800101.000002 scala/collection/immutable/HashMap$$anon$2$$anon$3.class
+-rw----     2.0 fat     1616 b-  0% stor 19800101.000002 scala/collection/immutable/HashMap$$anon$2.class
+-rw----     2.0 fat     8304 b-  0% stor 19800101.000002 scala/collection/immutable/HashMap$.class
+-rw----     2.0 fat     1346 b-  0% stor 19800101.000002 scala/collection/immutable/HashMap$EmptyHashMap$.class
+-rw----     2.0 fat     6661 b-  0% stor 19800101.000002 scala/collection/immutable/HashMap$HashMap1.class
+-rw----     2.0 fat     8738 b-  0% stor 19800101.000002 scala/collection/immutable/HashMap$HashMapCollision1.class
+-rw----     2.0 fat     1562 b-  0% stor 19800101.000002 scala/collection/immutable/HashMap$HashTrieMap$$anon$1.class
+-rw----     2.0 fat    11539 b-  0% stor 19800101.000002 scala/collection/immutable/HashMap$HashTrieMap.class
+-rw----     2.0 fat      864 b-  0% stor 19800101.000002 scala/collection/immutable/HashMap$Merger.class
+-rw----     2.0 fat     5174 b-  0% stor 19800101.000002 scala/collection/immutable/HashMap$SerializationProxy.class
+-rw----     2.0 fat    23359 b-  0% stor 19800101.000002 scala/collection/immutable/HashMap.class
+-rw----     2.0 fat     4048 b-  0% stor 19800101.000002 scala/collection/immutable/HashSet$.class
+-rw----     2.0 fat     1132 b-  0% stor 19800101.000002 scala/collection/immutable/HashSet$EmptyHashSet$.class
+-rw----     2.0 fat     5800 b-  0% stor 19800101.000002 scala/collection/immutable/HashSet$HashSet1.class
+-rw----     2.0 fat     9268 b-  0% stor 19800101.000002 scala/collection/immutable/HashSet$HashSetCollision1.class
+-rw----     2.0 fat     1393 b-  0% stor 19800101.000002 scala/collection/immutable/HashSet$HashTrieSet$$anon$1.class
+-rw----     2.0 fat    11954 b-  0% stor 19800101.000002 scala/collection/immutable/HashSet$HashTrieSet.class
+-rw----     2.0 fat      555 b-  0% stor 19800101.000002 scala/collection/immutable/HashSet$LeafHashSet.class
+-rw----     2.0 fat     4372 b-  0% stor 19800101.000002 scala/collection/immutable/HashSet$SerializationProxy.class
+-rw----     2.0 fat    22190 b-  0% stor 19800101.000002 scala/collection/immutable/HashSet.class
+-rw----     2.0 fat     1475 b-  0% stor 19800101.000002 scala/collection/immutable/IndexedSeq$.class
+-rw----     2.0 fat     7359 b-  0% stor 19800101.000002 scala/collection/immutable/IndexedSeq$Impl.class
+-rw----     2.0 fat     9686 b-  0% stor 19800101.000002 scala/collection/immutable/IndexedSeq.class
+-rw----     2.0 fat     1834 b-  0% stor 19800101.000002 scala/collection/immutable/IntMap$$anon$1.class
+-rw----     2.0 fat     3296 b-  0% stor 19800101.000002 scala/collection/immutable/IntMap$.class
+-rw----     2.0 fat     2275 b-  0% stor 19800101.000002 scala/collection/immutable/IntMap$Bin$.class
+-rw----     2.0 fat     3775 b-  0% stor 19800101.000002 scala/collection/immutable/IntMap$Bin.class
+-rw----     2.0 fat     2017 b-  0% stor 19800101.000002 scala/collection/immutable/IntMap$Nil$.class
+-rw----     2.0 fat     1824 b-  0% stor 19800101.000002 scala/collection/immutable/IntMap$Tip$.class
+-rw----     2.0 fat     2734 b-  0% stor 19800101.000002 scala/collection/immutable/IntMap$Tip.class
+-rw----     2.0 fat    28846 b-  0% stor 19800101.000002 scala/collection/immutable/IntMap.class
+-rw----     2.0 fat     2034 b-  0% stor 19800101.000002 scala/collection/immutable/IntMapEntryIterator.class
+-rw----     2.0 fat     3626 b-  0% stor 19800101.000002 scala/collection/immutable/IntMapIterator.class
+-rw----     2.0 fat     1817 b-  0% stor 19800101.000002 scala/collection/immutable/IntMapKeyIterator.class
+-rw----     2.0 fat     4398 b-  0% stor 19800101.000002 scala/collection/immutable/IntMapUtils$.class
+-rw----     2.0 fat     2405 b-  0% stor 19800101.000002 scala/collection/immutable/IntMapUtils.class
+-rw----     2.0 fat     1521 b-  0% stor 19800101.000002 scala/collection/immutable/IntMapValueIterator.class
+-rw----     2.0 fat     1500 b-  0% stor 19800101.000002 scala/collection/immutable/Iterable$.class
+-rw----     2.0 fat     9634 b-  0% stor 19800101.000002 scala/collection/immutable/Iterable.class
+-rw----     2.0 fat     1402 b-  0% stor 19800101.000002 scala/collection/immutable/LinearSeq$.class
+-rw----     2.0 fat     8948 b-  0% stor 19800101.000002 scala/collection/immutable/LinearSeq.class
+-rw----     2.0 fat     6245 b-  0% stor 19800101.000002 scala/collection/immutable/List$$anon$1.class
+-rw----     2.0 fat     2770 b-  0% stor 19800101.000002 scala/collection/immutable/List$.class
+-rw----     2.0 fat     2543 b-  0% stor 19800101.000002 scala/collection/immutable/List$SerializationProxy.class
+-rw----     2.0 fat    36650 b-  0% stor 19800101.000002 scala/collection/immutable/List.class
+-rw----     2.0 fat     1847 b-  0% stor 19800101.000002 scala/collection/immutable/ListMap$.class
+-rw----     2.0 fat      791 b-  0% stor 19800101.000002 scala/collection/immutable/ListMap$EmptyListMap$.class
+-rw----     2.0 fat     8573 b-  0% stor 19800101.000002 scala/collection/immutable/ListMap$Node.class
+-rw----     2.0 fat    13125 b-  0% stor 19800101.000002 scala/collection/immutable/ListMap.class
+-rw----     2.0 fat     1890 b-  0% stor 19800101.000002 scala/collection/immutable/ListSerializeEnd$.class
+-rw----     2.0 fat     1618 b-  0% stor 19800101.000002 scala/collection/immutable/ListSerializeEnd.class
+-rw----     2.0 fat     1534 b-  0% stor 19800101.000002 scala/collection/immutable/ListSet$.class
+-rw----     2.0 fat      767 b-  0% stor 19800101.000002 scala/collection/immutable/ListSet$EmptyListSet$.class
+-rw----     2.0 fat     5500 b-  0% stor 19800101.000002 scala/collection/immutable/ListSet$Node.class
+-rw----     2.0 fat    11468 b-  0% stor 19800101.000002 scala/collection/immutable/ListSet.class
+-rw----     2.0 fat     1848 b-  0% stor 19800101.000002 scala/collection/immutable/LongMap$$anon$1.class
+-rw----     2.0 fat     3315 b-  0% stor 19800101.000002 scala/collection/immutable/LongMap$.class
+-rw----     2.0 fat     2290 b-  0% stor 19800101.000002 scala/collection/immutable/LongMap$Bin$.class
+-rw----     2.0 fat     3857 b-  0% stor 19800101.000002 scala/collection/immutable/LongMap$Bin.class
+-rw----     2.0 fat     2029 b-  0% stor 19800101.000002 scala/collection/immutable/LongMap$Nil$.class
+-rw----     2.0 fat     1828 b-  0% stor 19800101.000002 scala/collection/immutable/LongMap$Tip$.class
+-rw----     2.0 fat     2797 b-  0% stor 19800101.000002 scala/collection/immutable/LongMap$Tip.class
+-rw----     2.0 fat    29007 b-  0% stor 19800101.000002 scala/collection/immutable/LongMap.class
+-rw----     2.0 fat     2049 b-  0% stor 19800101.000002 scala/collection/immutable/LongMapEntryIterator.class
+-rw----     2.0 fat     3644 b-  0% stor 19800101.000002 scala/collection/immutable/LongMapIterator.class
+-rw----     2.0 fat     1832 b-  0% stor 19800101.000002 scala/collection/immutable/LongMapKeyIterator.class
+-rw----     2.0 fat     4435 b-  0% stor 19800101.000002 scala/collection/immutable/LongMapUtils$.class
+-rw----     2.0 fat     2429 b-  0% stor 19800101.000002 scala/collection/immutable/LongMapUtils.class
+-rw----     2.0 fat     1539 b-  0% stor 19800101.000002 scala/collection/immutable/LongMapValueIterator.class
+-rw----     2.0 fat     1643 b-  0% stor 19800101.000002 scala/collection/immutable/Map$.class
+-rw----     2.0 fat     4210 b-  0% stor 19800101.000002 scala/collection/immutable/Map$EmptyMap$.class
+-rw----     2.0 fat     4955 b-  0% stor 19800101.000002 scala/collection/immutable/Map$Map1.class
+-rw----     2.0 fat     5317 b-  0% stor 19800101.000002 scala/collection/immutable/Map$Map2.class
+-rw----     2.0 fat     5811 b-  0% stor 19800101.000002 scala/collection/immutable/Map$Map3.class
+-rw----     2.0 fat     6244 b-  0% stor 19800101.000002 scala/collection/immutable/Map$Map4.class
+-rw----     2.0 fat    13932 b-  0% stor 19800101.000002 scala/collection/immutable/Map$WithDefault.class
+-rw----     2.0 fat    10432 b-  0% stor 19800101.000002 scala/collection/immutable/Map.class
+-rw----     2.0 fat    14561 b-  0% stor 19800101.000002 scala/collection/immutable/MapLike$$anon$1.class
+-rw----     2.0 fat    14566 b-  0% stor 19800101.000002 scala/collection/immutable/MapLike$$anon$2.class
+-rw----     2.0 fat     6795 b-  0% stor 19800101.000002 scala/collection/immutable/MapLike$ImmutableDefaultKeySet.class
+-rw----     2.0 fat    10188 b-  0% stor 19800101.000002 scala/collection/immutable/MapLike.class
+-rw----     2.0 fat    54926 b-  0% stor 19800101.000002 scala/collection/immutable/MapProxy$$anon$1.class
+-rw----     2.0 fat    47916 b-  0% stor 19800101.000002 scala/collection/immutable/MapProxy$$anon$2.class
+-rw----     2.0 fat     7675 b-  0% stor 19800101.000002 scala/collection/immutable/MapProxy.class
+-rw----     2.0 fat     2594 b-  0% stor 19800101.000002 scala/collection/immutable/Nil$.class
+-rw----     2.0 fat    29492 b-  0% stor 19800101.000002 scala/collection/immutable/Nil.class
+-rw----     2.0 fat     6792 b-  0% stor 19800101.000002 scala/collection/immutable/NumericRange$$anon$1.class
+-rw----     2.0 fat     9380 b-  0% stor 19800101.000002 scala/collection/immutable/NumericRange$.class
+-rw----     2.0 fat     2272 b-  0% stor 19800101.000002 scala/collection/immutable/NumericRange$Exclusive.class
+-rw----     2.0 fat     2284 b-  0% stor 19800101.000002 scala/collection/immutable/NumericRange$Inclusive.class
+-rw----     2.0 fat    22728 b-  0% stor 19800101.000002 scala/collection/immutable/NumericRange.class
+-rw----     2.0 fat     4743 b-  0% stor 19800101.000002 scala/collection/immutable/Page.class
+-rw----     2.0 fat     9049 b-  0% stor 19800101.000002 scala/collection/immutable/PagedSeq$.class
+-rw----     2.0 fat    14931 b-  0% stor 19800101.000002 scala/collection/immutable/PagedSeq.class
+-rw----     2.0 fat     4048 b-  0% stor 19800101.000002 scala/collection/immutable/Queue$.class
+-rw----     2.0 fat      859 b-  0% stor 19800101.000002 scala/collection/immutable/Queue$EmptyQueue$.class
+-rw----     2.0 fat    20931 b-  0% stor 19800101.000002 scala/collection/immutable/Queue.class
+-rw----     2.0 fat     2156 b-  0% stor 19800101.000002 scala/collection/immutable/Range$.class
+-rw----     2.0 fat     2360 b-  0% stor 19800101.000002 scala/collection/immutable/Range$BigDecimal$.class
+-rw----     2.0 fat     2095 b-  0% stor 19800101.000002 scala/collection/immutable/Range$BigInt$.class
+-rw----     2.0 fat     4132 b-  0% stor 19800101.000002 scala/collection/immutable/Range$Double$.class
+-rw----     2.0 fat      778 b-  0% stor 19800101.000002 scala/collection/immutable/Range$Inclusive.class
+-rw----     2.0 fat     1941 b-  0% stor 19800101.000002 scala/collection/immutable/Range$Int$.class
+-rw----     2.0 fat     1943 b-  0% stor 19800101.000002 scala/collection/immutable/Range$Long$.class
+-rw----     2.0 fat     2035 b-  0% stor 19800101.000002 scala/collection/immutable/Range$Partial$.class
+-rw----     2.0 fat     1809 b-  0% stor 19800101.000002 scala/collection/immutable/Range$Partial.class
+-rw----     2.0 fat    28612 b-  0% stor 19800101.000002 scala/collection/immutable/Range.class
+-rw----     2.0 fat    37178 b-  0% stor 19800101.000002 scala/collection/immutable/RedBlackTree$.class
+-rw----     2.0 fat     2412 b-  0% stor 19800101.000002 scala/collection/immutable/RedBlackTree$BlackTree$.class
+-rw----     2.0 fat     2205 b-  0% stor 19800101.000002 scala/collection/immutable/RedBlackTree$BlackTree.class
+-rw----     2.0 fat     1705 b-  0% stor 19800101.000002 scala/collection/immutable/RedBlackTree$EntriesIterator.class
+-rw----     2.0 fat     1396 b-  0% stor 19800101.000002 scala/collection/immutable/RedBlackTree$KeysIterator.class
+-rw----     2.0 fat     1912 b-  0% stor 19800101.000002 scala/collection/immutable/RedBlackTree$NList$.class
+-rw----     2.0 fat     1170 b-  0% stor 19800101.000002 scala/collection/immutable/RedBlackTree$NList.class
+-rw----     2.0 fat     2392 b-  0% stor 19800101.000002 scala/collection/immutable/RedBlackTree$RedTree$.class
+-rw----     2.0 fat     2207 b-  0% stor 19800101.000002 scala/collection/immutable/RedBlackTree$RedTree.class
+-rw----     2.0 fat     1995 b-  0% stor 19800101.000002 scala/collection/immutable/RedBlackTree$Tree.class
+-rw----     2.0 fat    33152 b-  0% stor 19800101.000002 scala/collection/immutable/RedBlackTree$TreeIterator.class
+-rw----     2.0 fat     1404 b-  0% stor 19800101.000002 scala/collection/immutable/RedBlackTree$ValuesIterator.class
+-rw----     2.0 fat    18322 b-  0% stor 19800101.000002 scala/collection/immutable/RedBlackTree.class
+-rw----     2.0 fat     1360 b-  0% stor 19800101.000002 scala/collection/immutable/Seq$.class
+-rw----     2.0 fat     9693 b-  0% stor 19800101.000002 scala/collection/immutable/Seq.class
+-rw----     2.0 fat     1217 b-  0% stor 19800101.000002 scala/collection/immutable/Set$.class
+-rw----     2.0 fat     8973 b-  0% stor 19800101.000002 scala/collection/immutable/Set$EmptySet$.class
+-rw----     2.0 fat     8076 b-  0% stor 19800101.000002 scala/collection/immutable/Set$Set1.class
+-rw----     2.0 fat     8328 b-  0% stor 19800101.000002 scala/collection/immutable/Set$Set2.class
+-rw----     2.0 fat     8609 b-  0% stor 19800101.000002 scala/collection/immutable/Set$Set3.class
+-rw----     2.0 fat     8888 b-  0% stor 19800101.000002 scala/collection/immutable/Set$Set4.class
+-rw----     2.0 fat     9778 b-  0% stor 19800101.000002 scala/collection/immutable/Set.class
+-rw----     2.0 fat    30065 b-  0% stor 19800101.000002 scala/collection/immutable/SetProxy$$anon$1.class
+-rw----     2.0 fat     3330 b-  0% stor 19800101.000002 scala/collection/immutable/SetProxy.class
+-rw----     2.0 fat     2306 b-  0% stor 19800101.000002 scala/collection/immutable/SortedMap$$anon$1$$anonfun$valuesIteratorFrom$1.class
+-rw----     2.0 fat    22541 b-  0% stor 19800101.000002 scala/collection/immutable/SortedMap$$anon$1.class
+-rw----     2.0 fat    22107 b-  0% stor 19800101.000002 scala/collection/immutable/SortedMap$$anon$2.class
+-rw----     2.0 fat     1943 b-  0% stor 19800101.000002 scala/collection/immutable/SortedMap$.class
+-rw----     2.0 fat     4509 b-  0% stor 19800101.000002 scala/collection/immutable/SortedMap$Default.class
+-rw----     2.0 fat    10588 b-  0% stor 19800101.000002 scala/collection/immutable/SortedMap$DefaultKeySortedSet.class
+-rw----     2.0 fat     9939 b-  0% stor 19800101.000002 scala/collection/immutable/SortedMap.class
+-rw----     2.0 fat     1995 b-  0% stor 19800101.000002 scala/collection/immutable/SortedSet$.class
+-rw----     2.0 fat     2813 b-  0% stor 19800101.000002 scala/collection/immutable/SortedSet.class
+-rw----     2.0 fat     2843 b-  0% stor 19800101.000002 scala/collection/immutable/Stack$.class
+-rw----     2.0 fat    25535 b-  0% stor 19800101.000002 scala/collection/immutable/Stack.class
+-rw----     2.0 fat    71425 b-  0% stor 19800101.000002 scala/collection/immutable/Stream$$anon$1.class
+-rw----     2.0 fat     1238 b-  0% stor 19800101.000002 scala/collection/immutable/Stream$$hash$colon$colon$.class
+-rw----     2.0 fat    13498 b-  0% stor 19800101.000002 scala/collection/immutable/Stream$.class
+-rw----     2.0 fat     2849 b-  0% stor 19800101.000002 scala/collection/immutable/Stream$Cons.class
+-rw----     2.0 fat     1722 b-  0% stor 19800101.000002 scala/collection/immutable/Stream$ConsWrapper.class
+-rw----     2.0 fat     1458 b-  0% stor 19800101.000002 scala/collection/immutable/Stream$Empty$.class
+-rw----     2.0 fat     2413 b-  0% stor 19800101.000002 scala/collection/immutable/Stream$StreamBuilder.class
+-rw----     2.0 fat      925 b-  0% stor 19800101.000002 scala/collection/immutable/Stream$StreamCanBuildFrom.class
+-rw----     2.0 fat     5641 b-  0% stor 19800101.000002 scala/collection/immutable/Stream$StreamWithFilter.class
+-rw----     2.0 fat     1559 b-  0% stor 19800101.000002 scala/collection/immutable/Stream$cons$.class
+-rw----     2.0 fat    58127 b-  0% stor 19800101.000002 scala/collection/immutable/Stream.class
+-rw----     2.0 fat     1745 b-  0% stor 19800101.000002 scala/collection/immutable/StreamIterator$LazyCell.class
+-rw----     2.0 fat     4702 b-  0% stor 19800101.000002 scala/collection/immutable/StreamIterator.class
+-rw----     2.0 fat      735 b-  0% stor 19800101.000002 scala/collection/immutable/StreamView.class
+-rw----     2.0 fat     3868 b-  0% stor 19800101.000002 scala/collection/immutable/StreamViewLike$$anon$1.class
+-rw----     2.0 fat     3937 b-  0% stor 19800101.000002 scala/collection/immutable/StreamViewLike$$anon$10.class
+-rw----     2.0 fat     4403 b-  0% stor 19800101.000002 scala/collection/immutable/StreamViewLike$$anon$11.class
+-rw----     2.0 fat     3593 b-  0% stor 19800101.000002 scala/collection/immutable/StreamViewLike$$anon$12.class
+-rw----     2.0 fat    70913 b-  0% stor 19800101.000002 scala/collection/immutable/StreamViewLike$$anon$13.class
+-rw----     2.0 fat     4469 b-  0% stor 19800101.000002 scala/collection/immutable/StreamViewLike$$anon$2.class
+-rw----     2.0 fat     4483 b-  0% stor 19800101.000002 scala/collection/immutable/StreamViewLike$$anon$3.class
+-rw----     2.0 fat     4683 b-  0% stor 19800101.000002 scala/collection/immutable/StreamViewLike$$anon$4.class
+-rw----     2.0 fat     5460 b-  0% stor 19800101.000002 scala/collection/immutable/StreamViewLike$$anon$5.class
+-rw----     2.0 fat     5159 b-  0% stor 19800101.000002 scala/collection/immutable/StreamViewLike$$anon$6.class
+-rw----     2.0 fat     4025 b-  0% stor 19800101.000002 scala/collection/immutable/StreamViewLike$$anon$7.class
+-rw----     2.0 fat     4249 b-  0% stor 19800101.000002 scala/collection/immutable/StreamViewLike$$anon$8.class
+-rw----     2.0 fat     5471 b-  0% stor 19800101.000002 scala/collection/immutable/StreamViewLike$$anon$9.class
+-rw----     2.0 fat    18772 b-  0% stor 19800101.000002 scala/collection/immutable/StreamViewLike$AbstractTransformed.class
+-rw----     2.0 fat      648 b-  0% stor 19800101.000002 scala/collection/immutable/StreamViewLike$Appended.class
+-rw----     2.0 fat      637 b-  0% stor 19800101.000002 scala/collection/immutable/StreamViewLike$DroppedWhile.class
+-rw----     2.0 fat      646 b-  0% stor 19800101.000002 scala/collection/immutable/StreamViewLike$EmptyView.class
+-rw----     2.0 fat      621 b-  0% stor 19800101.000002 scala/collection/immutable/StreamViewLike$Filtered.class
+-rw----     2.0 fat      656 b-  0% stor 19800101.000002 scala/collection/immutable/StreamViewLike$FlatMapped.class
+-rw----     2.0 fat      640 b-  0% stor 19800101.000002 scala/collection/immutable/StreamViewLike$Forced.class
+-rw----     2.0 fat      640 b-  0% stor 19800101.000002 scala/collection/immutable/StreamViewLike$Mapped.class
+-rw----     2.0 fat      644 b-  0% stor 19800101.000002 scala/collection/immutable/StreamViewLike$Patched.class
+-rw----     2.0 fat      652 b-  0% stor 19800101.000002 scala/collection/immutable/StreamViewLike$Prepended.class
+-rw----     2.0 fat      621 b-  0% stor 19800101.000002 scala/collection/immutable/StreamViewLike$Reversed.class
+-rw----     2.0 fat      613 b-  0% stor 19800101.000002 scala/collection/immutable/StreamViewLike$Sliced.class
+-rw----     2.0 fat      629 b-  0% stor 19800101.000002 scala/collection/immutable/StreamViewLike$TakenWhile.class
+-rw----     2.0 fat     1391 b-  0% stor 19800101.000002 scala/collection/immutable/StreamViewLike$Transformed.class
+-rw----     2.0 fat      659 b-  0% stor 19800101.000002 scala/collection/immutable/StreamViewLike$Zipped.class
+-rw----     2.0 fat      697 b-  0% stor 19800101.000002 scala/collection/immutable/StreamViewLike$ZippedAll.class
+-rw----     2.0 fat    14004 b-  0% stor 19800101.000002 scala/collection/immutable/StreamViewLike.class
+-rw----     2.0 fat     2344 b-  0% stor 19800101.000002 scala/collection/immutable/StringLike$$anon$1.class
+-rw----     2.0 fat      678 b-  0% stor 19800101.000002 scala/collection/immutable/StringLike$.class
+-rw----     2.0 fat    21490 b-  0% stor 19800101.000002 scala/collection/immutable/StringLike.class
+-rw----     2.0 fat     2852 b-  0% stor 19800101.000002 scala/collection/immutable/StringOps$.class
+-rw----     2.0 fat    55445 b-  0% stor 19800101.000002 scala/collection/immutable/StringOps.class
+-rw----     2.0 fat     1524 b-  0% stor 19800101.000002 scala/collection/immutable/Traversable$.class
+-rw----     2.0 fat     8955 b-  0% stor 19800101.000002 scala/collection/immutable/Traversable.class
+-rw----     2.0 fat     1934 b-  0% stor 19800101.000002 scala/collection/immutable/TreeMap$.class
+-rw----     2.0 fat    69351 b-  0% stor 19800101.000002 scala/collection/immutable/TreeMap.class
+-rw----     2.0 fat     1794 b-  0% stor 19800101.000002 scala/collection/immutable/TreeSet$.class
+-rw----     2.0 fat    60255 b-  0% stor 19800101.000002 scala/collection/immutable/TreeSet.class
+-rw----     2.0 fat     1237 b-  0% stor 19800101.000002 scala/collection/immutable/TrieIterator$$anon$1.class
+-rw----     2.0 fat     2804 b-  0% stor 19800101.000002 scala/collection/immutable/TrieIterator$DupIterator.class
+-rw----     2.0 fat    15205 b-  0% stor 19800101.000002 scala/collection/immutable/TrieIterator.class
+-rw----     2.0 fat     1544 b-  0% stor 19800101.000002 scala/collection/immutable/Vector$$anon$1.class
+-rw----     2.0 fat     2361 b-  0% stor 19800101.000002 scala/collection/immutable/Vector$.class
+-rw----     2.0 fat    40272 b-  0% stor 19800101.000002 scala/collection/immutable/Vector.class
+-rw----     2.0 fat    11154 b-  0% stor 19800101.000002 scala/collection/immutable/VectorBuilder.class
+-rw----     2.0 fat     8772 b-  0% stor 19800101.000002 scala/collection/immutable/VectorIterator.class
+-rw----     2.0 fat    14579 b-  0% stor 19800101.000002 scala/collection/immutable/VectorPointer.class
+-rw----     2.0 fat     1711 b-  0% stor 19800101.000002 scala/collection/immutable/WrappedString$$anon$1.class
+-rw----     2.0 fat     2723 b-  0% stor 19800101.000002 scala/collection/immutable/WrappedString$.class
+-rw----     2.0 fat    29007 b-  0% stor 19800101.000002 scala/collection/immutable/WrappedString.class
+-rw----     2.0 fat        0 bl  0% defN 19800101.000000 scala/collection/mutable/
+-rw----     2.0 fat    11594 b-  0% stor 19800101.000002 scala/collection/mutable/AbstractBuffer.class
+-rw----     2.0 fat     3573 b-  0% stor 19800101.000002 scala/collection/mutable/AbstractIterable.class
+-rw----     2.0 fat    18959 b-  0% stor 19800101.000002 scala/collection/mutable/AbstractMap.class
+-rw----     2.0 fat     5446 b-  0% stor 19800101.000002 scala/collection/mutable/AbstractSeq.class
+-rw----     2.0 fat    23638 b-  0% stor 19800101.000002 scala/collection/mutable/AbstractSet.class
+-rw----     2.0 fat    12812 b-  0% stor 19800101.000002 scala/collection/mutable/AbstractSortedMap.class
+-rw----     2.0 fat     9211 b-  0% stor 19800101.000002 scala/collection/mutable/AbstractSortedSet.class
+-rw----     2.0 fat    30150 b-  0% stor 19800101.000002 scala/collection/mutable/AnyRefMap$$anon$1.class
+-rw----     2.0 fat     1763 b-  0% stor 19800101.000002 scala/collection/mutable/AnyRefMap$$anon$2.class
+-rw----     2.0 fat     6177 b-  0% stor 19800101.000002 scala/collection/mutable/AnyRefMap$.class
+-rw----     2.0 fat     4942 b-  0% stor 19800101.000002 scala/collection/mutable/AnyRefMap$AnyRefMapBuilder.class
+-rw----     2.0 fat     6712 b-  0% stor 19800101.000002 scala/collection/mutable/AnyRefMap$ExceptionDefault.class
+-rw----     2.0 fat    26470 b-  0% stor 19800101.000002 scala/collection/mutable/AnyRefMap.class
+-rw----     2.0 fat     1553 b-  0% stor 19800101.000002 scala/collection/mutable/ArrayBuffer$.class
+-rw----     2.0 fat    36076 b-  0% stor 19800101.000002 scala/collection/mutable/ArrayBuffer.class
+-rw----     2.0 fat     2723 b-  0% stor 19800101.000002 scala/collection/mutable/ArrayBuilder$.class
+-rw----     2.0 fat     4183 b-  0% stor 19800101.000002 scala/collection/mutable/ArrayBuilder$ofBoolean.class
+-rw----     2.0 fat     4180 b-  0% stor 19800101.000002 scala/collection/mutable/ArrayBuilder$ofByte.class
+-rw----     2.0 fat     4180 b-  0% stor 19800101.000002 scala/collection/mutable/ArrayBuilder$ofChar.class
+-rw----     2.0 fat     4198 b-  0% stor 19800101.000002 scala/collection/mutable/ArrayBuilder$ofDouble.class
+-rw----     2.0 fat     4189 b-  0% stor 19800101.000002 scala/collection/mutable/ArrayBuilder$ofFloat.class
+-rw----     2.0 fat     4167 b-  0% stor 19800101.000002 scala/collection/mutable/ArrayBuilder$ofInt.class
+-rw----     2.0 fat     4180 b-  0% stor 19800101.000002 scala/collection/mutable/ArrayBuilder$ofLong.class
+-rw----     2.0 fat     4586 b-  0% stor 19800101.000002 scala/collection/mutable/ArrayBuilder$ofRef.class
+-rw----     2.0 fat     4189 b-  0% stor 19800101.000002 scala/collection/mutable/ArrayBuilder$ofShort.class
+-rw----     2.0 fat     2687 b-  0% stor 19800101.000002 scala/collection/mutable/ArrayBuilder$ofUnit.class
+-rw----     2.0 fat     9926 b-  0% stor 19800101.000002 scala/collection/mutable/ArrayBuilder.class
+-rw----     2.0 fat     8519 b-  0% stor 19800101.000002 scala/collection/mutable/ArrayLike$$anon$1.class
+-rw----     2.0 fat     1423 b-  0% stor 19800101.000002 scala/collection/mutable/ArrayLike.class
+-rw----     2.0 fat      434 b-  0% stor 19800101.000002 scala/collection/mutable/ArrayOps$.class
+-rw----     2.0 fat     2372 b-  0% stor 19800101.000002 scala/collection/mutable/ArrayOps$ofBoolean$.class
+-rw----     2.0 fat    53229 b-  0% stor 19800101.000002 scala/collection/mutable/ArrayOps$ofBoolean.class
+-rw----     2.0 fat     2348 b-  0% stor 19800101.000002 scala/collection/mutable/ArrayOps$ofByte$.class
+-rw----     2.0 fat    53228 b-  0% stor 19800101.000002 scala/collection/mutable/ArrayOps$ofByte.class
+-rw----     2.0 fat     2348 b-  0% stor 19800101.000002 scala/collection/mutable/ArrayOps$ofChar$.class
+-rw----     2.0 fat    53238 b-  0% stor 19800101.000002 scala/collection/mutable/ArrayOps$ofChar.class
+-rw----     2.0 fat     2364 b-  0% stor 19800101.000002 scala/collection/mutable/ArrayOps$ofDouble$.class
+-rw----     2.0 fat    53252 b-  0% stor 19800101.000002 scala/collection/mutable/ArrayOps$ofDouble.class
+-rw----     2.0 fat     2356 b-  0% stor 19800101.000002 scala/collection/mutable/ArrayOps$ofFloat$.class
+-rw----     2.0 fat    53240 b-  0% stor 19800101.000002 scala/collection/mutable/ArrayOps$ofFloat.class
+-rw----     2.0 fat     2336 b-  0% stor 19800101.000002 scala/collection/mutable/ArrayOps$ofInt$.class
+-rw----     2.0 fat    53189 b-  0% stor 19800101.000002 scala/collection/mutable/ArrayOps$ofInt.class
+-rw----     2.0 fat     2348 b-  0% stor 19800101.000002 scala/collection/mutable/ArrayOps$ofLong$.class
+-rw----     2.0 fat    53228 b-  0% stor 19800101.000002 scala/collection/mutable/ArrayOps$ofLong.class
+-rw----     2.0 fat     3131 b-  0% stor 19800101.000002 scala/collection/mutable/ArrayOps$ofRef$.class
+-rw----     2.0 fat    52787 b-  0% stor 19800101.000002 scala/collection/mutable/ArrayOps$ofRef.class
+-rw----     2.0 fat     2356 b-  0% stor 19800101.000002 scala/collection/mutable/ArrayOps$ofShort$.class
+-rw----     2.0 fat    53240 b-  0% stor 19800101.000002 scala/collection/mutable/ArrayOps$ofShort.class
+-rw----     2.0 fat     2747 b-  0% stor 19800101.000002 scala/collection/mutable/ArrayOps$ofUnit$.class
+-rw----     2.0 fat    54494 b-  0% stor 19800101.000002 scala/collection/mutable/ArrayOps$ofUnit.class
+-rw----     2.0 fat    27293 b-  0% stor 19800101.000002 scala/collection/mutable/ArrayOps.class
+-rw----     2.0 fat      962 b-  0% stor 19800101.000002 scala/collection/mutable/ArraySeq$$anon$1.class
+-rw----     2.0 fat     2938 b-  0% stor 19800101.000002 scala/collection/mutable/ArraySeq$.class
+-rw----     2.0 fat    28618 b-  0% stor 19800101.000002 scala/collection/mutable/ArraySeq.class
+-rw----     2.0 fat     1470 b-  0% stor 19800101.000002 scala/collection/mutable/ArrayStack$$anon$1.class
+-rw----     2.0 fat     4287 b-  0% stor 19800101.000002 scala/collection/mutable/ArrayStack$.class
+-rw----     2.0 fat    34243 b-  0% stor 19800101.000002 scala/collection/mutable/ArrayStack.class
+-rw----     2.0 fat     2632 b-  0% stor 19800101.000002 scala/collection/mutable/BitSet$.class
+-rw----     2.0 fat    22790 b-  0% stor 19800101.000002 scala/collection/mutable/BitSet.class
+-rw----     2.0 fat     1370 b-  0% stor 19800101.000002 scala/collection/mutable/Buffer$.class
+-rw----     2.0 fat     8563 b-  0% stor 19800101.000002 scala/collection/mutable/Buffer.class
+-rw----     2.0 fat    15332 b-  0% stor 19800101.000002 scala/collection/mutable/BufferLike.class
+-rw----     2.0 fat    63783 b-  0% stor 19800101.000002 scala/collection/mutable/BufferProxy$$anon$1.class
+-rw----     2.0 fat     8873 b-  0% stor 19800101.000002 scala/collection/mutable/BufferProxy.class
+-rw----     2.0 fat     5068 b-  0% stor 19800101.000002 scala/collection/mutable/Builder$$anon$1.class
+-rw----     2.0 fat     4338 b-  0% stor 19800101.000002 scala/collection/mutable/Builder.class
+-rw----     2.0 fat     1246 b-  0% stor 19800101.000002 scala/collection/mutable/Cloneable.class
+-rw----     2.0 fat     3077 b-  0% stor 19800101.000002 scala/collection/mutable/DefaultEntry.class
+-rw----     2.0 fat     5145 b-  0% stor 19800101.000002 scala/collection/mutable/DefaultMapModel.class
+-rw----     2.0 fat     5238 b-  0% stor 19800101.000002 scala/collection/mutable/DoubleLinkedList$$anon$1.class
+-rw----     2.0 fat     1628 b-  0% stor 19800101.000002 scala/collection/mutable/DoubleLinkedList$.class
+-rw----     2.0 fat    18956 b-  0% stor 19800101.000002 scala/collection/mutable/DoubleLinkedList.class
+-rw----     2.0 fat     8952 b-  0% stor 19800101.000002 scala/collection/mutable/DoubleLinkedListLike.class
+-rw----     2.0 fat     1900 b-  0% stor 19800101.000002 scala/collection/mutable/DoublingUnrolledBuffer.class
+-rw----     2.0 fat     1694 b-  0% stor 19800101.000002 scala/collection/mutable/FlatHashTable$$anon$1.class
+-rw----     2.0 fat      838 b-  0% stor 19800101.000002 scala/collection/mutable/FlatHashTable$$anon$2.class
+-rw----     2.0 fat     2287 b-  0% stor 19800101.000002 scala/collection/mutable/FlatHashTable$.class
+-rw----     2.0 fat     1378 b-  0% stor 19800101.000002 scala/collection/mutable/FlatHashTable$Contents.class
+-rw----     2.0 fat     2444 b-  0% stor 19800101.000002 scala/collection/mutable/FlatHashTable$HashUtils.class
+-rw----     2.0 fat      762 b-  0% stor 19800101.000002 scala/collection/mutable/FlatHashTable$NullSentinel$.class
+-rw----     2.0 fat    21285 b-  0% stor 19800101.000002 scala/collection/mutable/FlatHashTable.class
+-rw----     2.0 fat     5121 b-  0% stor 19800101.000002 scala/collection/mutable/GrowingBuilder.class
+-rw----     2.0 fat     1059 b-  0% stor 19800101.000002 scala/collection/mutable/HashEntry.class
+-rw----     2.0 fat     2474 b-  0% stor 19800101.000002 scala/collection/mutable/HashMap$$anon$1.class
+-rw----     2.0 fat     2505 b-  0% stor 19800101.000002 scala/collection/mutable/HashMap$$anon$2.class
+-rw----     2.0 fat     1442 b-  0% stor 19800101.000002 scala/collection/mutable/HashMap$$anon$3.class
+-rw----     2.0 fat     1446 b-  0% stor 19800101.000002 scala/collection/mutable/HashMap$$anon$4.class
+-rw----     2.0 fat     1695 b-  0% stor 19800101.000002 scala/collection/mutable/HashMap$.class
+-rw----     2.0 fat    28639 b-  0% stor 19800101.000002 scala/collection/mutable/HashMap.class
+-rw----     2.0 fat     1359 b-  0% stor 19800101.000002 scala/collection/mutable/HashSet$.class
+-rw----     2.0 fat    20484 b-  0% stor 19800101.000002 scala/collection/mutable/HashSet.class
+-rw----     2.0 fat     2450 b-  0% stor 19800101.000002 scala/collection/mutable/HashTable$$anon$1.class
+-rw----     2.0 fat     1276 b-  0% stor 19800101.000002 scala/collection/mutable/HashTable$.class
+-rw----     2.0 fat     4341 b-  0% stor 19800101.000002 scala/collection/mutable/HashTable$Contents.class
+-rw----     2.0 fat     1956 b-  0% stor 19800101.000002 scala/collection/mutable/HashTable$HashUtils.class
+-rw----     2.0 fat    19599 b-  0% stor 19800101.000002 scala/collection/mutable/HashTable.class
+-rw----     2.0 fat     4555 b-  0% stor 19800101.000002 scala/collection/mutable/History.class
+-rw----     2.0 fat     9764 b-  0% stor 19800101.000002 scala/collection/mutable/ImmutableMapAdaptor.class
+-rw----     2.0 fat     4819 b-  0% stor 19800101.000002 scala/collection/mutable/ImmutableSetAdaptor.class
+-rw----     2.0 fat     1398 b-  0% stor 19800101.000002 scala/collection/mutable/IndexedSeq$.class
+-rw----     2.0 fat     9050 b-  0% stor 19800101.000002 scala/collection/mutable/IndexedSeq.class
+-rw----     2.0 fat    74993 b-  0% stor 19800101.000002 scala/collection/mutable/IndexedSeqLike$$anon$1.class
+-rw----     2.0 fat     3184 b-  0% stor 19800101.000002 scala/collection/mutable/IndexedSeqLike.class
+-rw----     2.0 fat      787 b-  0% stor 19800101.000002 scala/collection/mutable/IndexedSeqOptimized.class
+-rw----     2.0 fat     5615 b-  0% stor 19800101.000002 scala/collection/mutable/IndexedSeqView$$anon$1.class
+-rw----     2.0 fat     4486 b-  0% stor 19800101.000002 scala/collection/mutable/IndexedSeqView$$anon$2.class
+-rw----     2.0 fat     4717 b-  0% stor 19800101.000002 scala/collection/mutable/IndexedSeqView$$anon$3.class
+-rw----     2.0 fat     5933 b-  0% stor 19800101.000002 scala/collection/mutable/IndexedSeqView$$anon$4.class
+-rw----     2.0 fat     2997 b-  0% stor 19800101.000002 scala/collection/mutable/IndexedSeqView$$anon$5.class
+-rw----     2.0 fat     1793 b-  0% stor 19800101.000002 scala/collection/mutable/IndexedSeqView$$anon$6.class
+-rw----     2.0 fat     1733 b-  0% stor 19800101.000002 scala/collection/mutable/IndexedSeqView$$anon$7.class
+-rw----     2.0 fat     1239 b-  0% stor 19800101.000002 scala/collection/mutable/IndexedSeqView$.class
+-rw----     2.0 fat    32086 b-  0% stor 19800101.000002 scala/collection/mutable/IndexedSeqView$AbstractTransformed.class
+-rw----     2.0 fat     1860 b-  0% stor 19800101.000002 scala/collection/mutable/IndexedSeqView$DroppedWhile.class
+-rw----     2.0 fat     1566 b-  0% stor 19800101.000002 scala/collection/mutable/IndexedSeqView$Filtered.class
+-rw----     2.0 fat     1573 b-  0% stor 19800101.000002 scala/collection/mutable/IndexedSeqView$Reversed.class
+-rw----     2.0 fat     2200 b-  0% stor 19800101.000002 scala/collection/mutable/IndexedSeqView$Sliced.class
+-rw----     2.0 fat     1838 b-  0% stor 19800101.000002 scala/collection/mutable/IndexedSeqView$TakenWhile.class
+-rw----     2.0 fat     1467 b-  0% stor 19800101.000002 scala/collection/mutable/IndexedSeqView$Transformed.class
+-rw----     2.0 fat    11823 b-  0% stor 19800101.000002 scala/collection/mutable/IndexedSeqView.class
+-rw----     2.0 fat     1487 b-  0% stor 19800101.000002 scala/collection/mutable/Iterable$.class
+-rw----     2.0 fat     9572 b-  0% stor 19800101.000002 scala/collection/mutable/Iterable.class
+-rw----     2.0 fat     5767 b-  0% stor 19800101.000002 scala/collection/mutable/LazyBuilder.class
+-rw----     2.0 fat     1391 b-  0% stor 19800101.000002 scala/collection/mutable/LinearSeq$.class
+-rw----     2.0 fat     8895 b-  0% stor 19800101.000002 scala/collection/mutable/LinearSeq.class
+-rw----     2.0 fat     3005 b-  0% stor 19800101.000002 scala/collection/mutable/LinkedEntry.class
+-rw----     2.0 fat     2138 b-  0% stor 19800101.000002 scala/collection/mutable/LinkedHashMap$$anon$1.class
+-rw----     2.0 fat     1908 b-  0% stor 19800101.000002 scala/collection/mutable/LinkedHashMap$$anon$2.class
+-rw----     2.0 fat     1912 b-  0% stor 19800101.000002 scala/collection/mutable/LinkedHashMap$$anon$3.class
+-rw----     2.0 fat     1749 b-  0% stor 19800101.000002 scala/collection/mutable/LinkedHashMap$.class
+-rw----     2.0 fat     1595 b-  0% stor 19800101.000002 scala/collection/mutable/LinkedHashMap$DefaultKeySet.class
+-rw----     2.0 fat     1585 b-  0% stor 19800101.000002 scala/collection/mutable/LinkedHashMap$FilteredKeys.class
+-rw----     2.0 fat     1597 b-  0% stor 19800101.000002 scala/collection/mutable/LinkedHashMap$MappedValues.class
+-rw----     2.0 fat    26306 b-  0% stor 19800101.000002 scala/collection/mutable/LinkedHashMap.class
+-rw----     2.0 fat     1964 b-  0% stor 19800101.000002 scala/collection/mutable/LinkedHashSet$$anon$1.class
+-rw----     2.0 fat     1413 b-  0% stor 19800101.000002 scala/collection/mutable/LinkedHashSet$.class
+-rw----     2.0 fat     2140 b-  0% stor 19800101.000002 scala/collection/mutable/LinkedHashSet$Entry.class
+-rw----     2.0 fat    23368 b-  0% stor 19800101.000002 scala/collection/mutable/LinkedHashSet.class
+-rw----     2.0 fat     3097 b-  0% stor 19800101.000002 scala/collection/mutable/LinkedList$.class
+-rw----     2.0 fat    17855 b-  0% stor 19800101.000002 scala/collection/mutable/LinkedList.class
+-rw----     2.0 fat     1582 b-  0% stor 19800101.000002 scala/collection/mutable/LinkedListLike$$anon$1.class
+-rw----     2.0 fat    10637 b-  0% stor 19800101.000002 scala/collection/mutable/LinkedListLike.class
+-rw----     2.0 fat     2013 b-  0% stor 19800101.000002 scala/collection/mutable/ListBuffer$$anon$1.class
+-rw----     2.0 fat     1648 b-  0% stor 19800101.000002 scala/collection/mutable/ListBuffer$.class
+-rw----     2.0 fat    43891 b-  0% stor 19800101.000002 scala/collection/mutable/ListBuffer.class
+-rw----     2.0 fat     1695 b-  0% stor 19800101.000002 scala/collection/mutable/ListMap$.class
+-rw----     2.0 fat    13513 b-  0% stor 19800101.000002 scala/collection/mutable/ListMap.class
+-rw----     2.0 fat    31378 b-  0% stor 19800101.000002 scala/collection/mutable/LongMap$$anon$1.class
+-rw----     2.0 fat     1721 b-  0% stor 19800101.000002 scala/collection/mutable/LongMap$$anon$2.class
+-rw----     2.0 fat     6521 b-  0% stor 19800101.000002 scala/collection/mutable/LongMap$.class
+-rw----     2.0 fat     4939 b-  0% stor 19800101.000002 scala/collection/mutable/LongMap$LongMapBuilder.class
+-rw----     2.0 fat    28554 b-  0% stor 19800101.000002 scala/collection/mutable/LongMap.class
+-rw----     2.0 fat     1515 b-  0% stor 19800101.000002 scala/collection/mutable/Map$.class
+-rw----     2.0 fat    20627 b-  0% stor 19800101.000002 scala/collection/mutable/Map$WithDefault.class
+-rw----     2.0 fat     5167 b-  0% stor 19800101.000002 scala/collection/mutable/Map.class
+-rw----     2.0 fat     5422 b-  0% stor 19800101.000002 scala/collection/mutable/MapBuilder.class
+-rw----     2.0 fat    16467 b-  0% stor 19800101.000002 scala/collection/mutable/MapLike.class
+-rw----     2.0 fat    61639 b-  0% stor 19800101.000002 scala/collection/mutable/MapProxy$$anon$1.class
+-rw----     2.0 fat    61381 b-  0% stor 19800101.000002 scala/collection/mutable/MapProxy$$anon$2.class
+-rw----     2.0 fat     7002 b-  0% stor 19800101.000002 scala/collection/mutable/MapProxy.class
+-rw----     2.0 fat     3916 b-  0% stor 19800101.000002 scala/collection/mutable/MultiMap.class
+-rw----     2.0 fat     2177 b-  0% stor 19800101.000002 scala/collection/mutable/MutableList$$anon$1.class
+-rw----     2.0 fat     1553 b-  0% stor 19800101.000002 scala/collection/mutable/MutableList$.class
+-rw----     2.0 fat    29118 b-  0% stor 19800101.000002 scala/collection/mutable/MutableList.class
+-rw----     2.0 fat     1077 b-  0% stor 19800101.000002 scala/collection/mutable/ObservableBuffer$$anon$1.class
+-rw----     2.0 fat     1307 b-  0% stor 19800101.000002 scala/collection/mutable/ObservableBuffer$$anon$2.class
+-rw----     2.0 fat     1319 b-  0% stor 19800101.000002 scala/collection/mutable/ObservableBuffer$$anon$3.class
+-rw----     2.0 fat     1351 b-  0% stor 19800101.000002 scala/collection/mutable/ObservableBuffer$$anon$4.class
+-rw----     2.0 fat     1528 b-  0% stor 19800101.000002 scala/collection/mutable/ObservableBuffer$$anon$5.class
+-rw----     2.0 fat     1055 b-  0% stor 19800101.000002 scala/collection/mutable/ObservableBuffer$$anon$6.class
+-rw----     2.0 fat     8305 b-  0% stor 19800101.000002 scala/collection/mutable/ObservableBuffer.class
+-rw----     2.0 fat     1386 b-  0% stor 19800101.000002 scala/collection/mutable/ObservableMap$$anon$1.class
+-rw----     2.0 fat     1383 b-  0% stor 19800101.000002 scala/collection/mutable/ObservableMap$$anon$2.class
+-rw----     2.0 fat     1351 b-  0% stor 19800101.000002 scala/collection/mutable/ObservableMap$$anon$3.class
+-rw----     2.0 fat     1037 b-  0% stor 19800101.000002 scala/collection/mutable/ObservableMap$$anon$4.class
+-rw----     2.0 fat     4183 b-  0% stor 19800101.000002 scala/collection/mutable/ObservableMap.class
+-rw----     2.0 fat     1195 b-  0% stor 19800101.000002 scala/collection/mutable/ObservableSet$$anon$1.class
+-rw----     2.0 fat     1193 b-  0% stor 19800101.000002 scala/collection/mutable/ObservableSet$$anon$2.class
+-rw----     2.0 fat     1034 b-  0% stor 19800101.000002 scala/collection/mutable/ObservableSet$$anon$3.class
+-rw----     2.0 fat     3163 b-  0% stor 19800101.000002 scala/collection/mutable/ObservableSet.class
+-rw----     2.0 fat     2651 b-  0% stor 19800101.000002 scala/collection/mutable/OpenHashMap$$anon$1.class
+-rw----     2.0 fat     1382 b-  0% stor 19800101.000002 scala/collection/mutable/OpenHashMap$.class
+-rw----     2.0 fat     1608 b-  0% stor 19800101.000002 scala/collection/mutable/OpenHashMap$OpenEntry.class
+-rw----     2.0 fat    23453 b-  0% stor 19800101.000002 scala/collection/mutable/OpenHashMap.class
+-rw----     2.0 fat     1774 b-  0% stor 19800101.000002 scala/collection/mutable/PriorityQueue$$anon$2.class
+-rw----     2.0 fat     1780 b-  0% stor 19800101.000002 scala/collection/mutable/PriorityQueue$$anon$3.class
+-rw----     2.0 fat     4873 b-  0% stor 19800101.000002 scala/collection/mutable/PriorityQueue$$anon$4.class
+-rw----     2.0 fat     1782 b-  0% stor 19800101.000002 scala/collection/mutable/PriorityQueue$.class
+-rw----     2.0 fat    21646 b-  0% stor 19800101.000002 scala/collection/mutable/PriorityQueue$ResizableArrayAccess.class
+-rw----     2.0 fat    22129 b-  0% stor 19800101.000002 scala/collection/mutable/PriorityQueue.class
+-rw----     2.0 fat     1279 b-  0% stor 19800101.000002 scala/collection/mutable/PriorityQueueProxy$$anon$1.class
+-rw----     2.0 fat     5294 b-  0% stor 19800101.000002 scala/collection/mutable/PriorityQueueProxy.class
+-rw----     2.0 fat     2626 b-  0% stor 19800101.000002 scala/collection/mutable/Publisher$$anon$1.class
+-rw----     2.0 fat     9020 b-  0% stor 19800101.000002 scala/collection/mutable/Publisher.class
+-rw----     2.0 fat     2716 b-  0% stor 19800101.000002 scala/collection/mutable/Queue$.class
+-rw----     2.0 fat    17876 b-  0% stor 19800101.000002 scala/collection/mutable/Queue.class
+-rw----     2.0 fat     5217 b-  0% stor 19800101.000002 scala/collection/mutable/QueueProxy$$anon$1.class
+-rw----     2.0 fat     5247 b-  0% stor 19800101.000002 scala/collection/mutable/QueueProxy.class
+-rw----     2.0 fat    22180 b-  0% stor 19800101.000002 scala/collection/mutable/RedBlackTree$.class
+-rw----     2.0 fat     1856 b-  0% stor 19800101.000002 scala/collection/mutable/RedBlackTree$EntriesIterator.class
+-rw----     2.0 fat     1549 b-  0% stor 19800101.000002 scala/collection/mutable/RedBlackTree$KeysIterator.class
+-rw----     2.0 fat     2932 b-  0% stor 19800101.000002 scala/collection/mutable/RedBlackTree$Node$.class
+-rw----     2.0 fat     3273 b-  0% stor 19800101.000002 scala/collection/mutable/RedBlackTree$Node.class
+-rw----     2.0 fat     1100 b-  0% stor 19800101.000002 scala/collection/mutable/RedBlackTree$Tree$.class
+-rw----     2.0 fat     1631 b-  0% stor 19800101.000002 scala/collection/mutable/RedBlackTree$Tree.class
+-rw----     2.0 fat    31407 b-  0% stor 19800101.000002 scala/collection/mutable/RedBlackTree$TreeIterator.class
+-rw----     2.0 fat     1557 b-  0% stor 19800101.000002 scala/collection/mutable/RedBlackTree$ValuesIterator.class
+-rw----     2.0 fat    17237 b-  0% stor 19800101.000002 scala/collection/mutable/RedBlackTree.class
+-rw----     2.0 fat     1426 b-  0% stor 19800101.000002 scala/collection/mutable/ResizableArray$.class
+-rw----     2.0 fat    14417 b-  0% stor 19800101.000002 scala/collection/mutable/ResizableArray.class
+-rw----     2.0 fat      811 b-  0% stor 19800101.000002 scala/collection/mutable/ReusableBuilder.class
+-rw----     2.0 fat     2477 b-  0% stor 19800101.000002 scala/collection/mutable/RevertibleHistory.class
+-rw----     2.0 fat     1349 b-  0% stor 19800101.000002 scala/collection/mutable/Seq$.class
+-rw----     2.0 fat     8902 b-  0% stor 19800101.000002 scala/collection/mutable/Seq.class
+-rw----     2.0 fat     4304 b-  0% stor 19800101.000002 scala/collection/mutable/SeqLike.class
+-rw----     2.0 fat     1271 b-  0% stor 19800101.000002 scala/collection/mutable/Set$.class
+-rw----     2.0 fat     2518 b-  0% stor 19800101.000002 scala/collection/mutable/Set.class
+-rw----     2.0 fat     5278 b-  0% stor 19800101.000002 scala/collection/mutable/SetBuilder.class
+-rw----     2.0 fat    13505 b-  0% stor 19800101.000002 scala/collection/mutable/SetLike.class
+-rw----     2.0 fat    55062 b-  0% stor 19800101.000002 scala/collection/mutable/SetProxy$$anon$1.class
+-rw----     2.0 fat     3294 b-  0% stor 19800101.000002 scala/collection/mutable/SetProxy.class
+-rw----     2.0 fat     1919 b-  0% stor 19800101.000002 scala/collection/mutable/SortedMap$.class
+-rw----     2.0 fat     6536 b-  0% stor 19800101.000002 scala/collection/mutable/SortedMap.class
+-rw----     2.0 fat     1971 b-  0% stor 19800101.000002 scala/collection/mutable/SortedSet$.class
+-rw----     2.0 fat     2803 b-  0% stor 19800101.000002 scala/collection/mutable/SortedSet.class
+-rw----     2.0 fat     2054 b-  0% stor 19800101.000002 scala/collection/mutable/Stack$.class
+-rw----     2.0 fat     4777 b-  0% stor 19800101.000002 scala/collection/mutable/Stack$StackBuilder.class
+-rw----     2.0 fat    16498 b-  0% stor 19800101.000002 scala/collection/mutable/Stack.class
+-rw----     2.0 fat     5476 b-  0% stor 19800101.000002 scala/collection/mutable/StackProxy$$anon$1.class
+-rw----     2.0 fat     6141 b-  0% stor 19800101.000002 scala/collection/mutable/StackProxy.class
+-rw----     2.0 fat      753 b-  0% stor 19800101.000002 scala/collection/mutable/StringBuilder$.class
+-rw----     2.0 fat    44319 b-  0% stor 19800101.000002 scala/collection/mutable/StringBuilder.class
+-rw----     2.0 fat      746 b-  0% stor 19800101.000002 scala/collection/mutable/Subscriber.class
+-rw----     2.0 fat    12207 b-  0% stor 19800101.000002 scala/collection/mutable/SynchronizedBuffer.class
+-rw----     2.0 fat    14176 b-  0% stor 19800101.000002 scala/collection/mutable/SynchronizedMap.class
+-rw----     2.0 fat     4363 b-  0% stor 19800101.000002 scala/collection/mutable/SynchronizedPriorityQueue.class
+-rw----     2.0 fat     4621 b-  0% stor 19800101.000002 scala/collection/mutable/SynchronizedQueue.class
+-rw----     2.0 fat    11847 b-  0% stor 19800101.000002 scala/collection/mutable/SynchronizedSet.class
+-rw----     2.0 fat     3982 b-  0% stor 19800101.000002 scala/collection/mutable/SynchronizedStack.class
+-rw----     2.0 fat     1511 b-  0% stor 19800101.000002 scala/collection/mutable/Traversable$.class
+-rw----     2.0 fat     8899 b-  0% stor 19800101.000002 scala/collection/mutable/Traversable.class
+-rw----     2.0 fat     1914 b-  0% stor 19800101.000002 scala/collection/mutable/TreeMap$.class
+-rw----     2.0 fat     9795 b-  0% stor 19800101.000002 scala/collection/mutable/TreeMap$TreeMapView.class
+-rw----     2.0 fat    19534 b-  0% stor 19800101.000002 scala/collection/mutable/TreeMap.class
+-rw----     2.0 fat     1859 b-  0% stor 19800101.000002 scala/collection/mutable/TreeSet$.class
+-rw----     2.0 fat     6689 b-  0% stor 19800101.000002 scala/collection/mutable/TreeSet$TreeSetView.class
+-rw----     2.0 fat    15685 b-  0% stor 19800101.000002 scala/collection/mutable/TreeSet.class
+-rw----     2.0 fat      423 b-  0% stor 19800101.000002 scala/collection/mutable/Undoable.class
+-rw----     2.0 fat     2602 b-  0% stor 19800101.000002 scala/collection/mutable/UnrolledBuffer$$anon$1.class
+-rw----     2.0 fat     2139 b-  0% stor 19800101.000002 scala/collection/mutable/UnrolledBuffer$.class
+-rw----     2.0 fat      741 b-  0% stor 19800101.000002 scala/collection/mutable/UnrolledBuffer$Unrolled$.class
+-rw----     2.0 fat    10729 b-  0% stor 19800101.000002 scala/collection/mutable/UnrolledBuffer$Unrolled.class
+-rw----     2.0 fat    21269 b-  0% stor 19800101.000002 scala/collection/mutable/UnrolledBuffer.class
+-rw----     2.0 fat     1731 b-  0% stor 19800101.000002 scala/collection/mutable/WeakHashMap$.class
+-rw----     2.0 fat     8598 b-  0% stor 19800101.000002 scala/collection/mutable/WeakHashMap.class
+-rw----     2.0 fat     3236 b-  0% stor 19800101.000002 scala/collection/mutable/WrappedArray$$anon$1.class
+-rw----     2.0 fat     3617 b-  0% stor 19800101.000002 scala/collection/mutable/WrappedArray$.class
+-rw----     2.0 fat     2139 b-  0% stor 19800101.000002 scala/collection/mutable/WrappedArray$ofBoolean.class
+-rw----     2.0 fat     2004 b-  0% stor 19800101.000002 scala/collection/mutable/WrappedArray$ofByte.class
+-rw----     2.0 fat     2014 b-  0% stor 19800101.000002 scala/collection/mutable/WrappedArray$ofChar.class
+-rw----     2.0 fat     2132 b-  0% stor 19800101.000002 scala/collection/mutable/WrappedArray$ofDouble.class
+-rw----     2.0 fat     2125 b-  0% stor 19800101.000002 scala/collection/mutable/WrappedArray$ofFloat.class
+-rw----     2.0 fat     2068 b-  0% stor 19800101.000002 scala/collection/mutable/WrappedArray$ofInt.class
+-rw----     2.0 fat     2118 b-  0% stor 19800101.000002 scala/collection/mutable/WrappedArray$ofLong.class
+-rw----     2.0 fat     2309 b-  0% stor 19800101.000002 scala/collection/mutable/WrappedArray$ofRef.class
+-rw----     2.0 fat     2011 b-  0% stor 19800101.000002 scala/collection/mutable/WrappedArray$ofShort.class
+-rw----     2.0 fat     2207 b-  0% stor 19800101.000002 scala/collection/mutable/WrappedArray$ofUnit.class
+-rw----     2.0 fat    27683 b-  0% stor 19800101.000002 scala/collection/mutable/WrappedArray.class
+-rw----     2.0 fat     9317 b-  0% stor 19800101.000002 scala/collection/mutable/WrappedArrayBuilder.class
+-rw----     2.0 fat     1256 b-  0% stor 19800101.000002 scala/collection/package$$anon$1.class
+-rw----     2.0 fat     1006 b-  0% stor 19800101.000002 scala/collection/package$.class
+-rw----     2.0 fat      983 b-  0% stor 19800101.000002 scala/collection/package.class
+-rw----     2.0 fat        0 bl  0% defN 19800101.000000 scala/collection/parallel/
+-rw----     2.0 fat     6528 b-  0% stor 19800101.000002 scala/collection/parallel/AdaptiveWorkStealingForkJoinTasks$WrappedTask.class
+-rw----     2.0 fat     2348 b-  0% stor 19800101.000002 scala/collection/parallel/AdaptiveWorkStealingForkJoinTasks.class
+-rw----     2.0 fat     6057 b-  0% stor 19800101.000002 scala/collection/parallel/AdaptiveWorkStealingTasks$WrappedTask.class
+-rw----     2.0 fat     1782 b-  0% stor 19800101.000002 scala/collection/parallel/AdaptiveWorkStealingTasks.class
+-rw----     2.0 fat     7007 b-  0% stor 19800101.000002 scala/collection/parallel/AdaptiveWorkStealingThreadPoolTasks$WrappedTask.class
+-rw----     2.0 fat     2465 b-  0% stor 19800101.000002 scala/collection/parallel/AdaptiveWorkStealingThreadPoolTasks.class
+-rw----     2.0 fat    25766 b-  0% stor 19800101.000002 scala/collection/parallel/AugmentedIterableIterator.class
+-rw----     2.0 fat     7119 b-  0% stor 19800101.000002 scala/collection/parallel/AugmentedSeqIterator.class
+-rw----     2.0 fat     8086 b-  0% stor 19800101.000002 scala/collection/parallel/BucketCombiner.class
+-rw----     2.0 fat    49970 b-  0% stor 19800101.000002 scala/collection/parallel/BufferSplitter.class
+-rw----     2.0 fat     3680 b-  0% stor 19800101.000002 scala/collection/parallel/Combiner.class
+-rw----     2.0 fat      805 b-  0% stor 19800101.000002 scala/collection/parallel/CombinerFactory.class
+-rw----     2.0 fat     2735 b-  0% stor 19800101.000002 scala/collection/parallel/CompositeThrowable$$anonfun$$lessinit$greater$1.class
+-rw----     2.0 fat     2026 b-  0% stor 19800101.000002 scala/collection/parallel/CompositeThrowable$.class
+-rw----     2.0 fat     6646 b-  0% stor 19800101.000002 scala/collection/parallel/CompositeThrowable.class
+-rw----     2.0 fat      767 b-  0% stor 19800101.000002 scala/collection/parallel/ExecutionContextTaskSupport$.class
+-rw----     2.0 fat     4502 b-  0% stor 19800101.000002 scala/collection/parallel/ExecutionContextTaskSupport.class
+-rw----     2.0 fat     3816 b-  0% stor 19800101.000002 scala/collection/parallel/ExecutionContextTasks.class
+-rw----     2.0 fat      472 b-  0% stor 19800101.000002 scala/collection/parallel/FactoryOps$Otherwise.class
+-rw----     2.0 fat     1756 b-  0% stor 19800101.000002 scala/collection/parallel/FactoryOps.class
+-rw----     2.0 fat      728 b-  0% stor 19800101.000002 scala/collection/parallel/ForkJoinTaskSupport$.class
+-rw----     2.0 fat     5519 b-  0% stor 19800101.000002 scala/collection/parallel/ForkJoinTaskSupport.class
+-rw----     2.0 fat      930 b-  0% stor 19800101.000002 scala/collection/parallel/ForkJoinTasks$.class
+-rw----     2.0 fat     1658 b-  0% stor 19800101.000002 scala/collection/parallel/ForkJoinTasks$WrappedTask.class
+-rw----     2.0 fat     5651 b-  0% stor 19800101.000002 scala/collection/parallel/ForkJoinTasks.class
+-rw----     2.0 fat     2777 b-  0% stor 19800101.000002 scala/collection/parallel/FutureTasks$$anonfun$compute$1$1.class
+-rw----     2.0 fat     9544 b-  0% stor 19800101.000002 scala/collection/parallel/FutureTasks.class
+-rw----     2.0 fat     1205 b-  0% stor 19800101.000002 scala/collection/parallel/FutureThreadPoolTasks$.class
+-rw----     2.0 fat     1099 b-  0% stor 19800101.000002 scala/collection/parallel/FutureThreadPoolTasks.class
+-rw----     2.0 fat      543 b-  0% stor 19800101.000002 scala/collection/parallel/HavingForkJoinPool.class
+-rw----     2.0 fat    48042 b-  0% stor 19800101.000002 scala/collection/parallel/IterableSplitter$Appended.class
+-rw----     2.0 fat    47552 b-  0% stor 19800101.000002 scala/collection/parallel/IterableSplitter$Mapped.class
+-rw----     2.0 fat    50763 b-  0% stor 19800101.000002 scala/collection/parallel/IterableSplitter$Taken.class
+-rw----     2.0 fat    49820 b-  0% stor 19800101.000002 scala/collection/parallel/IterableSplitter$Zipped.class
+-rw----     2.0 fat    49815 b-  0% stor 19800101.000002 scala/collection/parallel/IterableSplitter$ZippedAll.class
+-rw----     2.0 fat    15413 b-  0% stor 19800101.000002 scala/collection/parallel/IterableSplitter.class
+-rw----     2.0 fat     1834 b-  0% stor 19800101.000002 scala/collection/parallel/ParIterable$.class
+-rw----     2.0 fat     9294 b-  0% stor 19800101.000002 scala/collection/parallel/ParIterable.class
+-rw----     2.0 fat      804 b-  0% stor 19800101.000002 scala/collection/parallel/ParIterableLike$$anon$10.class
+-rw----     2.0 fat     2312 b-  0% stor 19800101.000002 scala/collection/parallel/ParIterableLike$$anon$11$$anon$1.class
+-rw----     2.0 fat     2313 b-  0% stor 19800101.000002 scala/collection/parallel/ParIterableLike$$anon$11$$anon$2.class
+-rw----     2.0 fat     1837 b-  0% stor 19800101.000002 scala/collection/parallel/ParIterableLike$$anon$11$$anon$3.class
+-rw----     2.0 fat     4222 b-  0% stor 19800101.000002 scala/collection/parallel/ParIterableLike$$anon$11.class
+-rw----     2.0 fat     1633 b-  0% stor 19800101.000002 scala/collection/parallel/ParIterableLike$$anon$12.class
+-rw----     2.0 fat     2118 b-  0% stor 19800101.000002 scala/collection/parallel/ParIterableLike$$anon$13$$anon$14.class
+-rw----     2.0 fat     2434 b-  0% stor 19800101.000002 scala/collection/parallel/ParIterableLike$$anon$13.class
+-rw----     2.0 fat     1859 b-  0% stor 19800101.000002 scala/collection/parallel/ParIterableLike$$anon$15.class
+-rw----     2.0 fat     1499 b-  0% stor 19800101.000002 scala/collection/parallel/ParIterableLike$$anon$16.class
+-rw----     2.0 fat     1403 b-  0% stor 19800101.000002 scala/collection/parallel/ParIterableLike$$anon$17.class
+-rw----     2.0 fat     1482 b-  0% stor 19800101.000002 scala/collection/parallel/ParIterableLike$$anon$18.class
+-rw----     2.0 fat     1281 b-  0% stor 19800101.000002 scala/collection/parallel/ParIterableLike$$anon$19.class
+-rw----     2.0 fat     4628 b-  0% stor 19800101.000002 scala/collection/parallel/ParIterableLike$$anon$4.class
+-rw----     2.0 fat     2070 b-  0% stor 19800101.000002 scala/collection/parallel/ParIterableLike$$anon$5.class
+-rw----     2.0 fat     2040 b-  0% stor 19800101.000002 scala/collection/parallel/ParIterableLike$$anon$6.class
+-rw----     2.0 fat     2070 b-  0% stor 19800101.000002 scala/collection/parallel/ParIterableLike$$anon$7.class
+-rw----     2.0 fat      791 b-  0% stor 19800101.000002 scala/collection/parallel/ParIterableLike$$anon$8.class
+-rw----     2.0 fat      791 b-  0% stor 19800101.000002 scala/collection/parallel/ParIterableLike$$anon$9.class
+-rw----     2.0 fat     5033 b-  0% stor 19800101.000002 scala/collection/parallel/ParIterableLike$Accessor.class
+-rw----     2.0 fat     6857 b-  0% stor 19800101.000002 scala/collection/parallel/ParIterableLike$Aggregate.class
+-rw----     2.0 fat      644 b-  0% stor 19800101.000002 scala/collection/parallel/ParIterableLike$BuilderOps$Otherwise.class
+-rw----     2.0 fat     1422 b-  0% stor 19800101.000002 scala/collection/parallel/ParIterableLike$BuilderOps.class
+-rw----     2.0 fat     7631 b-  0% stor 19800101.000002 scala/collection/parallel/ParIterableLike$Collect.class
+-rw----     2.0 fat     5585 b-  0% stor 19800101.000002 scala/collection/parallel/ParIterableLike$Composite.class
+-rw----     2.0 fat     7520 b-  0% stor 19800101.000002 scala/collection/parallel/ParIterableLike$Copy.class
+-rw----     2.0 fat    10446 b-  0% stor 19800101.000002 scala/collection/parallel/ParIterableLike$CopyToArray.class
+-rw----     2.0 fat     6645 b-  0% stor 19800101.000002 scala/collection/parallel/ParIterableLike$Count.class
+-rw----     2.0 fat    13048 b-  0% stor 19800101.000002 scala/collection/parallel/ParIterableLike$CreateScanTree.class
+-rw----     2.0 fat    11288 b-  0% stor 19800101.000002 scala/collection/parallel/ParIterableLike$Drop.class
+-rw----     2.0 fat     6775 b-  0% stor 19800101.000002 scala/collection/parallel/ParIterableLike$Exists.class
+-rw----     2.0 fat     7737 b-  0% stor 19800101.000002 scala/collection/parallel/ParIterableLike$Filter.class
+-rw----     2.0 fat     7770 b-  0% stor 19800101.000002 scala/collection/parallel/ParIterableLike$FilterNot.class
+-rw----     2.0 fat     6939 b-  0% stor 19800101.000002 scala/collection/parallel/ParIterableLike$Find.class
+-rw----     2.0 fat     7678 b-  0% stor 19800101.000002 scala/collection/parallel/ParIterableLike$FlatMap.class
+-rw----     2.0 fat     6566 b-  0% stor 19800101.000002 scala/collection/parallel/ParIterableLike$Fold.class
+-rw----     2.0 fat     6771 b-  0% stor 19800101.000002 scala/collection/parallel/ParIterableLike$Forall.class
+-rw----     2.0 fat     6416 b-  0% stor 19800101.000002 scala/collection/parallel/ParIterableLike$Foreach.class
+-rw----     2.0 fat     8518 b-  0% stor 19800101.000002 scala/collection/parallel/ParIterableLike$FromScanTree.class
+-rw----     2.0 fat     8271 b-  0% stor 19800101.000002 scala/collection/parallel/ParIterableLike$GroupBy.class
+-rw----     2.0 fat     7671 b-  0% stor 19800101.000002 scala/collection/parallel/ParIterableLike$Map.class
+-rw----     2.0 fat     6996 b-  0% stor 19800101.000002 scala/collection/parallel/ParIterableLike$Max.class
+-rw----     2.0 fat     6996 b-  0% stor 19800101.000002 scala/collection/parallel/ParIterableLike$Min.class
+-rw----     2.0 fat      614 b-  0% stor 19800101.000002 scala/collection/parallel/ParIterableLike$NonDivisible.class
+-rw----     2.0 fat     1769 b-  0% stor 19800101.000002 scala/collection/parallel/ParIterableLike$NonDivisibleTask.class
+-rw----     2.0 fat     2467 b-  0% stor 19800101.000002 scala/collection/parallel/ParIterableLike$ParComposite.class
+-rw----     2.0 fat     9514 b-  0% stor 19800101.000002 scala/collection/parallel/ParIterableLike$Partition.class
+-rw----     2.0 fat     6509 b-  0% stor 19800101.000002 scala/collection/parallel/ParIterableLike$Product.class
+-rw----     2.0 fat     6998 b-  0% stor 19800101.000002 scala/collection/parallel/ParIterableLike$Reduce.class
+-rw----     2.0 fat     5485 b-  0% stor 19800101.000002 scala/collection/parallel/ParIterableLike$ResultMapping.class
+-rw----     2.0 fat     3053 b-  0% stor 19800101.000002 scala/collection/parallel/ParIterableLike$ScanLeaf$.class
+-rw----     2.0 fat     8259 b-  0% stor 19800101.000002 scala/collection/parallel/ParIterableLike$ScanLeaf.class
+-rw----     2.0 fat     2655 b-  0% stor 19800101.000002 scala/collection/parallel/ParIterableLike$ScanNode$.class
+-rw----     2.0 fat     6510 b-  0% stor 19800101.000002 scala/collection/parallel/ParIterableLike$ScanNode.class
+-rw----     2.0 fat     1282 b-  0% stor 19800101.000002 scala/collection/parallel/ParIterableLike$ScanTree.class
+-rw----     2.0 fat     2279 b-  0% stor 19800101.000002 scala/collection/parallel/ParIterableLike$SeqComposite.class
+-rw----     2.0 fat      586 b-  0% stor 19800101.000002 scala/collection/parallel/ParIterableLike$SignallingOps.class
+-rw----     2.0 fat    11654 b-  0% stor 19800101.000002 scala/collection/parallel/ParIterableLike$Slice.class
+-rw----     2.0 fat    12563 b-  0% stor 19800101.000002 scala/collection/parallel/ParIterableLike$Span.class
+-rw----     2.0 fat    12280 b-  0% stor 19800101.000002 scala/collection/parallel/ParIterableLike$SplitAt.class
+-rw----     2.0 fat     1558 b-  0% stor 19800101.000002 scala/collection/parallel/ParIterableLike$StrictSplitterCheckTask.class
+-rw----     2.0 fat     6464 b-  0% stor 19800101.000002 scala/collection/parallel/ParIterableLike$Sum.class
+-rw----     2.0 fat    11228 b-  0% stor 19800101.000002 scala/collection/parallel/ParIterableLike$Take.class
+-rw----     2.0 fat    12029 b-  0% stor 19800101.000002 scala/collection/parallel/ParIterableLike$TakeWhile.class
+-rw----     2.0 fat     2405 b-  0% stor 19800101.000002 scala/collection/parallel/ParIterableLike$TaskOps.class
+-rw----     2.0 fat     7559 b-  0% stor 19800101.000002 scala/collection/parallel/ParIterableLike$ToParCollection.class
+-rw----     2.0 fat     8050 b-  0% stor 19800101.000002 scala/collection/parallel/ParIterableLike$ToParMap.class
+-rw----     2.0 fat      529 b-  0% stor 19800101.000002 scala/collection/parallel/ParIterableLike$Transformer.class
+-rw----     2.0 fat    10293 b-  0% stor 19800101.000002 scala/collection/parallel/ParIterableLike$Zip.class
+-rw----     2.0 fat    11715 b-  0% stor 19800101.000002 scala/collection/parallel/ParIterableLike$ZipAll.class
+-rw----     2.0 fat   107832 b-  0% stor 19800101.000002 scala/collection/parallel/ParIterableLike.class
+-rw----     2.0 fat     1905 b-  0% stor 19800101.000002 scala/collection/parallel/ParMap$.class
+-rw----     2.0 fat    56228 b-  0% stor 19800101.000002 scala/collection/parallel/ParMap$WithDefault.class
+-rw----     2.0 fat     5036 b-  0% stor 19800101.000002 scala/collection/parallel/ParMap.class
+-rw----     2.0 fat    59748 b-  0% stor 19800101.000002 scala/collection/parallel/ParMapLike$$anon$1.class
+-rw----     2.0 fat    59916 b-  0% stor 19800101.000002 scala/collection/parallel/ParMapLike$$anon$2.class
+-rw----     2.0 fat    48448 b-  0% stor 19800101.000002 scala/collection/parallel/ParMapLike$$anon$3.class
+-rw----     2.0 fat    48456 b-  0% stor 19800101.000002 scala/collection/parallel/ParMapLike$$anon$4.class
+-rw----     2.0 fat    59489 b-  0% stor 19800101.000002 scala/collection/parallel/ParMapLike$DefaultKeySet.class
+-rw----     2.0 fat    51680 b-  0% stor 19800101.000002 scala/collection/parallel/ParMapLike$DefaultValuesIterable.class
+-rw----     2.0 fat     9625 b-  0% stor 19800101.000002 scala/collection/parallel/ParMapLike.class
+-rw----     2.0 fat     1799 b-  0% stor 19800101.000002 scala/collection/parallel/ParSeq$.class
+-rw----     2.0 fat     9703 b-  0% stor 19800101.000002 scala/collection/parallel/ParSeq.class
+-rw----     2.0 fat     2002 b-  0% stor 19800101.000002 scala/collection/parallel/ParSeqLike$$anon$3.class
+-rw----     2.0 fat     1999 b-  0% stor 19800101.000002 scala/collection/parallel/ParSeqLike$$anon$4.class
+-rw----     2.0 fat     2003 b-  0% stor 19800101.000002 scala/collection/parallel/ParSeqLike$$anon$5.class
+-rw----     2.0 fat      769 b-  0% stor 19800101.000002 scala/collection/parallel/ParSeqLike$$anon$6.class
+-rw----     2.0 fat      775 b-  0% stor 19800101.000002 scala/collection/parallel/ParSeqLike$$anon$7.class
+-rw----     2.0 fat      766 b-  0% stor 19800101.000002 scala/collection/parallel/ParSeqLike$$anon$8.class
+-rw----     2.0 fat      786 b-  0% stor 19800101.000002 scala/collection/parallel/ParSeqLike$$anon$9.class
+-rw----     2.0 fat      664 b-  0% stor 19800101.000002 scala/collection/parallel/ParSeqLike$Accessor.class
+-rw----     2.0 fat     9893 b-  0% stor 19800101.000002 scala/collection/parallel/ParSeqLike$Corresponds.class
+-rw----     2.0 fat     1174 b-  0% stor 19800101.000002 scala/collection/parallel/ParSeqLike$Elements$$anon$1.class
+-rw----     2.0 fat     1459 b-  0% stor 19800101.000002 scala/collection/parallel/ParSeqLike$Elements$$anon$2.class
+-rw----     2.0 fat    56472 b-  0% stor 19800101.000002 scala/collection/parallel/ParSeqLike$Elements.class
+-rw----     2.0 fat    10321 b-  0% stor 19800101.000002 scala/collection/parallel/ParSeqLike$IndexWhere.class
+-rw----     2.0 fat    10373 b-  0% stor 19800101.000002 scala/collection/parallel/ParSeqLike$LastIndexWhere.class
+-rw----     2.0 fat     7673 b-  0% stor 19800101.000002 scala/collection/parallel/ParSeqLike$Reverse.class
+-rw----     2.0 fat     7829 b-  0% stor 19800101.000002 scala/collection/parallel/ParSeqLike$ReverseMap.class
+-rw----     2.0 fat     9702 b-  0% stor 19800101.000002 scala/collection/parallel/ParSeqLike$SameElements.class
+-rw----     2.0 fat    10696 b-  0% stor 19800101.000002 scala/collection/parallel/ParSeqLike$SegmentLength.class
+-rw----     2.0 fat      707 b-  0% stor 19800101.000002 scala/collection/parallel/ParSeqLike$Transformer.class
+-rw----     2.0 fat    10820 b-  0% stor 19800101.000002 scala/collection/parallel/ParSeqLike$Updated.class
+-rw----     2.0 fat     8696 b-  0% stor 19800101.000002 scala/collection/parallel/ParSeqLike$Zip.class
+-rw----     2.0 fat    38493 b-  0% stor 19800101.000002 scala/collection/parallel/ParSeqLike.class
+-rw----     2.0 fat     1454 b-  0% stor 19800101.000002 scala/collection/parallel/ParSet$.class
+-rw----     2.0 fat     3587 b-  0% stor 19800101.000002 scala/collection/parallel/ParSet.class
+-rw----     2.0 fat     3820 b-  0% stor 19800101.000002 scala/collection/parallel/ParSetLike.class
+-rw----     2.0 fat     1979 b-  0% stor 19800101.000002 scala/collection/parallel/ParallelCollectionImplicits$$anon$1.class
+-rw----     2.0 fat     1660 b-  0% stor 19800101.000002 scala/collection/parallel/ParallelCollectionImplicits$$anon$2$$anon$3.class
+-rw----     2.0 fat     2328 b-  0% stor 19800101.000002 scala/collection/parallel/ParallelCollectionImplicits$$anon$2.class
+-rw----     2.0 fat     1668 b-  0% stor 19800101.000002 scala/collection/parallel/ParallelCollectionImplicits$$anon$4$$anon$5.class
+-rw----     2.0 fat     1993 b-  0% stor 19800101.000002 scala/collection/parallel/ParallelCollectionImplicits$$anon$4.class
+-rw----     2.0 fat     1891 b-  0% stor 19800101.000002 scala/collection/parallel/ParallelCollectionImplicits$.class
+-rw----     2.0 fat     1847 b-  0% stor 19800101.000002 scala/collection/parallel/ParallelCollectionImplicits.class
+-rw----     2.0 fat     1108 b-  0% stor 19800101.000002 scala/collection/parallel/PreciseSplitter.class
+-rw----     2.0 fat     1281 b-  0% stor 19800101.000002 scala/collection/parallel/RemainsIterator.class
+-rw----     2.0 fat     1637 b-  0% stor 19800101.000002 scala/collection/parallel/SeqSplitter$$anon$1.class
+-rw----     2.0 fat    17030 b-  0% stor 19800101.000002 scala/collection/parallel/SeqSplitter$Appended.class
+-rw----     2.0 fat    13364 b-  0% stor 19800101.000002 scala/collection/parallel/SeqSplitter$Mapped.class
+-rw----     2.0 fat    53615 b-  0% stor 19800101.000002 scala/collection/parallel/SeqSplitter$Patched.class
+-rw----     2.0 fat    13200 b-  0% stor 19800101.000002 scala/collection/parallel/SeqSplitter$Taken.class
+-rw----     2.0 fat    13766 b-  0% stor 19800101.000002 scala/collection/parallel/SeqSplitter$Zipped.class
+-rw----     2.0 fat    13768 b-  0% stor 19800101.000002 scala/collection/parallel/SeqSplitter$ZippedAll.class
+-rw----     2.0 fat    13460 b-  0% stor 19800101.000002 scala/collection/parallel/SeqSplitter.class
+-rw----     2.0 fat    29378 b-  0% stor 19800101.000002 scala/collection/parallel/Splitter$$anon$1.class
+-rw----     2.0 fat      726 b-  0% stor 19800101.000002 scala/collection/parallel/Splitter$.class
+-rw----     2.0 fat     1124 b-  0% stor 19800101.000002 scala/collection/parallel/Splitter.class
+-rw----     2.0 fat     6075 b-  0% stor 19800101.000002 scala/collection/parallel/Task.class
+-rw----     2.0 fat      431 b-  0% stor 19800101.000002 scala/collection/parallel/TaskSupport.class
+-rw----     2.0 fat     1225 b-  0% stor 19800101.000002 scala/collection/parallel/Tasks$WrappedTask.class
+-rw----     2.0 fat     3374 b-  0% stor 19800101.000002 scala/collection/parallel/Tasks.class
+-rw----     2.0 fat      759 b-  0% stor 19800101.000002 scala/collection/parallel/ThreadPoolTaskSupport$.class
+-rw----     2.0 fat     6218 b-  0% stor 19800101.000002 scala/collection/parallel/ThreadPoolTaskSupport.class
+-rw----     2.0 fat     1344 b-  0% stor 19800101.000002 scala/collection/parallel/ThreadPoolTasks$$anon$1.class
+-rw----     2.0 fat     1783 b-  0% stor 19800101.000002 scala/collection/parallel/ThreadPoolTasks$.class
+-rw----     2.0 fat     3229 b-  0% stor 19800101.000002 scala/collection/parallel/ThreadPoolTasks$WrappedTask.class
+-rw----     2.0 fat     7381 b-  0% stor 19800101.000002 scala/collection/parallel/ThreadPoolTasks.class
+-rw----     2.0 fat      713 b-  0% stor 19800101.000002 scala/collection/parallel/ThrowableOps.class
+-rw----     2.0 fat      480 b-  0% stor 19800101.000002 scala/collection/parallel/TraversableOps$Otherwise.class
+-rw----     2.0 fat     1881 b-  0% stor 19800101.000002 scala/collection/parallel/TraversableOps.class
+-rw----     2.0 fat        0 bl  0% defN 19800101.000000 scala/collection/parallel/immutable/
+-rw----     2.0 fat      708 b-  0% stor 19800101.000002 scala/collection/parallel/immutable/HashMapCombiner$$anon$1.class
+-rw----     2.0 fat     1055 b-  0% stor 19800101.000002 scala/collection/parallel/immutable/HashMapCombiner$.class
+-rw----     2.0 fat    10519 b-  0% stor 19800101.000002 scala/collection/parallel/immutable/HashMapCombiner$CreateGroupedTrie.class
+-rw----     2.0 fat     6929 b-  0% stor 19800101.000002 scala/collection/parallel/immutable/HashMapCombiner$CreateTrie.class
+-rw----     2.0 fat    12102 b-  0% stor 19800101.000002 scala/collection/parallel/immutable/HashMapCombiner.class
+-rw----     2.0 fat      705 b-  0% stor 19800101.000002 scala/collection/parallel/immutable/HashSetCombiner$$anon$1.class
+-rw----     2.0 fat     1032 b-  0% stor 19800101.000002 scala/collection/parallel/immutable/HashSetCombiner$.class
+-rw----     2.0 fat     6644 b-  0% stor 19800101.000002 scala/collection/parallel/immutable/HashSetCombiner$CreateTrie.class
+-rw----     2.0 fat     8966 b-  0% stor 19800101.000002 scala/collection/parallel/immutable/HashSetCombiner.class
+-rw----     2.0 fat     9497 b-  0% stor 19800101.000002 scala/collection/parallel/immutable/LazyParVectorCombiner.class
+-rw----     2.0 fat     3069 b-  0% stor 19800101.000002 scala/collection/parallel/immutable/ParHashMap$.class
+-rw----     2.0 fat    51262 b-  0% stor 19800101.000002 scala/collection/parallel/immutable/ParHashMap$ParHashMapIterator.class
+-rw----     2.0 fat    65471 b-  0% stor 19800101.000002 scala/collection/parallel/immutable/ParHashMap.class
+-rw----     2.0 fat     2173 b-  0% stor 19800101.000002 scala/collection/parallel/immutable/ParHashSet$.class
+-rw----     2.0 fat    49972 b-  0% stor 19800101.000002 scala/collection/parallel/immutable/ParHashSet$ParHashSetIterator.class
+-rw----     2.0 fat    62992 b-  0% stor 19800101.000002 scala/collection/parallel/immutable/ParHashSet.class
+-rw----     2.0 fat     1665 b-  0% stor 19800101.000002 scala/collection/parallel/immutable/ParIterable$.class
+-rw----     2.0 fat    10104 b-  0% stor 19800101.000002 scala/collection/parallel/immutable/ParIterable.class
+-rw----     2.0 fat     1984 b-  0% stor 19800101.000002 scala/collection/parallel/immutable/ParMap$.class
+-rw----     2.0 fat    12005 b-  0% stor 19800101.000002 scala/collection/parallel/immutable/ParMap$WithDefault.class
+-rw----     2.0 fat     8484 b-  0% stor 19800101.000002 scala/collection/parallel/immutable/ParMap.class
+-rw----     2.0 fat     1195 b-  0% stor 19800101.000002 scala/collection/parallel/immutable/ParRange$.class
+-rw----     2.0 fat      866 b-  0% stor 19800101.000002 scala/collection/parallel/immutable/ParRange$ParRangeIterator$.class
+-rw----     2.0 fat    56646 b-  0% stor 19800101.000002 scala/collection/parallel/immutable/ParRange$ParRangeIterator.class
+-rw----     2.0 fat    65911 b-  0% stor 19800101.000002 scala/collection/parallel/immutable/ParRange.class
+-rw----     2.0 fat     1630 b-  0% stor 19800101.000002 scala/collection/parallel/immutable/ParSeq$.class
+-rw----     2.0 fat     9149 b-  0% stor 19800101.000002 scala/collection/parallel/immutable/ParSeq.class
+-rw----     2.0 fat     1511 b-  0% stor 19800101.000002 scala/collection/parallel/immutable/ParSet$.class
+-rw----     2.0 fat     3984 b-  0% stor 19800101.000002 scala/collection/parallel/immutable/ParSet.class
+-rw----     2.0 fat     1748 b-  0% stor 19800101.000002 scala/collection/parallel/immutable/ParVector$.class
+-rw----     2.0 fat    31925 b-  0% stor 19800101.000002 scala/collection/parallel/immutable/ParVector$ParVectorIterator.class
+-rw----     2.0 fat    68764 b-  0% stor 19800101.000002 scala/collection/parallel/immutable/ParVector.class
+-rw----     2.0 fat     8696 b-  0% stor 19800101.000002 scala/collection/parallel/immutable/Repetition$$anon$1.class
+-rw----     2.0 fat     1224 b-  0% stor 19800101.000002 scala/collection/parallel/immutable/Repetition$ParIterator$.class
+-rw----     2.0 fat    55657 b-  0% stor 19800101.000002 scala/collection/parallel/immutable/Repetition$ParIterator.class
+-rw----     2.0 fat    64184 b-  0% stor 19800101.000002 scala/collection/parallel/immutable/Repetition.class
+-rw----     2.0 fat      892 b-  0% stor 19800101.000002 scala/collection/parallel/immutable/package$.class
+-rw----     2.0 fat      918 b-  0% stor 19800101.000002 scala/collection/parallel/immutable/package.class
+-rw----     2.0 fat        0 bl  0% defN 19800101.000000 scala/collection/parallel/mutable/
+-rw----     2.0 fat     1849 b-  0% stor 19800101.000002 scala/collection/parallel/mutable/ExposedArrayBuffer.class
+-rw----     2.0 fat     1553 b-  0% stor 19800101.000002 scala/collection/parallel/mutable/ExposedArraySeq.class
+-rw----     2.0 fat     6230 b-  0% stor 19800101.000002 scala/collection/parallel/mutable/LazyCombiner.class
+-rw----     2.0 fat     6002 b-  0% stor 19800101.000002 scala/collection/parallel/mutable/ParArray$.class
+-rw----     2.0 fat     5248 b-  0% stor 19800101.000002 scala/collection/parallel/mutable/ParArray$Map.class
+-rw----     2.0 fat     1177 b-  0% stor 19800101.000002 scala/collection/parallel/mutable/ParArray$ParArrayIterator$.class
+-rw----     2.0 fat    70743 b-  0% stor 19800101.000002 scala/collection/parallel/mutable/ParArray$ParArrayIterator.class
+-rw----     2.0 fat     7266 b-  0% stor 19800101.000002 scala/collection/parallel/mutable/ParArray$ScanToArray.class
+-rw----     2.0 fat    82289 b-  0% stor 19800101.000002 scala/collection/parallel/mutable/ParArray.class
+-rw----     2.0 fat    51302 b-  0% stor 19800101.000002 scala/collection/parallel/mutable/ParFlatHashTable$ParFlatHashTableIterator.class
+-rw----     2.0 fat     2292 b-  0% stor 19800101.000002 scala/collection/parallel/mutable/ParFlatHashTable.class
+-rw----     2.0 fat     2400 b-  0% stor 19800101.000002 scala/collection/parallel/mutable/ParHashMap$.class
+-rw----     2.0 fat     2987 b-  0% stor 19800101.000002 scala/collection/parallel/mutable/ParHashMap$ParHashMapIterator.class
+-rw----     2.0 fat    84379 b-  0% stor 19800101.000002 scala/collection/parallel/mutable/ParHashMap.class
+-rw----     2.0 fat      864 b-  0% stor 19800101.000002 scala/collection/parallel/mutable/ParHashMapCombiner$$anon$1.class
+-rw----     2.0 fat     1317 b-  0% stor 19800101.000002 scala/collection/parallel/mutable/ParHashMapCombiner$.class
+-rw----     2.0 fat    12187 b-  0% stor 19800101.000002 scala/collection/parallel/mutable/ParHashMapCombiner$AddingHashTable.class
+-rw----     2.0 fat     7232 b-  0% stor 19800101.000002 scala/collection/parallel/mutable/ParHashMapCombiner$FillBlocks.class
+-rw----     2.0 fat    11376 b-  0% stor 19800101.000002 scala/collection/parallel/mutable/ParHashMapCombiner$table$2$.class
+-rw----     2.0 fat    11579 b-  0% stor 19800101.000002 scala/collection/parallel/mutable/ParHashMapCombiner.class
+-rw----     2.0 fat     1890 b-  0% stor 19800101.000002 scala/collection/parallel/mutable/ParHashSet$.class
+-rw----     2.0 fat     1930 b-  0% stor 19800101.000002 scala/collection/parallel/mutable/ParHashSet$ParHashSetIterator.class
+-rw----     2.0 fat    76052 b-  0% stor 19800101.000002 scala/collection/parallel/mutable/ParHashSet.class
+-rw----     2.0 fat      869 b-  0% stor 19800101.000002 scala/collection/parallel/mutable/ParHashSetCombiner$$anon$1.class
+-rw----     2.0 fat    12508 b-  0% stor 19800101.000002 scala/collection/parallel/mutable/ParHashSetCombiner$$anon$2.class
+-rw----     2.0 fat     1294 b-  0% stor 19800101.000002 scala/collection/parallel/mutable/ParHashSetCombiner$.class
+-rw----     2.0 fat    10855 b-  0% stor 19800101.000002 scala/collection/parallel/mutable/ParHashSetCombiner$AddingFlatHashTable.class
+-rw----     2.0 fat    10359 b-  0% stor 19800101.000002 scala/collection/parallel/mutable/ParHashSetCombiner$FillBlocks.class
+-rw----     2.0 fat    10574 b-  0% stor 19800101.000002 scala/collection/parallel/mutable/ParHashSetCombiner.class
+-rw----     2.0 fat    54923 b-  0% stor 19800101.000002 scala/collection/parallel/mutable/ParHashTable$EntryIterator.class
+-rw----     2.0 fat     2763 b-  0% stor 19800101.000002 scala/collection/parallel/mutable/ParHashTable.class
+-rw----     2.0 fat     1882 b-  0% stor 19800101.000002 scala/collection/parallel/mutable/ParIterable$.class
+-rw----     2.0 fat    10198 b-  0% stor 19800101.000002 scala/collection/parallel/mutable/ParIterable.class
+-rw----     2.0 fat     1969 b-  0% stor 19800101.000002 scala/collection/parallel/mutable/ParMap$.class
+-rw----     2.0 fat    15599 b-  0% stor 19800101.000002 scala/collection/parallel/mutable/ParMap$WithDefault.class
+-rw----     2.0 fat     7719 b-  0% stor 19800101.000002 scala/collection/parallel/mutable/ParMap.class
+-rw----     2.0 fat     3694 b-  0% stor 19800101.000002 scala/collection/parallel/mutable/ParMapLike.class
+-rw----     2.0 fat     1847 b-  0% stor 19800101.000002 scala/collection/parallel/mutable/ParSeq$.class
+-rw----     2.0 fat     9395 b-  0% stor 19800101.000002 scala/collection/parallel/mutable/ParSeq.class
+-rw----     2.0 fat     1628 b-  0% stor 19800101.000002 scala/collection/parallel/mutable/ParSet$.class
+-rw----     2.0 fat     3640 b-  0% stor 19800101.000002 scala/collection/parallel/mutable/ParSet.class
+-rw----     2.0 fat     2997 b-  0% stor 19800101.000002 scala/collection/parallel/mutable/ParSetLike.class
+-rw----     2.0 fat     1950 b-  0% stor 19800101.000002 scala/collection/parallel/mutable/ParTrieMap$.class
+-rw----     2.0 fat     5164 b-  0% stor 19800101.000002 scala/collection/parallel/mutable/ParTrieMap$Size.class
+-rw----     2.0 fat    72552 b-  0% stor 19800101.000002 scala/collection/parallel/mutable/ParTrieMap.class
+-rw----     2.0 fat     2316 b-  0% stor 19800101.000002 scala/collection/parallel/mutable/ParTrieMapCombiner.class
+-rw----     2.0 fat    25373 b-  0% stor 19800101.000002 scala/collection/parallel/mutable/ParTrieMapSplitter.class
+-rw----     2.0 fat     9527 b-  0% stor 19800101.000002 scala/collection/parallel/mutable/ResizableParArrayCombiner$$anon$1.class
+-rw----     2.0 fat     1592 b-  0% stor 19800101.000002 scala/collection/parallel/mutable/ResizableParArrayCombiner$.class
+-rw----     2.0 fat     6629 b-  0% stor 19800101.000002 scala/collection/parallel/mutable/ResizableParArrayCombiner$CopyChainToArray.class
+-rw----     2.0 fat     6106 b-  0% stor 19800101.000002 scala/collection/parallel/mutable/ResizableParArrayCombiner.class
+-rw----     2.0 fat     2004 b-  0% stor 19800101.000002 scala/collection/parallel/mutable/SizeMapUtils.class
+-rw----     2.0 fat     7482 b-  0% stor 19800101.000002 scala/collection/parallel/mutable/UnrolledParArrayCombiner$$anon$1.class
+-rw----     2.0 fat      862 b-  0% stor 19800101.000002 scala/collection/parallel/mutable/UnrolledParArrayCombiner$.class
+-rw----     2.0 fat     6898 b-  0% stor 19800101.000002 scala/collection/parallel/mutable/UnrolledParArrayCombiner$CopyUnrolledToArray.class
+-rw----     2.0 fat     7185 b-  0% stor 19800101.000002 scala/collection/parallel/mutable/UnrolledParArrayCombiner.class
+-rw----     2.0 fat      771 b-  0% stor 19800101.000002 scala/collection/parallel/mutable/package$.class
+-rw----     2.0 fat      884 b-  0% stor 19800101.000002 scala/collection/parallel/mutable/package.class
+-rw----     2.0 fat     2930 b-  0% stor 19800101.000002 scala/collection/parallel/package$.class
+-rw----     2.0 fat     2305 b-  0% stor 19800101.000002 scala/collection/parallel/package$CollectionsHaveToParArray.class
+-rw----     2.0 fat     2542 b-  0% stor 19800101.000002 scala/collection/parallel/package.class
+-rw----     2.0 fat        0 bl  0% defN 19800101.000000 scala/collection/script/
+-rw----     2.0 fat     1842 b-  0% stor 19800101.000002 scala/collection/script/End$.class
+-rw----     2.0 fat     1559 b-  0% stor 19800101.000002 scala/collection/script/End.class
+-rw----     2.0 fat     1815 b-  0% stor 19800101.000002 scala/collection/script/Include$.class
+-rw----     2.0 fat     5543 b-  0% stor 19800101.000002 scala/collection/script/Include.class
+-rw----     2.0 fat     1749 b-  0% stor 19800101.000002 scala/collection/script/Index$.class
+-rw----     2.0 fat     5373 b-  0% stor 19800101.000002 scala/collection/script/Index.class
+-rw----     2.0 fat      712 b-  0% stor 19800101.000002 scala/collection/script/Location.class
+-rw----     2.0 fat      566 b-  0% stor 19800101.000002 scala/collection/script/Message.class
+-rw----     2.0 fat     1845 b-  0% stor 19800101.000002 scala/collection/script/NoLo$.class
+-rw----     2.0 fat     1565 b-  0% stor 19800101.000002 scala/collection/script/NoLo.class
+-rw----     2.0 fat     1806 b-  0% stor 19800101.000002 scala/collection/script/Remove$.class
+-rw----     2.0 fat     5532 b-  0% stor 19800101.000002 scala/collection/script/Remove.class
+-rw----     2.0 fat     1206 b-  0% stor 19800101.000002 scala/collection/script/Reset$.class
+-rw----     2.0 fat     3627 b-  0% stor 19800101.000002 scala/collection/script/Reset.class
+-rw----     2.0 fat     1873 b-  0% stor 19800101.000002 scala/collection/script/Script.class
+-rw----     2.0 fat      818 b-  0% stor 19800101.000002 scala/collection/script/Scriptable.class
+-rw----     2.0 fat     1848 b-  0% stor 19800101.000002 scala/collection/script/Start$.class
+-rw----     2.0 fat     1570 b-  0% stor 19800101.000002 scala/collection/script/Start.class
+-rw----     2.0 fat     1806 b-  0% stor 19800101.000002 scala/collection/script/Update$.class
+-rw----     2.0 fat     5532 b-  0% stor 19800101.000002 scala/collection/script/Update.class
+-rw----     2.0 fat        0 bl  0% defN 19800101.000000 scala/compat/
+-rw----     2.0 fat     2089 b-  0% stor 19800101.000002 scala/compat/Platform$.class
+-rw----     2.0 fat     2006 b-  0% stor 19800101.000002 scala/compat/Platform.class
+-rw----     2.0 fat        0 bl  0% defN 19800101.000000 scala/concurrent/
+-rw----     2.0 fat     3517 b-  0% stor 19800101.000002 scala/concurrent/Await$.class
+-rw----     2.0 fat     1640 b-  0% stor 19800101.000002 scala/concurrent/Await.class
+-rw----     2.0 fat      460 b-  0% stor 19800101.000002 scala/concurrent/AwaitPermission$.class
+-rw----     2.0 fat      400 b-  0% stor 19800101.000002 scala/concurrent/AwaitPermission.class
+-rw----     2.0 fat     1555 b-  0% stor 19800101.000002 scala/concurrent/Awaitable.class
+-rw----     2.0 fat     5042 b-  0% stor 19800101.000002 scala/concurrent/BatchingExecutor$Batch.class
+-rw----     2.0 fat     3652 b-  0% stor 19800101.000002 scala/concurrent/BatchingExecutor.class
+-rw----     2.0 fat     2058 b-  0% stor 19800101.000002 scala/concurrent/BlockContext$.class
+-rw----     2.0 fat      988 b-  0% stor 19800101.000002 scala/concurrent/BlockContext$DefaultBlockContext$.class
+-rw----     2.0 fat     1827 b-  0% stor 19800101.000002 scala/concurrent/BlockContext.class
+-rw----     2.0 fat      499 b-  0% stor 19800101.000002 scala/concurrent/CanAwait.class
+-rw----     2.0 fat     1621 b-  0% stor 19800101.000002 scala/concurrent/Channel$LinkedList.class
+-rw----     2.0 fat     3056 b-  0% stor 19800101.000002 scala/concurrent/Channel.class
+-rw----     2.0 fat      990 b-  0% stor 19800101.000002 scala/concurrent/DelayedLazyVal$$anon$1.class
+-rw----     2.0 fat     2471 b-  0% stor 19800101.000002 scala/concurrent/DelayedLazyVal.class
+-rw----     2.0 fat     4628 b-  0% stor 19800101.000002 scala/concurrent/ExecutionContext$.class
+-rw----     2.0 fat     1254 b-  0% stor 19800101.000002 scala/concurrent/ExecutionContext$Implicits$.class
+-rw----     2.0 fat     5432 b-  0% stor 19800101.000002 scala/concurrent/ExecutionContext.class
+-rw----     2.0 fat      542 b-  0% stor 19800101.000002 scala/concurrent/ExecutionContextExecutor.class
+-rw----     2.0 fat      589 b-  0% stor 19800101.000002 scala/concurrent/ExecutionContextExecutorService.class
+-rw----     2.0 fat     1801 b-  0% stor 19800101.000002 scala/concurrent/Future$$anonfun$fallbackTo$1.class
+-rw----     2.0 fat     1780 b-  0% stor 19800101.000002 scala/concurrent/Future$$anonfun$fallbackTo$2.class
+-rw----     2.0 fat    21073 b-  0% stor 19800101.000002 scala/concurrent/Future$.class
+-rw----     2.0 fat     2598 b-  0% stor 19800101.000002 scala/concurrent/Future$InternalCallbackExecutor$.class
+-rw----     2.0 fat     9948 b-  0% stor 19800101.000002 scala/concurrent/Future$never$.class
+-rw----     2.0 fat    38915 b-  0% stor 19800101.000002 scala/concurrent/Future.class
+-rw----     2.0 fat     1059 b-  0% stor 19800101.000002 scala/concurrent/JavaConversions$.class
+-rw----     2.0 fat     1004 b-  0% stor 19800101.000002 scala/concurrent/JavaConversions.class
+-rw----     2.0 fat     1315 b-  0% stor 19800101.000002 scala/concurrent/Lock.class
+-rw----     2.0 fat      452 b-  0% stor 19800101.000002 scala/concurrent/OnCompleteRunnable.class
+-rw----     2.0 fat     1813 b-  0% stor 19800101.000002 scala/concurrent/Promise$.class
+-rw----     2.0 fat     7504 b-  0% stor 19800101.000002 scala/concurrent/Promise.class
+-rw----     2.0 fat     4000 b-  0% stor 19800101.000002 scala/concurrent/SyncChannel.class
+-rw----     2.0 fat     3938 b-  0% stor 19800101.000002 scala/concurrent/SyncVar.class
+-rw----     2.0 fat        0 bl  0% defN 19800101.000000 scala/concurrent/duration/
+-rw----     2.0 fat     1878 b-  0% stor 19800101.000002 scala/concurrent/duration/Deadline$.class
+-rw----     2.0 fat     3858 b-  0% stor 19800101.000002 scala/concurrent/duration/Deadline$DeadlineIsOrdered$.class
+-rw----     2.0 fat     6693 b-  0% stor 19800101.000002 scala/concurrent/duration/Deadline.class
+-rw----     2.0 fat     2344 b-  0% stor 19800101.000002 scala/concurrent/duration/Duration$$anon$1.class
+-rw----     2.0 fat     1667 b-  0% stor 19800101.000002 scala/concurrent/duration/Duration$$anon$2.class
+-rw----     2.0 fat     1617 b-  0% stor 19800101.000002 scala/concurrent/duration/Duration$$anon$3.class
+-rw----     2.0 fat    15776 b-  0% stor 19800101.000002 scala/concurrent/duration/Duration$.class
+-rw----     2.0 fat     3840 b-  0% stor 19800101.000002 scala/concurrent/duration/Duration$DurationIsOrdered$.class
+-rw----     2.0 fat     3867 b-  0% stor 19800101.000002 scala/concurrent/duration/Duration$Infinite.class
+-rw----     2.0 fat     8459 b-  0% stor 19800101.000002 scala/concurrent/duration/Duration.class
+-rw----     2.0 fat      469 b-  0% stor 19800101.000002 scala/concurrent/duration/DurationConversions$.class
+-rw----     2.0 fat      491 b-  0% stor 19800101.000002 scala/concurrent/duration/DurationConversions$Classifier.class
+-rw----     2.0 fat     1448 b-  0% stor 19800101.000002 scala/concurrent/duration/DurationConversions$fromNowConvert$.class
+-rw----     2.0 fat     1227 b-  0% stor 19800101.000002 scala/concurrent/duration/DurationConversions$spanConvert$.class
+-rw----     2.0 fat    12746 b-  0% stor 19800101.000002 scala/concurrent/duration/DurationConversions.class
+-rw----     2.0 fat     1916 b-  0% stor 19800101.000002 scala/concurrent/duration/FiniteDuration$.class
+-rw----     2.0 fat     3930 b-  0% stor 19800101.000002 scala/concurrent/duration/FiniteDuration$FiniteDurationIsOrdered$.class
+-rw----     2.0 fat    13313 b-  0% stor 19800101.000002 scala/concurrent/duration/FiniteDuration.class
+-rw----     2.0 fat     3165 b-  0% stor 19800101.000002 scala/concurrent/duration/package$.class
+-rw----     2.0 fat     1517 b-  0% stor 19800101.000002 scala/concurrent/duration/package$DoubleMult$.class
+-rw----     2.0 fat     1461 b-  0% stor 19800101.000002 scala/concurrent/duration/package$DoubleMult.class
+-rw----     2.0 fat     2088 b-  0% stor 19800101.000002 scala/concurrent/duration/package$DurationDouble$.class
+-rw----     2.0 fat     6260 b-  0% stor 19800101.000002 scala/concurrent/duration/package$DurationDouble.class
+-rw----     2.0 fat     1609 b-  0% stor 19800101.000002 scala/concurrent/duration/package$DurationInt$.class
+-rw----     2.0 fat     6233 b-  0% stor 19800101.000002 scala/concurrent/duration/package$DurationInt.class
+-rw----     2.0 fat     1539 b-  0% stor 19800101.000002 scala/concurrent/duration/package$DurationLong$.class
+-rw----     2.0 fat     6246 b-  0% stor 19800101.000002 scala/concurrent/duration/package$DurationLong.class
+-rw----     2.0 fat     1855 b-  0% stor 19800101.000002 scala/concurrent/duration/package$IntMult$.class
+-rw----     2.0 fat     1783 b-  0% stor 19800101.000002 scala/concurrent/duration/package$IntMult.class
+-rw----     2.0 fat     1864 b-  0% stor 19800101.000002 scala/concurrent/duration/package$LongMult$.class
+-rw----     2.0 fat     1796 b-  0% stor 19800101.000002 scala/concurrent/duration/package$LongMult.class
+-rw----     2.0 fat      526 b-  0% stor 19800101.000002 scala/concurrent/duration/package$fromNow$.class
+-rw----     2.0 fat      517 b-  0% stor 19800101.000002 scala/concurrent/duration/package$span$.class
+-rw----     2.0 fat     7250 b-  0% stor 19800101.000002 scala/concurrent/duration/package.class
+-rw----     2.0 fat        0 bl  0% defN 19800101.000000 scala/concurrent/forkjoin/
+-rw----     2.0 fat      433 b-  0% stor 19800101.000002 scala/concurrent/forkjoin/package$.class
+-rw----     2.0 fat     1308 b-  0% stor 19800101.000002 scala/concurrent/forkjoin/package$ForkJoinPool$.class
+-rw----     2.0 fat     3320 b-  0% stor 19800101.000002 scala/concurrent/forkjoin/package$ForkJoinTask$.class
+-rw----     2.0 fat      881 b-  0% stor 19800101.000002 scala/concurrent/forkjoin/package$ThreadLocalRandom$.class
+-rw----     2.0 fat     3219 b-  0% stor 19800101.000002 scala/concurrent/forkjoin/package.class
+-rw----     2.0 fat        0 bl  0% defN 19800101.000000 scala/concurrent/impl/
+-rw----     2.0 fat     3447 b-  0% stor 19800101.000002 scala/concurrent/impl/CallbackRunnable.class
+-rw----     2.0 fat     1424 b-  0% stor 19800101.000002 scala/concurrent/impl/ExecutionContextImpl$$anon$1$$anonfun$$lessinit$greater$1.class
+-rw----     2.0 fat     4930 b-  0% stor 19800101.000002 scala/concurrent/impl/ExecutionContextImpl$$anon$1.class
+-rw----     2.0 fat     2128 b-  0% stor 19800101.000002 scala/concurrent/impl/ExecutionContextImpl$$anon$3.class
+-rw----     2.0 fat     1141 b-  0% stor 19800101.000002 scala/concurrent/impl/ExecutionContextImpl$$anon$6.class
+-rw----     2.0 fat     6406 b-  0% stor 19800101.000002 scala/concurrent/impl/ExecutionContextImpl$.class
+-rw----     2.0 fat     1919 b-  0% stor 19800101.000002 scala/concurrent/impl/ExecutionContextImpl$AdaptedForkJoinTask.class
+-rw----     2.0 fat     2202 b-  0% stor 19800101.000002 scala/concurrent/impl/ExecutionContextImpl$DefaultThreadFactory$$anon$2$$anon$5.class
+-rw----     2.0 fat     2425 b-  0% stor 19800101.000002 scala/concurrent/impl/ExecutionContextImpl$DefaultThreadFactory$$anon$2.class
+-rw----     2.0 fat     1326 b-  0% stor 19800101.000002 scala/concurrent/impl/ExecutionContextImpl$DefaultThreadFactory$$anon$4.class
+-rw----     2.0 fat     4698 b-  0% stor 19800101.000002 scala/concurrent/impl/ExecutionContextImpl$DefaultThreadFactory.class
+-rw----     2.0 fat     7445 b-  0% stor 19800101.000002 scala/concurrent/impl/ExecutionContextImpl.class
+-rw----     2.0 fat     1808 b-  0% stor 19800101.000002 scala/concurrent/impl/Promise$.class
+-rw----     2.0 fat     6999 b-  0% stor 19800101.000002 scala/concurrent/impl/Promise$CompletionLatch.class
+-rw----     2.0 fat    21015 b-  0% stor 19800101.000002 scala/concurrent/impl/Promise$DefaultPromise.class
+-rw----     2.0 fat     1528 b-  0% stor 19800101.000002 scala/concurrent/impl/Promise$KeptPromise$.class
+-rw----     2.0 fat     2079 b-  0% stor 19800101.000002 scala/concurrent/impl/Promise$KeptPromise$Failed$$anonfun$fallbackTo$1.class
+-rw----     2.0 fat    14999 b-  0% stor 19800101.000002 scala/concurrent/impl/Promise$KeptPromise$Failed.class
+-rw----     2.0 fat     3956 b-  0% stor 19800101.000002 scala/concurrent/impl/Promise$KeptPromise$Kept.class
+-rw----     2.0 fat    16065 b-  0% stor 19800101.000002 scala/concurrent/impl/Promise$KeptPromise$Successful.class
+-rw----     2.0 fat    11634 b-  0% stor 19800101.000002 scala/concurrent/impl/Promise.class
+-rw----     2.0 fat     3049 b-  0% stor 19800101.000002 scala/concurrent/package$.class
+-rw----     2.0 fat     2090 b-  0% stor 19800101.000002 scala/concurrent/package.class
+-rw----     2.0 fat      615 b-  0% stor 19800101.000002 scala/deprecated$.class
+-rw----     2.0 fat     1443 b-  0% stor 19800101.000002 scala/deprecated.class
+-rw----     2.0 fat      648 b-  0% stor 19800101.000002 scala/deprecatedInheritance$.class
+-rw----     2.0 fat     1523 b-  0% stor 19800101.000002 scala/deprecatedInheritance.class
+-rw----     2.0 fat     1026 b-  0% stor 19800101.000002 scala/deprecatedName$.class
+-rw----     2.0 fat     1445 b-  0% stor 19800101.000002 scala/deprecatedName.class
+-rw----     2.0 fat      645 b-  0% stor 19800101.000002 scala/deprecatedOverriding$.class
+-rw----     2.0 fat     1516 b-  0% stor 19800101.000002 scala/deprecatedOverriding.class
+-rw----     2.0 fat      592 b-  0% stor 19800101.000002 scala/inline.class
+-rw----     2.0 fat        0 bl  0% defN 19800101.000000 scala/io/
+-rw----     2.0 fat      476 b-  0% stor 19800101.000002 scala/io/AnsiColor$.class
+-rw----     2.0 fat     5548 b-  0% stor 19800101.000002 scala/io/AnsiColor.class
+-rw----     2.0 fat     2084 b-  0% stor 19800101.000002 scala/io/BufferedSource$BufferedLineIterator.class
+-rw----     2.0 fat     7391 b-  0% stor 19800101.000002 scala/io/BufferedSource.class
+-rw----     2.0 fat      913 b-  0% stor 19800101.000002 scala/io/Codec$$anon$1.class
+-rw----     2.0 fat     4310 b-  0% stor 19800101.000002 scala/io/Codec$.class
+-rw----     2.0 fat     8125 b-  0% stor 19800101.000002 scala/io/Codec.class
+-rw----     2.0 fat     1041 b-  0% stor 19800101.000002 scala/io/LowPriorityCodecImplicits.class
+-rw----     2.0 fat     1040 b-  0% stor 19800101.000002 scala/io/Position$.class
+-rw----     2.0 fat     2386 b-  0% stor 19800101.000002 scala/io/Position.class
+-rw----     2.0 fat      943 b-  0% stor 19800101.000002 scala/io/Source$$anon$1.class
+-rw----     2.0 fat    10912 b-  0% stor 19800101.000002 scala/io/Source$.class
+-rw----     2.0 fat     2514 b-  0% stor 19800101.000002 scala/io/Source$LineIterator.class
+-rw----     2.0 fat     1065 b-  0% stor 19800101.000002 scala/io/Source$NoPositioner$.class
+-rw----     2.0 fat     2602 b-  0% stor 19800101.000002 scala/io/Source$Positioner.class
+-rw----     2.0 fat      645 b-  0% stor 19800101.000002 scala/io/Source$RelaxedPosition$.class
+-rw----     2.0 fat      716 b-  0% stor 19800101.000002 scala/io/Source$RelaxedPositioner$.class
+-rw----     2.0 fat    44342 b-  0% stor 19800101.000002 scala/io/Source.class
+-rw----     2.0 fat     3231 b-  0% stor 19800101.000002 scala/io/StdIn$.class
+-rw----     2.0 fat     9143 b-  0% stor 19800101.000002 scala/io/StdIn.class
+-rw----     2.0 fat     3733 b-  0% stor 19800101.000002 scala/language$.class
+-rw----     2.0 fat     1172 b-  0% stor 19800101.000002 scala/language$experimental$.class
+-rw----     2.0 fat     1892 b-  0% stor 19800101.000002 scala/language.class
+-rw----     2.0 fat      417 b-  0% stor 19800101.000002 scala/languageFeature$.class
+-rw----     2.0 fat      558 b-  0% stor 19800101.000002 scala/languageFeature$dynamics$.class
+-rw----     2.0 fat      238 b-  0% stor 19800101.000002 scala/languageFeature$dynamics.class
+-rw----     2.0 fat      578 b-  0% stor 19800101.000002 scala/languageFeature$existentials$.class
+-rw----     2.0 fat      246 b-  0% stor 19800101.000002 scala/languageFeature$existentials.class
+-rw----     2.0 fat      647 b-  0% stor 19800101.000002 scala/languageFeature$experimental$.class
+-rw----     2.0 fat      652 b-  0% stor 19800101.000002 scala/languageFeature$experimental$macros$.class
+-rw----     2.0 fat      312 b-  0% stor 19800101.000002 scala/languageFeature$experimental$macros.class
+-rw----     2.0 fat      573 b-  0% stor 19800101.000002 scala/languageFeature$higherKinds$.class
+-rw----     2.0 fat      244 b-  0% stor 19800101.000002 scala/languageFeature$higherKinds.class
+-rw----     2.0 fat      613 b-  0% stor 19800101.000002 scala/languageFeature$implicitConversions$.class
+-rw----     2.0 fat      260 b-  0% stor 19800101.000002 scala/languageFeature$implicitConversions.class
+-rw----     2.0 fat      568 b-  0% stor 19800101.000002 scala/languageFeature$postfixOps$.class
+-rw----     2.0 fat      242 b-  0% stor 19800101.000002 scala/languageFeature$postfixOps.class
+-rw----     2.0 fat      593 b-  0% stor 19800101.000002 scala/languageFeature$reflectiveCalls$.class
+-rw----     2.0 fat      252 b-  0% stor 19800101.000002 scala/languageFeature$reflectiveCalls.class
+-rw----     2.0 fat     2317 b-  0% stor 19800101.000002 scala/languageFeature.class
+-rw----     2.0 fat        0 bl  0% defN 19800101.000000 scala/math/
+-rw----     2.0 fat     9090 b-  0% stor 19800101.000002 scala/math/BigDecimal$.class
+-rw----     2.0 fat     1712 b-  0% stor 19800101.000002 scala/math/BigDecimal$RoundingMode$.class
+-rw----     2.0 fat    27558 b-  0% stor 19800101.000002 scala/math/BigDecimal.class
+-rw----     2.0 fat     3686 b-  0% stor 19800101.000002 scala/math/BigInt$.class
+-rw----     2.0 fat    17197 b-  0% stor 19800101.000002 scala/math/BigInt.class
+-rw----     2.0 fat      784 b-  0% stor 19800101.000002 scala/math/Equiv$$anon$1.class
+-rw----     2.0 fat      838 b-  0% stor 19800101.000002 scala/math/Equiv$$anon$2.class
+-rw----     2.0 fat     1014 b-  0% stor 19800101.000002 scala/math/Equiv$$anon$3.class
+-rw----     2.0 fat     1061 b-  0% stor 19800101.000002 scala/math/Equiv$$anon$4.class
+-rw----     2.0 fat     4225 b-  0% stor 19800101.000002 scala/math/Equiv$.class
+-rw----     2.0 fat     3902 b-  0% stor 19800101.000002 scala/math/Equiv.class
+-rw----     2.0 fat      540 b-  0% stor 19800101.000002 scala/math/Fractional$.class
+-rw----     2.0 fat     1270 b-  0% stor 19800101.000002 scala/math/Fractional$ExtraImplicits.class
+-rw----     2.0 fat     1239 b-  0% stor 19800101.000002 scala/math/Fractional$FractionalOps.class
+-rw----     2.0 fat     1256 b-  0% stor 19800101.000002 scala/math/Fractional$Implicits$.class
+-rw----     2.0 fat     2200 b-  0% stor 19800101.000002 scala/math/Fractional.class
+-rw----     2.0 fat      534 b-  0% stor 19800101.000002 scala/math/Integral$.class
+-rw----     2.0 fat     1226 b-  0% stor 19800101.000002 scala/math/Integral$ExtraImplicits.class
+-rw----     2.0 fat     1212 b-  0% stor 19800101.000002 scala/math/Integral$Implicits$.class
+-rw----     2.0 fat     1624 b-  0% stor 19800101.000002 scala/math/Integral$IntegralOps.class
+-rw----     2.0 fat     2325 b-  0% stor 19800101.000002 scala/math/Integral.class
+-rw----     2.0 fat     1115 b-  0% stor 19800101.000002 scala/math/LowPriorityEquiv.class
+-rw----     2.0 fat     3846 b-  0% stor 19800101.000002 scala/math/LowPriorityOrderingImplicits$$anon$6.class
+-rw----     2.0 fat     3801 b-  0% stor 19800101.000002 scala/math/LowPriorityOrderingImplicits$$anon$7.class
+-rw----     2.0 fat     2264 b-  0% stor 19800101.000002 scala/math/LowPriorityOrderingImplicits.class
+-rw----     2.0 fat      531 b-  0% stor 19800101.000002 scala/math/Numeric$.class
+-rw----     2.0 fat     8246 b-  0% stor 19800101.000002 scala/math/Numeric$BigDecimalAsIfIntegral$.class
+-rw----     2.0 fat     1583 b-  0% stor 19800101.000002 scala/math/Numeric$BigDecimalAsIfIntegral.class
+-rw----     2.0 fat     3742 b-  0% stor 19800101.000002 scala/math/Numeric$BigDecimalIsConflicted.class
+-rw----     2.0 fat     8023 b-  0% stor 19800101.000002 scala/math/Numeric$BigDecimalIsFractional$.class
+-rw----     2.0 fat     1349 b-  0% stor 19800101.000002 scala/math/Numeric$BigDecimalIsFractional.class
+-rw----     2.0 fat     8118 b-  0% stor 19800101.000002 scala/math/Numeric$BigIntIsIntegral$.class
+-rw----     2.0 fat     4080 b-  0% stor 19800101.000002 scala/math/Numeric$BigIntIsIntegral.class
+-rw----     2.0 fat     7598 b-  0% stor 19800101.000002 scala/math/Numeric$ByteIsIntegral$.class
+-rw----     2.0 fat     3274 b-  0% stor 19800101.000002 scala/math/Numeric$ByteIsIntegral.class
+-rw----     2.0 fat     7608 b-  0% stor 19800101.000002 scala/math/Numeric$CharIsIntegral$.class
+-rw----     2.0 fat     3274 b-  0% stor 19800101.000002 scala/math/Numeric$CharIsIntegral.class
+-rw----     2.0 fat     8864 b-  0% stor 19800101.000002 scala/math/Numeric$DoubleAsIfIntegral$.class
+-rw----     2.0 fat     1604 b-  0% stor 19800101.000002 scala/math/Numeric$DoubleAsIfIntegral.class
+-rw----     2.0 fat     3067 b-  0% stor 19800101.000002 scala/math/Numeric$DoubleIsConflicted.class
+-rw----     2.0 fat     8369 b-  0% stor 19800101.000002 scala/math/Numeric$DoubleIsFractional$.class
+-rw----     2.0 fat     1059 b-  0% stor 19800101.000002 scala/math/Numeric$DoubleIsFractional.class
+-rw----     2.0 fat     1169 b-  0% stor 19800101.000002 scala/math/Numeric$ExtraImplicits.class
+-rw----     2.0 fat     8848 b-  0% stor 19800101.000002 scala/math/Numeric$FloatAsIfIntegral$.class
+-rw----     2.0 fat     1595 b-  0% stor 19800101.000002 scala/math/Numeric$FloatAsIfIntegral.class
+-rw----     2.0 fat     3057 b-  0% stor 19800101.000002 scala/math/Numeric$FloatIsConflicted.class
+-rw----     2.0 fat     8354 b-  0% stor 19800101.000002 scala/math/Numeric$FloatIsFractional$.class
+-rw----     2.0 fat     1051 b-  0% stor 19800101.000002 scala/math/Numeric$FloatIsFractional.class
+-rw----     2.0 fat     1155 b-  0% stor 19800101.000002 scala/math/Numeric$Implicits$.class
+-rw----     2.0 fat     7537 b-  0% stor 19800101.000002 scala/math/Numeric$IntIsIntegral$.class
+-rw----     2.0 fat     3149 b-  0% stor 19800101.000002 scala/math/Numeric$IntIsIntegral.class
+-rw----     2.0 fat     7561 b-  0% stor 19800101.000002 scala/math/Numeric$LongIsIntegral$.class
+-rw----     2.0 fat     3213 b-  0% stor 19800101.000002 scala/math/Numeric$LongIsIntegral.class
+-rw----     2.0 fat     2179 b-  0% stor 19800101.000002 scala/math/Numeric$Ops.class
+-rw----     2.0 fat     7610 b-  0% stor 19800101.000002 scala/math/Numeric$ShortIsIntegral$.class
+-rw----     2.0 fat     3285 b-  0% stor 19800101.000002 scala/math/Numeric$ShortIsIntegral.class
+-rw----     2.0 fat    12181 b-  0% stor 19800101.000002 scala/math/Numeric.class
+-rw----     2.0 fat     1710 b-  0% stor 19800101.000002 scala/math/Ordered$$anon$1.class
+-rw----     2.0 fat      886 b-  0% stor 19800101.000002 scala/math/Ordered$.class
+-rw----     2.0 fat     3095 b-  0% stor 19800101.000002 scala/math/Ordered.class
+-rw----     2.0 fat     4248 b-  0% stor 19800101.000002 scala/math/Ordering$$anon$10.class
+-rw----     2.0 fat     3977 b-  0% stor 19800101.000002 scala/math/Ordering$$anon$11.class
+-rw----     2.0 fat     4161 b-  0% stor 19800101.000002 scala/math/Ordering$$anon$12.class
+-rw----     2.0 fat     4346 b-  0% stor 19800101.000002 scala/math/Ordering$$anon$13.class
+-rw----     2.0 fat     4531 b-  0% stor 19800101.000002 scala/math/Ordering$$anon$14.class
+-rw----     2.0 fat     4716 b-  0% stor 19800101.000002 scala/math/Ordering$$anon$15.class
+-rw----     2.0 fat     4901 b-  0% stor 19800101.000002 scala/math/Ordering$$anon$16.class
+-rw----     2.0 fat     5086 b-  0% stor 19800101.000002 scala/math/Ordering$$anon$17.class
+-rw----     2.0 fat     5271 b-  0% stor 19800101.000002 scala/math/Ordering$$anon$18.class
+-rw----     2.0 fat     4021 b-  0% stor 19800101.000002 scala/math/Ordering$$anon$3.class
+-rw----     2.0 fat     3473 b-  0% stor 19800101.000002 scala/math/Ordering$$anon$4.class
+-rw----     2.0 fat     3633 b-  0% stor 19800101.000002 scala/math/Ordering$$anon$5.class
+-rw----     2.0 fat     3730 b-  0% stor 19800101.000002 scala/math/Ordering$$anon$9.class
+-rw----     2.0 fat    11344 b-  0% stor 19800101.000002 scala/math/Ordering$.class
+-rw----     2.0 fat     3832 b-  0% stor 19800101.000002 scala/math/Ordering$BigDecimal$.class
+-rw----     2.0 fat     1071 b-  0% stor 19800101.000002 scala/math/Ordering$BigDecimalOrdering.class
+-rw----     2.0 fat     3772 b-  0% stor 19800101.000002 scala/math/Ordering$BigInt$.class
+-rw----     2.0 fat     1019 b-  0% stor 19800101.000002 scala/math/Ordering$BigIntOrdering.class
+-rw----     2.0 fat     3747 b-  0% stor 19800101.000002 scala/math/Ordering$Boolean$.class
+-rw----     2.0 fat      903 b-  0% stor 19800101.000002 scala/math/Ordering$BooleanOrdering.class
+-rw----     2.0 fat     3723 b-  0% stor 19800101.000002 scala/math/Ordering$Byte$.class
+-rw----     2.0 fat      885 b-  0% stor 19800101.000002 scala/math/Ordering$ByteOrdering.class
+-rw----     2.0 fat     3723 b-  0% stor 19800101.000002 scala/math/Ordering$Char$.class
+-rw----     2.0 fat      890 b-  0% stor 19800101.000002 scala/math/Ordering$CharOrdering.class
+-rw----     2.0 fat     4682 b-  0% stor 19800101.000002 scala/math/Ordering$Double$.class
+-rw----     2.0 fat     4504 b-  0% stor 19800101.000002 scala/math/Ordering$DoubleOrdering$$anon$2.class
+-rw----     2.0 fat     3190 b-  0% stor 19800101.000002 scala/math/Ordering$DoubleOrdering.class
+-rw----     2.0 fat     4290 b-  0% stor 19800101.000002 scala/math/Ordering$ExtraImplicits$$anon$8.class
+-rw----     2.0 fat     1803 b-  0% stor 19800101.000002 scala/math/Ordering$ExtraImplicits.class
+-rw----     2.0 fat     4669 b-  0% stor 19800101.000002 scala/math/Ordering$Float$.class
+-rw----     2.0 fat     4493 b-  0% stor 19800101.000002 scala/math/Ordering$FloatOrdering$$anon$1.class
+-rw----     2.0 fat     3180 b-  0% stor 19800101.000002 scala/math/Ordering$FloatOrdering.class
+-rw----     2.0 fat     1518 b-  0% stor 19800101.000002 scala/math/Ordering$Implicits$.class
+-rw----     2.0 fat     3715 b-  0% stor 19800101.000002 scala/math/Ordering$Int$.class
+-rw----     2.0 fat      883 b-  0% stor 19800101.000002 scala/math/Ordering$IntOrdering.class
+-rw----     2.0 fat     3723 b-  0% stor 19800101.000002 scala/math/Ordering$Long$.class
+-rw----     2.0 fat      885 b-  0% stor 19800101.000002 scala/math/Ordering$LongOrdering.class
+-rw----     2.0 fat     1923 b-  0% stor 19800101.000002 scala/math/Ordering$Ops.class
+-rw----     2.0 fat     1776 b-  0% stor 19800101.000002 scala/math/Ordering$OptionOrdering.class
+-rw----     2.0 fat     3731 b-  0% stor 19800101.000002 scala/math/Ordering$Short$.class
+-rw----     2.0 fat      891 b-  0% stor 19800101.000002 scala/math/Ordering$ShortOrdering.class
+-rw----     2.0 fat     3764 b-  0% stor 19800101.000002 scala/math/Ordering$String$.class
+-rw----     2.0 fat     1023 b-  0% stor 19800101.000002 scala/math/Ordering$StringOrdering.class
+-rw----     2.0 fat     3806 b-  0% stor 19800101.000002 scala/math/Ordering$Unit$.class
+-rw----     2.0 fat      983 b-  0% stor 19800101.000002 scala/math/Ordering$UnitOrdering.class
+-rw----     2.0 fat    23115 b-  0% stor 19800101.000002 scala/math/Ordering.class
+-rw----     2.0 fat     1984 b-  0% stor 19800101.000002 scala/math/PartialOrdering$$anon$1.class
+-rw----     2.0 fat     2945 b-  0% stor 19800101.000002 scala/math/PartialOrdering.class
+-rw----     2.0 fat     3338 b-  0% stor 19800101.000002 scala/math/PartiallyOrdered.class
+-rw----     2.0 fat      348 b-  0% stor 19800101.000002 scala/math/ScalaNumber.class
+-rw----     2.0 fat     5853 b-  0% stor 19800101.000002 scala/math/ScalaNumericAnyConversions.class
+-rw----     2.0 fat      581 b-  0% stor 19800101.000002 scala/math/ScalaNumericConversions.class
+-rw----     2.0 fat     5697 b-  0% stor 19800101.000002 scala/math/package$.class
+-rw----     2.0 fat     4755 b-  0% stor 19800101.000002 scala/math/package.class
+-rw----     2.0 fat      592 b-  0% stor 19800101.000002 scala/native.class
+-rw----     2.0 fat      600 b-  0% stor 19800101.000002 scala/noinline.class
+-rw----     2.0 fat      545 b-  0% stor 19800101.000002 scala/package$$anon$1.class
+-rw----     2.0 fat     6235 b-  0% stor 19800101.000002 scala/package$.class
+-rw----     2.0 fat     7056 b-  0% stor 19800101.000002 scala/package.class
+-rw----     2.0 fat        0 bl  0% defN 19800101.000000 scala/ref/
+-rw----     2.0 fat     4523 b-  0% stor 19800101.000002 scala/ref/PhantomReference.class
+-rw----     2.0 fat     1854 b-  0% stor 19800101.000002 scala/ref/PhantomReferenceWithWrapper.class
+-rw----     2.0 fat     2426 b-  0% stor 19800101.000002 scala/ref/Reference.class
+-rw----     2.0 fat     2594 b-  0% stor 19800101.000002 scala/ref/ReferenceQueue.class
+-rw----     2.0 fat      625 b-  0% stor 19800101.000002 scala/ref/ReferenceWithWrapper.class
+-rw----     2.0 fat     2906 b-  0% stor 19800101.000002 scala/ref/ReferenceWrapper.class
+-rw----     2.0 fat     1247 b-  0% stor 19800101.000002 scala/ref/SoftReference$.class
+-rw----     2.0 fat     5097 b-  0% stor 19800101.000002 scala/ref/SoftReference.class
+-rw----     2.0 fat     1976 b-  0% stor 19800101.000002 scala/ref/SoftReferenceWithWrapper.class
+-rw----     2.0 fat     1247 b-  0% stor 19800101.000002 scala/ref/WeakReference$.class
+-rw----     2.0 fat     5097 b-  0% stor 19800101.000002 scala/ref/WeakReference.class
+-rw----     2.0 fat     1976 b-  0% stor 19800101.000002 scala/ref/WeakReferenceWithWrapper.class
+-rw----     2.0 fat        0 bl  0% defN 19800101.000000 scala/reflect/
+-rw----     2.0 fat     6629 b-  0% stor 19800101.000002 scala/reflect/AnyValManifest.class
+-rw----     2.0 fat    14887 b-  0% stor 19800101.000002 scala/reflect/ClassManifestDeprecatedApis.class
+-rw----     2.0 fat     8068 b-  0% stor 19800101.000002 scala/reflect/ClassManifestFactory$.class
+-rw----     2.0 fat     6367 b-  0% stor 19800101.000002 scala/reflect/ClassManifestFactory$AbstractTypeClassManifest.class
+-rw----     2.0 fat     7256 b-  0% stor 19800101.000002 scala/reflect/ClassManifestFactory.class
+-rw----     2.0 fat     5728 b-  0% stor 19800101.000002 scala/reflect/ClassTag$.class
+-rw----     2.0 fat     5670 b-  0% stor 19800101.000002 scala/reflect/ClassTag$GenericClassTag.class
+-rw----     2.0 fat     8980 b-  0% stor 19800101.000002 scala/reflect/ClassTag.class
+-rw----     2.0 fat     7315 b-  0% stor 19800101.000002 scala/reflect/ClassTypeManifest.class
+-rw----     2.0 fat     3634 b-  0% stor 19800101.000002 scala/reflect/Manifest.class
+-rw----     2.0 fat     9485 b-  0% stor 19800101.000002 scala/reflect/ManifestFactory$.class
+-rw----     2.0 fat     6505 b-  0% stor 19800101.000002 scala/reflect/ManifestFactory$AbstractTypeManifest.class
+-rw----     2.0 fat     1683 b-  0% stor 19800101.000002 scala/reflect/ManifestFactory$AnyManifest.class
+-rw----     2.0 fat     1743 b-  0% stor 19800101.000002 scala/reflect/ManifestFactory$AnyValPhantomManifest.class
+-rw----     2.0 fat     2114 b-  0% stor 19800101.000002 scala/reflect/ManifestFactory$BooleanManifest.class
+-rw----     2.0 fat     2087 b-  0% stor 19800101.000002 scala/reflect/ManifestFactory$ByteManifest.class
+-rw----     2.0 fat     2097 b-  0% stor 19800101.000002 scala/reflect/ManifestFactory$CharManifest.class
+-rw----     2.0 fat     6716 b-  0% stor 19800101.000002 scala/reflect/ManifestFactory$ClassTypeManifest.class
+-rw----     2.0 fat     2105 b-  0% stor 19800101.000002 scala/reflect/ManifestFactory$DoubleManifest.class
+-rw----     2.0 fat     2096 b-  0% stor 19800101.000002 scala/reflect/ManifestFactory$FloatManifest.class
+-rw----     2.0 fat     2086 b-  0% stor 19800101.000002 scala/reflect/ManifestFactory$IntManifest.class
+-rw----     2.0 fat     6122 b-  0% stor 19800101.000002 scala/reflect/ManifestFactory$IntersectionTypeManifest.class
+-rw----     2.0 fat     2087 b-  0% stor 19800101.000002 scala/reflect/ManifestFactory$LongManifest.class
+-rw----     2.0 fat     1705 b-  0% stor 19800101.000002 scala/reflect/ManifestFactory$NothingManifest.class
+-rw----     2.0 fat     1789 b-  0% stor 19800101.000002 scala/reflect/ManifestFactory$NullManifest.class
+-rw----     2.0 fat     1722 b-  0% stor 19800101.000002 scala/reflect/ManifestFactory$ObjectManifest.class
+-rw----     2.0 fat     1584 b-  0% stor 19800101.000002 scala/reflect/ManifestFactory$PhantomManifest.class
+-rw----     2.0 fat     2096 b-  0% stor 19800101.000002 scala/reflect/ManifestFactory$ShortManifest.class
+-rw----     2.0 fat     6441 b-  0% stor 19800101.000002 scala/reflect/ManifestFactory$SingletonTypeManifest.class
+-rw----     2.0 fat     2659 b-  0% stor 19800101.000002 scala/reflect/ManifestFactory$UnitManifest.class
+-rw----     2.0 fat     6519 b-  0% stor 19800101.000002 scala/reflect/ManifestFactory$WildcardManifest.class
+-rw----     2.0 fat    13935 b-  0% stor 19800101.000002 scala/reflect/ManifestFactory.class
+-rw----     2.0 fat     5416 b-  0% stor 19800101.000002 scala/reflect/NameTransformer$.class
+-rw----     2.0 fat      962 b-  0% stor 19800101.000002 scala/reflect/NameTransformer$OpCodes.class
+-rw----     2.0 fat     2631 b-  0% stor 19800101.000002 scala/reflect/NameTransformer.class
+-rw----     2.0 fat      750 b-  0% stor 19800101.000002 scala/reflect/NoManifest$.class
+-rw----     2.0 fat      706 b-  0% stor 19800101.000002 scala/reflect/NoManifest.class
+-rw----     2.0 fat      530 b-  0% stor 19800101.000002 scala/reflect/OptManifest.class
+-rw----     2.0 fat      441 b-  0% stor 19800101.000002 scala/reflect/ScalaLongSignature.class
+-rw----     2.0 fat      432 b-  0% stor 19800101.000002 scala/reflect/ScalaSignature.class
+-rw----     2.0 fat        0 bl  0% defN 19800101.000000 scala/reflect/macros/
+-rw----     2.0 fat        0 bl  0% defN 19800101.000000 scala/reflect/macros/internal/
+-rw----     2.0 fat     1023 b-  0% stor 19800101.000002 scala/reflect/macros/internal/macroImpl.class
+-rw----     2.0 fat     1738 b-  0% stor 19800101.000002 scala/reflect/package$.class
+-rw----     2.0 fat     1750 b-  0% stor 19800101.000002 scala/reflect/package.class
+-rw----     2.0 fat      762 b-  0% stor 19800101.000002 scala/remote.class
+-rw----     2.0 fat        0 bl  0% defN 19800101.000000 scala/runtime/
+-rw----     2.0 fat      546 b-  0% stor 19800101.000002 scala/runtime/AbstractFunction0$mcB$sp.class
+-rw----     2.0 fat      546 b-  0% stor 19800101.000002 scala/runtime/AbstractFunction0$mcC$sp.class
+-rw----     2.0 fat      546 b-  0% stor 19800101.000002 scala/runtime/AbstractFunction0$mcD$sp.class
+-rw----     2.0 fat      546 b-  0% stor 19800101.000002 scala/runtime/AbstractFunction0$mcF$sp.class
+-rw----     2.0 fat      546 b-  0% stor 19800101.000002 scala/runtime/AbstractFunction0$mcI$sp.class
+-rw----     2.0 fat      546 b-  0% stor 19800101.000002 scala/runtime/AbstractFunction0$mcJ$sp.class
+-rw----     2.0 fat      546 b-  0% stor 19800101.000002 scala/runtime/AbstractFunction0$mcS$sp.class
+-rw----     2.0 fat      553 b-  0% stor 19800101.000002 scala/runtime/AbstractFunction0$mcV$sp.class
+-rw----     2.0 fat      546 b-  0% stor 19800101.000002 scala/runtime/AbstractFunction0$mcZ$sp.class
+-rw----     2.0 fat     2428 b-  0% stor 19800101.000002 scala/runtime/AbstractFunction0.class
+-rw----     2.0 fat      586 b-  0% stor 19800101.000002 scala/runtime/AbstractFunction1$mcDD$sp.class
+-rw----     2.0 fat      586 b-  0% stor 19800101.000002 scala/runtime/AbstractFunction1$mcDF$sp.class
+-rw----     2.0 fat      586 b-  0% stor 19800101.000002 scala/runtime/AbstractFunction1$mcDI$sp.class
+-rw----     2.0 fat      586 b-  0% stor 19800101.000002 scala/runtime/AbstractFunction1$mcDJ$sp.class
+-rw----     2.0 fat      586 b-  0% stor 19800101.000002 scala/runtime/AbstractFunction1$mcFD$sp.class
+-rw----     2.0 fat      586 b-  0% stor 19800101.000002 scala/runtime/AbstractFunction1$mcFF$sp.class
+-rw----     2.0 fat      586 b-  0% stor 19800101.000002 scala/runtime/AbstractFunction1$mcFI$sp.class
+-rw----     2.0 fat      586 b-  0% stor 19800101.000002 scala/runtime/AbstractFunction1$mcFJ$sp.class
+-rw----     2.0 fat      586 b-  0% stor 19800101.000002 scala/runtime/AbstractFunction1$mcID$sp.class
+-rw----     2.0 fat      586 b-  0% stor 19800101.000002 scala/runtime/AbstractFunction1$mcIF$sp.class
+-rw----     2.0 fat      586 b-  0% stor 19800101.000002 scala/runtime/AbstractFunction1$mcII$sp.class
+-rw----     2.0 fat      586 b-  0% stor 19800101.000002 scala/runtime/AbstractFunction1$mcIJ$sp.class
+-rw----     2.0 fat      586 b-  0% stor 19800101.000002 scala/runtime/AbstractFunction1$mcJD$sp.class
+-rw----     2.0 fat      586 b-  0% stor 19800101.000002 scala/runtime/AbstractFunction1$mcJF$sp.class
+-rw----     2.0 fat      586 b-  0% stor 19800101.000002 scala/runtime/AbstractFunction1$mcJI$sp.class
+-rw----     2.0 fat      586 b-  0% stor 19800101.000002 scala/runtime/AbstractFunction1$mcJJ$sp.class
+-rw----     2.0 fat      593 b-  0% stor 19800101.000002 scala/runtime/AbstractFunction1$mcVD$sp.class
+-rw----     2.0 fat      593 b-  0% stor 19800101.000002 scala/runtime/AbstractFunction1$mcVF$sp.class
+-rw----     2.0 fat      593 b-  0% stor 19800101.000002 scala/runtime/AbstractFunction1$mcVI$sp.class
+-rw----     2.0 fat      593 b-  0% stor 19800101.000002 scala/runtime/AbstractFunction1$mcVJ$sp.class
+-rw----     2.0 fat      586 b-  0% stor 19800101.000002 scala/runtime/AbstractFunction1$mcZD$sp.class
+-rw----     2.0 fat      586 b-  0% stor 19800101.000002 scala/runtime/AbstractFunction1$mcZF$sp.class
+-rw----     2.0 fat      586 b-  0% stor 19800101.000002 scala/runtime/AbstractFunction1$mcZI$sp.class
+-rw----     2.0 fat      586 b-  0% stor 19800101.000002 scala/runtime/AbstractFunction1$mcZJ$sp.class
+-rw----     2.0 fat     6676 b-  0% stor 19800101.000002 scala/runtime/AbstractFunction1.class
+-rw----     2.0 fat     3244 b-  0% stor 19800101.000002 scala/runtime/AbstractFunction10.class
+-rw----     2.0 fat     3340 b-  0% stor 19800101.000002 scala/runtime/AbstractFunction11.class
+-rw----     2.0 fat     3437 b-  0% stor 19800101.000002 scala/runtime/AbstractFunction12.class
+-rw----     2.0 fat     3534 b-  0% stor 19800101.000002 scala/runtime/AbstractFunction13.class
+-rw----     2.0 fat     3631 b-  0% stor 19800101.000002 scala/runtime/AbstractFunction14.class
+-rw----     2.0 fat     3728 b-  0% stor 19800101.000002 scala/runtime/AbstractFunction15.class
+-rw----     2.0 fat     3825 b-  0% stor 19800101.000002 scala/runtime/AbstractFunction16.class
+-rw----     2.0 fat     3922 b-  0% stor 19800101.000002 scala/runtime/AbstractFunction17.class
+-rw----     2.0 fat     4018 b-  0% stor 19800101.000002 scala/runtime/AbstractFunction18.class
+-rw----     2.0 fat     4115 b-  0% stor 19800101.000002 scala/runtime/AbstractFunction19.class
+-rw----     2.0 fat      626 b-  0% stor 19800101.000002 scala/runtime/AbstractFunction2$mcDDD$sp.class
+-rw----     2.0 fat      626 b-  0% stor 19800101.000002 scala/runtime/AbstractFunction2$mcDDI$sp.class
+-rw----     2.0 fat      626 b-  0% stor 19800101.000002 scala/runtime/AbstractFunction2$mcDDJ$sp.class
+-rw----     2.0 fat      626 b-  0% stor 19800101.000002 scala/runtime/AbstractFunction2$mcDID$sp.class
+-rw----     2.0 fat      626 b-  0% stor 19800101.000002 scala/runtime/AbstractFunction2$mcDII$sp.class
+-rw----     2.0 fat      626 b-  0% stor 19800101.000002 scala/runtime/AbstractFunction2$mcDIJ$sp.class
+-rw----     2.0 fat      626 b-  0% stor 19800101.000002 scala/runtime/AbstractFunction2$mcDJD$sp.class
+-rw----     2.0 fat      626 b-  0% stor 19800101.000002 scala/runtime/AbstractFunction2$mcDJI$sp.class
+-rw----     2.0 fat      626 b-  0% stor 19800101.000002 scala/runtime/AbstractFunction2$mcDJJ$sp.class
+-rw----     2.0 fat      626 b-  0% stor 19800101.000002 scala/runtime/AbstractFunction2$mcFDD$sp.class
+-rw----     2.0 fat      626 b-  0% stor 19800101.000002 scala/runtime/AbstractFunction2$mcFDI$sp.class
+-rw----     2.0 fat      626 b-  0% stor 19800101.000002 scala/runtime/AbstractFunction2$mcFDJ$sp.class
+-rw----     2.0 fat      626 b-  0% stor 19800101.000002 scala/runtime/AbstractFunction2$mcFID$sp.class
+-rw----     2.0 fat      626 b-  0% stor 19800101.000002 scala/runtime/AbstractFunction2$mcFII$sp.class
+-rw----     2.0 fat      626 b-  0% stor 19800101.000002 scala/runtime/AbstractFunction2$mcFIJ$sp.class
+-rw----     2.0 fat      626 b-  0% stor 19800101.000002 scala/runtime/AbstractFunction2$mcFJD$sp.class
+-rw----     2.0 fat      626 b-  0% stor 19800101.000002 scala/runtime/AbstractFunction2$mcFJI$sp.class
+-rw----     2.0 fat      626 b-  0% stor 19800101.000002 scala/runtime/AbstractFunction2$mcFJJ$sp.class
+-rw----     2.0 fat      626 b-  0% stor 19800101.000002 scala/runtime/AbstractFunction2$mcIDD$sp.class
+-rw----     2.0 fat      626 b-  0% stor 19800101.000002 scala/runtime/AbstractFunction2$mcIDI$sp.class
+-rw----     2.0 fat      626 b-  0% stor 19800101.000002 scala/runtime/AbstractFunction2$mcIDJ$sp.class
+-rw----     2.0 fat      626 b-  0% stor 19800101.000002 scala/runtime/AbstractFunction2$mcIID$sp.class
+-rw----     2.0 fat      626 b-  0% stor 19800101.000002 scala/runtime/AbstractFunction2$mcIII$sp.class
+-rw----     2.0 fat      626 b-  0% stor 19800101.000002 scala/runtime/AbstractFunction2$mcIIJ$sp.class
+-rw----     2.0 fat      626 b-  0% stor 19800101.000002 scala/runtime/AbstractFunction2$mcIJD$sp.class
+-rw----     2.0 fat      626 b-  0% stor 19800101.000002 scala/runtime/AbstractFunction2$mcIJI$sp.class
+-rw----     2.0 fat      626 b-  0% stor 19800101.000002 scala/runtime/AbstractFunction2$mcIJJ$sp.class
+-rw----     2.0 fat      626 b-  0% stor 19800101.000002 scala/runtime/AbstractFunction2$mcJDD$sp.class
+-rw----     2.0 fat      626 b-  0% stor 19800101.000002 scala/runtime/AbstractFunction2$mcJDI$sp.class
+-rw----     2.0 fat      626 b-  0% stor 19800101.000002 scala/runtime/AbstractFunction2$mcJDJ$sp.class
+-rw----     2.0 fat      626 b-  0% stor 19800101.000002 scala/runtime/AbstractFunction2$mcJID$sp.class
+-rw----     2.0 fat      626 b-  0% stor 19800101.000002 scala/runtime/AbstractFunction2$mcJII$sp.class
+-rw----     2.0 fat      626 b-  0% stor 19800101.000002 scala/runtime/AbstractFunction2$mcJIJ$sp.class
+-rw----     2.0 fat      626 b-  0% stor 19800101.000002 scala/runtime/AbstractFunction2$mcJJD$sp.class
+-rw----     2.0 fat      626 b-  0% stor 19800101.000002 scala/runtime/AbstractFunction2$mcJJI$sp.class
+-rw----     2.0 fat      626 b-  0% stor 19800101.000002 scala/runtime/AbstractFunction2$mcJJJ$sp.class
+-rw----     2.0 fat      633 b-  0% stor 19800101.000002 scala/runtime/AbstractFunction2$mcVDD$sp.class
+-rw----     2.0 fat      633 b-  0% stor 19800101.000002 scala/runtime/AbstractFunction2$mcVDI$sp.class
+-rw----     2.0 fat      633 b-  0% stor 19800101.000002 scala/runtime/AbstractFunction2$mcVDJ$sp.class
+-rw----     2.0 fat      633 b-  0% stor 19800101.000002 scala/runtime/AbstractFunction2$mcVID$sp.class
+-rw----     2.0 fat      633 b-  0% stor 19800101.000002 scala/runtime/AbstractFunction2$mcVII$sp.class
+-rw----     2.0 fat      633 b-  0% stor 19800101.000002 scala/runtime/AbstractFunction2$mcVIJ$sp.class
+-rw----     2.0 fat      633 b-  0% stor 19800101.000002 scala/runtime/AbstractFunction2$mcVJD$sp.class
+-rw----     2.0 fat      633 b-  0% stor 19800101.000002 scala/runtime/AbstractFunction2$mcVJI$sp.class
+-rw----     2.0 fat      633 b-  0% stor 19800101.000002 scala/runtime/AbstractFunction2$mcVJJ$sp.class
+-rw----     2.0 fat      626 b-  0% stor 19800101.000002 scala/runtime/AbstractFunction2$mcZDD$sp.class
+-rw----     2.0 fat      626 b-  0% stor 19800101.000002 scala/runtime/AbstractFunction2$mcZDI$sp.class
+-rw----     2.0 fat      626 b-  0% stor 19800101.000002 scala/runtime/AbstractFunction2$mcZDJ$sp.class
+-rw----     2.0 fat      626 b-  0% stor 19800101.000002 scala/runtime/AbstractFunction2$mcZID$sp.class
+-rw----     2.0 fat      626 b-  0% stor 19800101.000002 scala/runtime/AbstractFunction2$mcZII$sp.class
+-rw----     2.0 fat      626 b-  0% stor 19800101.000002 scala/runtime/AbstractFunction2$mcZIJ$sp.class
+-rw----     2.0 fat      626 b-  0% stor 19800101.000002 scala/runtime/AbstractFunction2$mcZJD$sp.class
+-rw----     2.0 fat      626 b-  0% stor 19800101.000002 scala/runtime/AbstractFunction2$mcZJI$sp.class
+-rw----     2.0 fat      626 b-  0% stor 19800101.000002 scala/runtime/AbstractFunction2$mcZJJ$sp.class
+-rw----     2.0 fat    12673 b-  0% stor 19800101.000002 scala/runtime/AbstractFunction2.class
+-rw----     2.0 fat     4212 b-  0% stor 19800101.000002 scala/runtime/AbstractFunction20.class
+-rw----     2.0 fat     4309 b-  0% stor 19800101.000002 scala/runtime/AbstractFunction21.class
+-rw----     2.0 fat     4406 b-  0% stor 19800101.000002 scala/runtime/AbstractFunction22.class
+-rw----     2.0 fat     2582 b-  0% stor 19800101.000002 scala/runtime/AbstractFunction3.class
+-rw----     2.0 fat     2674 b-  0% stor 19800101.000002 scala/runtime/AbstractFunction4.class
+-rw----     2.0 fat     2766 b-  0% stor 19800101.000002 scala/runtime/AbstractFunction5.class
+-rw----     2.0 fat     2857 b-  0% stor 19800101.000002 scala/runtime/AbstractFunction6.class
+-rw----     2.0 fat     2949 b-  0% stor 19800101.000002 scala/runtime/AbstractFunction7.class
+-rw----     2.0 fat     3041 b-  0% stor 19800101.000002 scala/runtime/AbstractFunction8.class
+-rw----     2.0 fat     3132 b-  0% stor 19800101.000002 scala/runtime/AbstractFunction9.class
+-rw----     2.0 fat     1360 b-  0% stor 19800101.000002 scala/runtime/AbstractPartialFunction$mcDD$sp.class
+-rw----     2.0 fat     1455 b-  0% stor 19800101.000002 scala/runtime/AbstractPartialFunction$mcDF$sp.class
+-rw----     2.0 fat     1457 b-  0% stor 19800101.000002 scala/runtime/AbstractPartialFunction$mcDI$sp.class
+-rw----     2.0 fat     1452 b-  0% stor 19800101.000002 scala/runtime/AbstractPartialFunction$mcDJ$sp.class
+-rw----     2.0 fat     1455 b-  0% stor 19800101.000002 scala/runtime/AbstractPartialFunction$mcFD$sp.class
+-rw----     2.0 fat     1357 b-  0% stor 19800101.000002 scala/runtime/AbstractPartialFunction$mcFF$sp.class
+-rw----     2.0 fat     1454 b-  0% stor 19800101.000002 scala/runtime/AbstractPartialFunction$mcFI$sp.class
+-rw----     2.0 fat     1449 b-  0% stor 19800101.000002 scala/runtime/AbstractPartialFunction$mcFJ$sp.class
+-rw----     2.0 fat     1457 b-  0% stor 19800101.000002 scala/runtime/AbstractPartialFunction$mcID$sp.class
+-rw----     2.0 fat     1454 b-  0% stor 19800101.000002 scala/runtime/AbstractPartialFunction$mcIF$sp.class
+-rw----     2.0 fat     1359 b-  0% stor 19800101.000002 scala/runtime/AbstractPartialFunction$mcII$sp.class
+-rw----     2.0 fat     1451 b-  0% stor 19800101.000002 scala/runtime/AbstractPartialFunction$mcIJ$sp.class
+-rw----     2.0 fat     1452 b-  0% stor 19800101.000002 scala/runtime/AbstractPartialFunction$mcJD$sp.class
+-rw----     2.0 fat     1449 b-  0% stor 19800101.000002 scala/runtime/AbstractPartialFunction$mcJF$sp.class
+-rw----     2.0 fat     1451 b-  0% stor 19800101.000002 scala/runtime/AbstractPartialFunction$mcJI$sp.class
+-rw----     2.0 fat     1354 b-  0% stor 19800101.000002 scala/runtime/AbstractPartialFunction$mcJJ$sp.class
+-rw----     2.0 fat     1439 b-  0% stor 19800101.000002 scala/runtime/AbstractPartialFunction$mcVD$sp.class
+-rw----     2.0 fat     1436 b-  0% stor 19800101.000002 scala/runtime/AbstractPartialFunction$mcVF$sp.class
+-rw----     2.0 fat     1438 b-  0% stor 19800101.000002 scala/runtime/AbstractPartialFunction$mcVI$sp.class
+-rw----     2.0 fat     1433 b-  0% stor 19800101.000002 scala/runtime/AbstractPartialFunction$mcVJ$sp.class
+-rw----     2.0 fat     1437 b-  0% stor 19800101.000002 scala/runtime/AbstractPartialFunction$mcZD$sp.class
+-rw----     2.0 fat     1434 b-  0% stor 19800101.000002 scala/runtime/AbstractPartialFunction$mcZF$sp.class
+-rw----     2.0 fat     1436 b-  0% stor 19800101.000002 scala/runtime/AbstractPartialFunction$mcZI$sp.class
+-rw----     2.0 fat     1431 b-  0% stor 19800101.000002 scala/runtime/AbstractPartialFunction$mcZJ$sp.class
+-rw----     2.0 fat     8069 b-  0% stor 19800101.000002 scala/runtime/AbstractPartialFunction.class
+-rw----     2.0 fat     2403 b-  0% stor 19800101.000002 scala/runtime/ArrayCharSequence.class
+-rw----     2.0 fat      795 b-  0% stor 19800101.000002 scala/runtime/BooleanRef.class
+-rw----     2.0 fat     1039 b-  0% stor 19800101.000002 scala/runtime/BoxedUnit.class
+-rw----     2.0 fat    14953 b-  0% stor 19800101.000002 scala/runtime/BoxesRunTime.class
+-rw----     2.0 fat      768 b-  0% stor 19800101.000002 scala/runtime/ByteRef.class
+-rw----     2.0 fat      773 b-  0% stor 19800101.000002 scala/runtime/CharRef.class
+-rw----     2.0 fat      780 b-  0% stor 19800101.000002 scala/runtime/DoubleRef.class
+-rw----     2.0 fat     1543 b-  0% stor 19800101.000002 scala/runtime/EmptyMethodCache.class
+-rw----     2.0 fat      774 b-  0% stor 19800101.000002 scala/runtime/FloatRef.class
+-rw----     2.0 fat     5510 b-  0% stor 19800101.000002 scala/runtime/FractionalProxy.class
+-rw----     2.0 fat      766 b-  0% stor 19800101.000002 scala/runtime/IntRef.class
+-rw----     2.0 fat     4135 b-  0% stor 19800101.000002 scala/runtime/IntegralProxy.class
+-rw----     2.0 fat     3546 b-  0% stor 19800101.000002 scala/runtime/LambdaDeserialize.class
+-rw----     2.0 fat     7531 b-  0% stor 19800101.000002 scala/runtime/LambdaDeserializer$.class
+-rw----     2.0 fat     1560 b-  0% stor 19800101.000002 scala/runtime/LambdaDeserializer.class
+-rw----     2.0 fat     1972 b-  0% stor 19800101.000002 scala/runtime/LazyBoolean.class
+-rw----     2.0 fat     1983 b-  0% stor 19800101.000002 scala/runtime/LazyByte.class
+-rw----     2.0 fat     1993 b-  0% stor 19800101.000002 scala/runtime/LazyChar.class
+-rw----     2.0 fat     1998 b-  0% stor 19800101.000002 scala/runtime/LazyDouble.class
+-rw----     2.0 fat     1990 b-  0% stor 19800101.000002 scala/runtime/LazyFloat.class
+-rw----     2.0 fat     1984 b-  0% stor 19800101.000002 scala/runtime/LazyInt.class
+-rw----     2.0 fat     1983 b-  0% stor 19800101.000002 scala/runtime/LazyLong.class
+-rw----     2.0 fat     2135 b-  0% stor 19800101.000002 scala/runtime/LazyRef.class
+-rw----     2.0 fat     1990 b-  0% stor 19800101.000002 scala/runtime/LazyShort.class
+-rw----     2.0 fat     1624 b-  0% stor 19800101.000002 scala/runtime/LazyUnit.class
+-rw----     2.0 fat      764 b-  0% stor 19800101.000002 scala/runtime/LongRef.class
+-rw----     2.0 fat     2041 b-  0% stor 19800101.000002 scala/runtime/MegaMethodCache.class
+-rw----     2.0 fat     1286 b-  0% stor 19800101.000002 scala/runtime/MethodCache.class
+-rw----     2.0 fat     1070 b-  0% stor 19800101.000002 scala/runtime/NonLocalReturnControl$mcB$sp.class
+-rw----     2.0 fat     1080 b-  0% stor 19800101.000002 scala/runtime/NonLocalReturnControl$mcC$sp.class
+-rw----     2.0 fat     1074 b-  0% stor 19800101.000002 scala/runtime/NonLocalReturnControl$mcD$sp.class
+-rw----     2.0 fat     1072 b-  0% stor 19800101.000002 scala/runtime/NonLocalReturnControl$mcF$sp.class
+-rw----     2.0 fat     1076 b-  0% stor 19800101.000002 scala/runtime/NonLocalReturnControl$mcI$sp.class
+-rw----     2.0 fat     1070 b-  0% stor 19800101.000002 scala/runtime/NonLocalReturnControl$mcJ$sp.class
+-rw----     2.0 fat     1072 b-  0% stor 19800101.000002 scala/runtime/NonLocalReturnControl$mcS$sp.class
+-rw----     2.0 fat     1079 b-  0% stor 19800101.000002 scala/runtime/NonLocalReturnControl$mcV$sp.class
+-rw----     2.0 fat     1070 b-  0% stor 19800101.000002 scala/runtime/NonLocalReturnControl$mcZ$sp.class
+-rw----     2.0 fat     3114 b-  0% stor 19800101.000002 scala/runtime/NonLocalReturnControl.class
+-rw----     2.0 fat      328 b-  0% stor 19800101.000002 scala/runtime/Nothing$.class
+-rw----     2.0 fat      316 b-  0% stor 19800101.000002 scala/runtime/Null$.class
+-rw----     2.0 fat     1228 b-  0% stor 19800101.000002 scala/runtime/ObjectRef.class
+-rw----     2.0 fat     1600 b-  0% stor 19800101.000002 scala/runtime/OrderedProxy.class
+-rw----     2.0 fat     2809 b-  0% stor 19800101.000002 scala/runtime/PolyMethodCache.class
+-rw----     2.0 fat     1206 b-  0% stor 19800101.000002 scala/runtime/RangedProxy.class
+-rw----     2.0 fat     1261 b-  0% stor 19800101.000002 scala/runtime/RichBoolean$.class
+-rw----     2.0 fat     3507 b-  0% stor 19800101.000002 scala/runtime/RichBoolean.class
+-rw----     2.0 fat     2910 b-  0% stor 19800101.000002 scala/runtime/RichByte$.class
+-rw----     2.0 fat     9336 b-  0% stor 19800101.000002 scala/runtime/RichByte.class
+-rw----     2.0 fat     6267 b-  0% stor 19800101.000002 scala/runtime/RichChar$.class
+-rw----     2.0 fat    17173 b-  0% stor 19800101.000002 scala/runtime/RichChar.class
+-rw----     2.0 fat     5023 b-  0% stor 19800101.000002 scala/runtime/RichDouble$.class
+-rw----     2.0 fat    14271 b-  0% stor 19800101.000002 scala/runtime/RichDouble.class
+-rw----     2.0 fat     1667 b-  0% stor 19800101.000002 scala/runtime/RichException.class
+-rw----     2.0 fat     5038 b-  0% stor 19800101.000002 scala/runtime/RichFloat$.class
+-rw----     2.0 fat    14241 b-  0% stor 19800101.000002 scala/runtime/RichFloat.class
+-rw----     2.0 fat     4636 b-  0% stor 19800101.000002 scala/runtime/RichInt$.class
+-rw----     2.0 fat    13026 b-  0% stor 19800101.000002 scala/runtime/RichInt.class
+-rw----     2.0 fat     3980 b-  0% stor 19800101.000002 scala/runtime/RichLong$.class
+-rw----     2.0 fat    13261 b-  0% stor 19800101.000002 scala/runtime/RichLong.class
+-rw----     2.0 fat     2926 b-  0% stor 19800101.000002 scala/runtime/RichShort$.class
+-rw----     2.0 fat     9360 b-  0% stor 19800101.000002 scala/runtime/RichShort.class
+-rw----     2.0 fat     4505 b-  0% stor 19800101.000002 scala/runtime/ScalaNumberProxy.class
+-rw----     2.0 fat     1460 b-  0% stor 19800101.000002 scala/runtime/ScalaRunTime$$anon$1.class
+-rw----     2.0 fat    17209 b-  0% stor 19800101.000002 scala/runtime/ScalaRunTime$.class
+-rw----     2.0 fat     4566 b-  0% stor 19800101.000002 scala/runtime/ScalaRunTime.class
+-rw----     2.0 fat     1125 b-  0% stor 19800101.000002 scala/runtime/ScalaWholeNumberProxy.class
+-rw----     2.0 fat     2485 b-  0% stor 19800101.000002 scala/runtime/SeqCharSequence.class
+-rw----     2.0 fat      774 b-  0% stor 19800101.000002 scala/runtime/ShortRef.class
+-rw----     2.0 fat     1872 b-  0% stor 19800101.000002 scala/runtime/Statics.class
+-rw----     2.0 fat     1473 b-  0% stor 19800101.000002 scala/runtime/StringAdd$.class
+-rw----     2.0 fat     2165 b-  0% stor 19800101.000002 scala/runtime/StringAdd.class
+-rw----     2.0 fat     1604 b-  0% stor 19800101.000002 scala/runtime/StringFormat$.class
+-rw----     2.0 fat     2695 b-  0% stor 19800101.000002 scala/runtime/StringFormat.class
+-rw----     2.0 fat     2720 b-  0% stor 19800101.000002 scala/runtime/StructuralCallSite.class
+-rw----     2.0 fat     2045 b-  0% stor 19800101.000002 scala/runtime/SymbolLiteral.class
+-rw----     2.0 fat      240 b-  0% stor 19800101.000002 scala/runtime/TraitSetter.class
+-rw----     2.0 fat    12719 b-  0% stor 19800101.000002 scala/runtime/Tuple2Zipped$.class
+-rw----     2.0 fat     3748 b-  0% stor 19800101.000002 scala/runtime/Tuple2Zipped$Ops$.class
+-rw----     2.0 fat     3122 b-  0% stor 19800101.000002 scala/runtime/Tuple2Zipped$Ops.class
+-rw----     2.0 fat    20015 b-  0% stor 19800101.000002 scala/runtime/Tuple2Zipped.class
+-rw----     2.0 fat    15451 b-  0% stor 19800101.000002 scala/runtime/Tuple3Zipped$.class
+-rw----     2.0 fat     4343 b-  0% stor 19800101.000002 scala/runtime/Tuple3Zipped$Ops$.class
+-rw----     2.0 fat     3603 b-  0% stor 19800101.000002 scala/runtime/Tuple3Zipped$Ops.class
+-rw----     2.0 fat    22646 b-  0% stor 19800101.000002 scala/runtime/Tuple3Zipped.class
+-rw----     2.0 fat      835 b-  0% stor 19800101.000002 scala/runtime/VolatileBooleanRef.class
+-rw----     2.0 fat      808 b-  0% stor 19800101.000002 scala/runtime/VolatileByteRef.class
+-rw----     2.0 fat      813 b-  0% stor 19800101.000002 scala/runtime/VolatileCharRef.class
+-rw----     2.0 fat      820 b-  0% stor 19800101.000002 scala/runtime/VolatileDoubleRef.class
+-rw----     2.0 fat      814 b-  0% stor 19800101.000002 scala/runtime/VolatileFloatRef.class
+-rw----     2.0 fat      806 b-  0% stor 19800101.000002 scala/runtime/VolatileIntRef.class
+-rw----     2.0 fat      804 b-  0% stor 19800101.000002 scala/runtime/VolatileLongRef.class
+-rw----     2.0 fat     1292 b-  0% stor 19800101.000002 scala/runtime/VolatileObjectRef.class
+-rw----     2.0 fat      814 b-  0% stor 19800101.000002 scala/runtime/VolatileShortRef.class
+-rw----     2.0 fat     2212 b-  0% stor 19800101.000002 scala/runtime/ZippedTraversable2$$anon$1.class
+-rw----     2.0 fat      993 b-  0% stor 19800101.000002 scala/runtime/ZippedTraversable2$.class
+-rw----     2.0 fat     1428 b-  0% stor 19800101.000002 scala/runtime/ZippedTraversable2.class
+-rw----     2.0 fat     2258 b-  0% stor 19800101.000002 scala/runtime/ZippedTraversable3$$anon$1.class
+-rw----     2.0 fat     1025 b-  0% stor 19800101.000002 scala/runtime/ZippedTraversable3$.class
+-rw----     2.0 fat     1525 b-  0% stor 19800101.000002 scala/runtime/ZippedTraversable3.class
+-rw----     2.0 fat        0 bl  0% defN 19800101.000000 scala/runtime/java8/
+-rw----     2.0 fat      567 b-  0% stor 19800101.000002 scala/runtime/java8/JFunction0$mcB$sp.class
+-rw----     2.0 fat      577 b-  0% stor 19800101.000002 scala/runtime/java8/JFunction0$mcC$sp.class
+-rw----     2.0 fat      571 b-  0% stor 19800101.000002 scala/runtime/java8/JFunction0$mcD$sp.class
+-rw----     2.0 fat      569 b-  0% stor 19800101.000002 scala/runtime/java8/JFunction0$mcF$sp.class
+-rw----     2.0 fat      573 b-  0% stor 19800101.000002 scala/runtime/java8/JFunction0$mcI$sp.class
+-rw----     2.0 fat      567 b-  0% stor 19800101.000002 scala/runtime/java8/JFunction0$mcJ$sp.class
+-rw----     2.0 fat      569 b-  0% stor 19800101.000002 scala/runtime/java8/JFunction0$mcS$sp.class
+-rw----     2.0 fat      565 b-  0% stor 19800101.000002 scala/runtime/java8/JFunction0$mcV$sp.class
+-rw----     2.0 fat      573 b-  0% stor 19800101.000002 scala/runtime/java8/JFunction0$mcZ$sp.class
+-rw----     2.0 fat      683 b-  0% stor 19800101.000002 scala/runtime/java8/JFunction1$mcDD$sp.class
+-rw----     2.0 fat      682 b-  0% stor 19800101.000002 scala/runtime/java8/JFunction1$mcDF$sp.class
+-rw----     2.0 fat      680 b-  0% stor 19800101.000002 scala/runtime/java8/JFunction1$mcDI$sp.class
+-rw----     2.0 fat      681 b-  0% stor 19800101.000002 scala/runtime/java8/JFunction1$mcDJ$sp.class
+-rw----     2.0 fat      681 b-  0% stor 19800101.000002 scala/runtime/java8/JFunction1$mcFD$sp.class
+-rw----     2.0 fat      680 b-  0% stor 19800101.000002 scala/runtime/java8/JFunction1$mcFF$sp.class
+-rw----     2.0 fat      678 b-  0% stor 19800101.000002 scala/runtime/java8/JFunction1$mcFI$sp.class
+-rw----     2.0 fat      679 b-  0% stor 19800101.000002 scala/runtime/java8/JFunction1$mcFJ$sp.class
+-rw----     2.0 fat      685 b-  0% stor 19800101.000002 scala/runtime/java8/JFunction1$mcID$sp.class
+-rw----     2.0 fat      684 b-  0% stor 19800101.000002 scala/runtime/java8/JFunction1$mcIF$sp.class
+-rw----     2.0 fat      682 b-  0% stor 19800101.000002 scala/runtime/java8/JFunction1$mcII$sp.class
+-rw----     2.0 fat      683 b-  0% stor 19800101.000002 scala/runtime/java8/JFunction1$mcIJ$sp.class
+-rw----     2.0 fat      679 b-  0% stor 19800101.000002 scala/runtime/java8/JFunction1$mcJD$sp.class
+-rw----     2.0 fat      678 b-  0% stor 19800101.000002 scala/runtime/java8/JFunction1$mcJF$sp.class
+-rw----     2.0 fat      676 b-  0% stor 19800101.000002 scala/runtime/java8/JFunction1$mcJI$sp.class
+-rw----     2.0 fat      677 b-  0% stor 19800101.000002 scala/runtime/java8/JFunction1$mcJJ$sp.class
+-rw----     2.0 fat      709 b-  0% stor 19800101.000002 scala/runtime/java8/JFunction1$mcVD$sp.class
+-rw----     2.0 fat      708 b-  0% stor 19800101.000002 scala/runtime/java8/JFunction1$mcVF$sp.class
+-rw----     2.0 fat      706 b-  0% stor 19800101.000002 scala/runtime/java8/JFunction1$mcVI$sp.class
+-rw----     2.0 fat      707 b-  0% stor 19800101.000002 scala/runtime/java8/JFunction1$mcVJ$sp.class
+-rw----     2.0 fat      685 b-  0% stor 19800101.000002 scala/runtime/java8/JFunction1$mcZD$sp.class
+-rw----     2.0 fat      684 b-  0% stor 19800101.000002 scala/runtime/java8/JFunction1$mcZF$sp.class
+-rw----     2.0 fat      682 b-  0% stor 19800101.000002 scala/runtime/java8/JFunction1$mcZI$sp.class
+-rw----     2.0 fat      683 b-  0% stor 19800101.000002 scala/runtime/java8/JFunction1$mcZJ$sp.class
+-rw----     2.0 fat      726 b-  0% stor 19800101.000002 scala/runtime/java8/JFunction2$mcDDD$sp.class
+-rw----     2.0 fat      773 b-  0% stor 19800101.000002 scala/runtime/java8/JFunction2$mcDDI$sp.class
+-rw----     2.0 fat      774 b-  0% stor 19800101.000002 scala/runtime/java8/JFunction2$mcDDJ$sp.class
+-rw----     2.0 fat      773 b-  0% stor 19800101.000002 scala/runtime/java8/JFunction2$mcDID$sp.class
+-rw----     2.0 fat      723 b-  0% stor 19800101.000002 scala/runtime/java8/JFunction2$mcDII$sp.class
+-rw----     2.0 fat      771 b-  0% stor 19800101.000002 scala/runtime/java8/JFunction2$mcDIJ$sp.class
+-rw----     2.0 fat      774 b-  0% stor 19800101.000002 scala/runtime/java8/JFunction2$mcDJD$sp.class
+-rw----     2.0 fat      771 b-  0% stor 19800101.000002 scala/runtime/java8/JFunction2$mcDJI$sp.class
+-rw----     2.0 fat      724 b-  0% stor 19800101.000002 scala/runtime/java8/JFunction2$mcDJJ$sp.class
+-rw----     2.0 fat      724 b-  0% stor 19800101.000002 scala/runtime/java8/JFunction2$mcFDD$sp.class
+-rw----     2.0 fat      771 b-  0% stor 19800101.000002 scala/runtime/java8/JFunction2$mcFDI$sp.class
+-rw----     2.0 fat      772 b-  0% stor 19800101.000002 scala/runtime/java8/JFunction2$mcFDJ$sp.class
+-rw----     2.0 fat      771 b-  0% stor 19800101.000002 scala/runtime/java8/JFunction2$mcFID$sp.class
+-rw----     2.0 fat      721 b-  0% stor 19800101.000002 scala/runtime/java8/JFunction2$mcFII$sp.class
+-rw----     2.0 fat      769 b-  0% stor 19800101.000002 scala/runtime/java8/JFunction2$mcFIJ$sp.class
+-rw----     2.0 fat      772 b-  0% stor 19800101.000002 scala/runtime/java8/JFunction2$mcFJD$sp.class
+-rw----     2.0 fat      769 b-  0% stor 19800101.000002 scala/runtime/java8/JFunction2$mcFJI$sp.class
+-rw----     2.0 fat      722 b-  0% stor 19800101.000002 scala/runtime/java8/JFunction2$mcFJJ$sp.class
+-rw----     2.0 fat      728 b-  0% stor 19800101.000002 scala/runtime/java8/JFunction2$mcIDD$sp.class
+-rw----     2.0 fat      775 b-  0% stor 19800101.000002 scala/runtime/java8/JFunction2$mcIDI$sp.class
+-rw----     2.0 fat      776 b-  0% stor 19800101.000002 scala/runtime/java8/JFunction2$mcIDJ$sp.class
+-rw----     2.0 fat      775 b-  0% stor 19800101.000002 scala/runtime/java8/JFunction2$mcIID$sp.class
+-rw----     2.0 fat      725 b-  0% stor 19800101.000002 scala/runtime/java8/JFunction2$mcIII$sp.class
+-rw----     2.0 fat      773 b-  0% stor 19800101.000002 scala/runtime/java8/JFunction2$mcIIJ$sp.class
+-rw----     2.0 fat      776 b-  0% stor 19800101.000002 scala/runtime/java8/JFunction2$mcIJD$sp.class
+-rw----     2.0 fat      773 b-  0% stor 19800101.000002 scala/runtime/java8/JFunction2$mcIJI$sp.class
+-rw----     2.0 fat      726 b-  0% stor 19800101.000002 scala/runtime/java8/JFunction2$mcIJJ$sp.class
+-rw----     2.0 fat      722 b-  0% stor 19800101.000002 scala/runtime/java8/JFunction2$mcJDD$sp.class
+-rw----     2.0 fat      769 b-  0% stor 19800101.000002 scala/runtime/java8/JFunction2$mcJDI$sp.class
+-rw----     2.0 fat      770 b-  0% stor 19800101.000002 scala/runtime/java8/JFunction2$mcJDJ$sp.class
+-rw----     2.0 fat      769 b-  0% stor 19800101.000002 scala/runtime/java8/JFunction2$mcJID$sp.class
+-rw----     2.0 fat      719 b-  0% stor 19800101.000002 scala/runtime/java8/JFunction2$mcJII$sp.class
+-rw----     2.0 fat      767 b-  0% stor 19800101.000002 scala/runtime/java8/JFunction2$mcJIJ$sp.class
+-rw----     2.0 fat      770 b-  0% stor 19800101.000002 scala/runtime/java8/JFunction2$mcJJD$sp.class
+-rw----     2.0 fat      767 b-  0% stor 19800101.000002 scala/runtime/java8/JFunction2$mcJJI$sp.class
+-rw----     2.0 fat      720 b-  0% stor 19800101.000002 scala/runtime/java8/JFunction2$mcJJJ$sp.class
+-rw----     2.0 fat      752 b-  0% stor 19800101.000002 scala/runtime/java8/JFunction2$mcVDD$sp.class
+-rw----     2.0 fat      799 b-  0% stor 19800101.000002 scala/runtime/java8/JFunction2$mcVDI$sp.class
+-rw----     2.0 fat      800 b-  0% stor 19800101.000002 scala/runtime/java8/JFunction2$mcVDJ$sp.class
+-rw----     2.0 fat      799 b-  0% stor 19800101.000002 scala/runtime/java8/JFunction2$mcVID$sp.class
+-rw----     2.0 fat      749 b-  0% stor 19800101.000002 scala/runtime/java8/JFunction2$mcVII$sp.class
+-rw----     2.0 fat      797 b-  0% stor 19800101.000002 scala/runtime/java8/JFunction2$mcVIJ$sp.class
+-rw----     2.0 fat      800 b-  0% stor 19800101.000002 scala/runtime/java8/JFunction2$mcVJD$sp.class
+-rw----     2.0 fat      797 b-  0% stor 19800101.000002 scala/runtime/java8/JFunction2$mcVJI$sp.class
+-rw----     2.0 fat      750 b-  0% stor 19800101.000002 scala/runtime/java8/JFunction2$mcVJJ$sp.class
+-rw----     2.0 fat      728 b-  0% stor 19800101.000002 scala/runtime/java8/JFunction2$mcZDD$sp.class
+-rw----     2.0 fat      775 b-  0% stor 19800101.000002 scala/runtime/java8/JFunction2$mcZDI$sp.class
+-rw----     2.0 fat      776 b-  0% stor 19800101.000002 scala/runtime/java8/JFunction2$mcZDJ$sp.class
+-rw----     2.0 fat      775 b-  0% stor 19800101.000002 scala/runtime/java8/JFunction2$mcZID$sp.class
+-rw----     2.0 fat      725 b-  0% stor 19800101.000002 scala/runtime/java8/JFunction2$mcZII$sp.class
+-rw----     2.0 fat      773 b-  0% stor 19800101.000002 scala/runtime/java8/JFunction2$mcZIJ$sp.class
+-rw----     2.0 fat      776 b-  0% stor 19800101.000002 scala/runtime/java8/JFunction2$mcZJD$sp.class
+-rw----     2.0 fat      773 b-  0% stor 19800101.000002 scala/runtime/java8/JFunction2$mcZJI$sp.class
+-rw----     2.0 fat      726 b-  0% stor 19800101.000002 scala/runtime/java8/JFunction2$mcZJJ$sp.class
+-rw----     2.0 fat      405 b-  0% stor 19800101.000002 scala/runtime/package$.class
+-rw----     2.0 fat      343 b-  0% stor 19800101.000002 scala/runtime/package.class
+-rw----     2.0 fat     1646 b-  0% stor 19800101.000002 scala/specialized.class
+-rw----     2.0 fat        0 bl  0% defN 19800101.000000 scala/sys/
+-rw----     2.0 fat     3214 b-  0% stor 19800101.000002 scala/sys/BooleanProp$.class
+-rw----     2.0 fat     1743 b-  0% stor 19800101.000002 scala/sys/BooleanProp$BooleanPropImpl.class
+-rw----     2.0 fat     2602 b-  0% stor 19800101.000002 scala/sys/BooleanProp$ConstantImpl.class
+-rw----     2.0 fat     2479 b-  0% stor 19800101.000002 scala/sys/BooleanProp.class
+-rw----     2.0 fat     1487 b-  0% stor 19800101.000002 scala/sys/CreatorImpl.class
+-rw----     2.0 fat      986 b-  0% stor 19800101.000002 scala/sys/Prop$.class
+-rw----     2.0 fat      426 b-  0% stor 19800101.000002 scala/sys/Prop$Creator.class
+-rw----     2.0 fat     1393 b-  0% stor 19800101.000002 scala/sys/Prop$DoubleProp$$anonfun$$lessinit$greater$4.class
+-rw----     2.0 fat      654 b-  0% stor 19800101.000002 scala/sys/Prop$DoubleProp$.class
+-rw----     2.0 fat     1147 b-  0% stor 19800101.000002 scala/sys/Prop$FileProp$$anonfun$$lessinit$greater$1.class
+-rw----     2.0 fat      642 b-  0% stor 19800101.000002 scala/sys/Prop$FileProp$.class
+-rw----     2.0 fat     1380 b-  0% stor 19800101.000002 scala/sys/Prop$IntProp$$anonfun$$lessinit$greater$3.class
+-rw----     2.0 fat      642 b-  0% stor 19800101.000002 scala/sys/Prop$IntProp$.class
+-rw----     2.0 fat     1104 b-  0% stor 19800101.000002 scala/sys/Prop$StringProp$$anonfun$$lessinit$greater$2.class
+-rw----     2.0 fat      654 b-  0% stor 19800101.000002 scala/sys/Prop$StringProp$.class
+-rw----     2.0 fat     2743 b-  0% stor 19800101.000002 scala/sys/Prop.class
+-rw----     2.0 fat     5680 b-  0% stor 19800101.000002 scala/sys/PropImpl.class
+-rw----     2.0 fat      934 b-  0% stor 19800101.000002 scala/sys/ShutdownHookThread$$anon$1.class
+-rw----     2.0 fat     1682 b-  0% stor 19800101.000002 scala/sys/ShutdownHookThread$.class
+-rw----     2.0 fat     1897 b-  0% stor 19800101.000002 scala/sys/ShutdownHookThread.class
+-rw----     2.0 fat     3508 b-  0% stor 19800101.000002 scala/sys/SystemProperties$.class
+-rw----     2.0 fat    11784 b-  0% stor 19800101.000002 scala/sys/SystemProperties.class
+-rw----     2.0 fat     3540 b-  0% stor 19800101.000002 scala/sys/package$.class
+-rw----     2.0 fat     1927 b-  0% stor 19800101.000002 scala/sys/package.class
+-rw----     2.0 fat        0 bl  0% defN 19800101.000000 scala/sys/process/
+-rw----     2.0 fat    13558 b-  0% stor 19800101.000002 scala/sys/process/BasicIO$.class
+-rw----     2.0 fat     5088 b-  0% stor 19800101.000002 scala/sys/process/BasicIO$Streamed$.class
+-rw----     2.0 fat     1592 b-  0% stor 19800101.000002 scala/sys/process/BasicIO$Streamed.class
+-rw----     2.0 fat      929 b-  0% stor 19800101.000002 scala/sys/process/BasicIO$Uncloseable$$anon$1.class
+-rw----     2.0 fat      923 b-  0% stor 19800101.000002 scala/sys/process/BasicIO$Uncloseable$$anon$2.class
+-rw----     2.0 fat     1532 b-  0% stor 19800101.000002 scala/sys/process/BasicIO$Uncloseable$.class
+-rw----     2.0 fat      690 b-  0% stor 19800101.000002 scala/sys/process/BasicIO$Uncloseable.class
+-rw----     2.0 fat     5512 b-  0% stor 19800101.000002 scala/sys/process/BasicIO.class
+-rw----     2.0 fat     2520 b-  0% stor 19800101.000002 scala/sys/process/FileProcessLogger.class
+-rw----     2.0 fat     8209 b-  0% stor 19800101.000002 scala/sys/process/Process$.class
+-rw----     2.0 fat     5202 b-  0% stor 19800101.000002 scala/sys/process/Process.class
+-rw----     2.0 fat      545 b-  0% stor 19800101.000002 scala/sys/process/ProcessBuilder$.class
+-rw----     2.0 fat      872 b-  0% stor 19800101.000002 scala/sys/process/ProcessBuilder$FileBuilder.class
+-rw----     2.0 fat     3048 b-  0% stor 19800101.000002 scala/sys/process/ProcessBuilder$Sink.class
+-rw----     2.0 fat     3255 b-  0% stor 19800101.000002 scala/sys/process/ProcessBuilder$Source.class
+-rw----     2.0 fat      327 b-  0% stor 19800101.000002 scala/sys/process/ProcessBuilder$URLBuilder.class
+-rw----     2.0 fat     5608 b-  0% stor 19800101.000002 scala/sys/process/ProcessBuilder.class
+-rw----     2.0 fat    15470 b-  0% stor 19800101.000002 scala/sys/process/ProcessBuilderImpl$AbstractBuilder.class
+-rw----     2.0 fat     1986 b-  0% stor 19800101.000002 scala/sys/process/ProcessBuilderImpl$AndBuilder.class
+-rw----     2.0 fat     2830 b-  0% stor 19800101.000002 scala/sys/process/ProcessBuilderImpl$BasicBuilder.class
+-rw----     2.0 fat     1342 b-  0% stor 19800101.000002 scala/sys/process/ProcessBuilderImpl$DaemonBuilder.class
+-rw----     2.0 fat     1809 b-  0% stor 19800101.000002 scala/sys/process/ProcessBuilderImpl$Dummy.class
+-rw----     2.0 fat     5202 b-  0% stor 19800101.000002 scala/sys/process/ProcessBuilderImpl$FileImpl.class
+-rw----     2.0 fat     1301 b-  0% stor 19800101.000002 scala/sys/process/ProcessBuilderImpl$FileInput$$anonfun$$lessinit$greater$2.class
+-rw----     2.0 fat     1133 b-  0% stor 19800101.000002 scala/sys/process/ProcessBuilderImpl$FileInput.class
+-rw----     2.0 fat     1366 b-  0% stor 19800101.000002 scala/sys/process/ProcessBuilderImpl$FileOutput$$anonfun$$lessinit$greater$3.class
+-rw----     2.0 fat     1167 b-  0% stor 19800101.000002 scala/sys/process/ProcessBuilderImpl$FileOutput.class
+-rw----     2.0 fat     2025 b-  0% stor 19800101.000002 scala/sys/process/ProcessBuilderImpl$IStreamBuilder$$anonfun$$lessinit$greater$5.class
+-rw----     2.0 fat     1418 b-  0% stor 19800101.000002 scala/sys/process/ProcessBuilderImpl$IStreamBuilder.class
+-rw----     2.0 fat     2025 b-  0% stor 19800101.000002 scala/sys/process/ProcessBuilderImpl$OStreamBuilder$$anonfun$$lessinit$greater$4.class
+-rw----     2.0 fat     1419 b-  0% stor 19800101.000002 scala/sys/process/ProcessBuilderImpl$OStreamBuilder.class
+-rw----     2.0 fat     1979 b-  0% stor 19800101.000002 scala/sys/process/ProcessBuilderImpl$OrBuilder.class
+-rw----     2.0 fat     2268 b-  0% stor 19800101.000002 scala/sys/process/ProcessBuilderImpl$PipedBuilder.class
+-rw----     2.0 fat     2021 b-  0% stor 19800101.000002 scala/sys/process/ProcessBuilderImpl$SequenceBuilder.class
+-rw----     2.0 fat     1625 b-  0% stor 19800101.000002 scala/sys/process/ProcessBuilderImpl$SequentialBuilder.class
+-rw----     2.0 fat     5135 b-  0% stor 19800101.000002 scala/sys/process/ProcessBuilderImpl$Simple.class
+-rw----     2.0 fat     4310 b-  0% stor 19800101.000002 scala/sys/process/ProcessBuilderImpl$ThreadBuilder.class
+-rw----     2.0 fat     2949 b-  0% stor 19800101.000002 scala/sys/process/ProcessBuilderImpl$URLImpl.class
+-rw----     2.0 fat     1266 b-  0% stor 19800101.000002 scala/sys/process/ProcessBuilderImpl$URLInput$$anonfun$$lessinit$greater$1.class
+-rw----     2.0 fat     1120 b-  0% stor 19800101.000002 scala/sys/process/ProcessBuilderImpl$URLInput.class
+-rw----     2.0 fat     6318 b-  0% stor 19800101.000002 scala/sys/process/ProcessBuilderImpl.class
+-rw----     2.0 fat    14850 b-  0% stor 19800101.000002 scala/sys/process/ProcessCreation.class
+-rw----     2.0 fat     3564 b-  0% stor 19800101.000002 scala/sys/process/ProcessIO.class
+-rw----     2.0 fat     1501 b-  0% stor 19800101.000002 scala/sys/process/ProcessImpl$AndProcess$$anonfun$$lessinit$greater$1.class
+-rw----     2.0 fat     1283 b-  0% stor 19800101.000002 scala/sys/process/ProcessImpl$AndProcess.class
+-rw----     2.0 fat      823 b-  0% stor 19800101.000002 scala/sys/process/ProcessImpl$BasicProcess.class
+-rw----     2.0 fat     9301 b-  0% stor 19800101.000002 scala/sys/process/ProcessImpl$CompoundProcess.class
+-rw----     2.0 fat     2005 b-  0% stor 19800101.000002 scala/sys/process/ProcessImpl$DummyProcess.class
+-rw----     2.0 fat     3879 b-  0% stor 19800101.000002 scala/sys/process/ProcessImpl$Future$.class
+-rw----     2.0 fat     1497 b-  0% stor 19800101.000002 scala/sys/process/ProcessImpl$OrProcess$$anonfun$$lessinit$greater$2.class
+-rw----     2.0 fat     1278 b-  0% stor 19800101.000002 scala/sys/process/ProcessImpl$OrProcess.class
+-rw----     2.0 fat     4291 b-  0% stor 19800101.000002 scala/sys/process/ProcessImpl$PipeSink.class
+-rw----     2.0 fat     4407 b-  0% stor 19800101.000002 scala/sys/process/ProcessImpl$PipeSource.class
+-rw----     2.0 fat     4261 b-  0% stor 19800101.000002 scala/sys/process/ProcessImpl$PipeThread.class
+-rw----     2.0 fat    10156 b-  0% stor 19800101.000002 scala/sys/process/ProcessImpl$PipedProcesses.class
+-rw----     2.0 fat     1489 b-  0% stor 19800101.000002 scala/sys/process/ProcessImpl$ProcessSequence$$anonfun$$lessinit$greater$3.class
+-rw----     2.0 fat     1308 b-  0% stor 19800101.000002 scala/sys/process/ProcessImpl$ProcessSequence.class
+-rw----     2.0 fat     4651 b-  0% stor 19800101.000002 scala/sys/process/ProcessImpl$SequentialProcess.class
+-rw----     2.0 fat     3108 b-  0% stor 19800101.000002 scala/sys/process/ProcessImpl$SimpleProcess.class
+-rw----     2.0 fat      918 b-  0% stor 19800101.000002 scala/sys/process/ProcessImpl$Spawn$$anon$1.class
+-rw----     2.0 fat     1375 b-  0% stor 19800101.000002 scala/sys/process/ProcessImpl$Spawn$.class
+-rw----     2.0 fat     1452 b-  0% stor 19800101.000002 scala/sys/process/ProcessImpl$ThreadProcess.class
+-rw----     2.0 fat     5636 b-  0% stor 19800101.000002 scala/sys/process/ProcessImpl.class
+-rw----     2.0 fat     4884 b-  0% stor 19800101.000002 scala/sys/process/ProcessImplicits.class
+-rw----     2.0 fat     1423 b-  0% stor 19800101.000002 scala/sys/process/ProcessLogger$$anon$1.class
+-rw----     2.0 fat     1484 b-  0% stor 19800101.000002 scala/sys/process/ProcessLogger$.class
+-rw----     2.0 fat     2117 b-  0% stor 19800101.000002 scala/sys/process/ProcessLogger.class
+-rw----     2.0 fat     4449 b-  0% stor 19800101.000002 scala/sys/process/package$.class
+-rw----     2.0 fat     2357 b-  0% stor 19800101.000002 scala/sys/process/package.class
+-rw----     2.0 fat     1965 b-  0% stor 19800101.000002 scala/sys/process/processInternal$$anonfun$ioFailure$1.class
+-rw----     2.0 fat     1777 b-  0% stor 19800101.000002 scala/sys/process/processInternal$$anonfun$onError$1.class
+-rw----     2.0 fat     2046 b-  0% stor 19800101.000002 scala/sys/process/processInternal$$anonfun$onIOInterrupt$1.class
+-rw----     2.0 fat     2040 b-  0% stor 19800101.000002 scala/sys/process/processInternal$$anonfun$onInterrupt$1.class
+-rw----     2.0 fat     2943 b-  0% stor 19800101.000002 scala/sys/process/processInternal$.class
+-rw----     2.0 fat     2647 b-  0% stor 19800101.000002 scala/sys/process/processInternal.class
+-rw----     2.0 fat        0 bl  0% defN 19800101.000000 scala/text/
+-rw----     2.0 fat     1818 b-  0% stor 19800101.000002 scala/text/DocBreak$.class
+-rw----     2.0 fat     1927 b-  0% stor 19800101.000002 scala/text/DocBreak.class
+-rw----     2.0 fat     1895 b-  0% stor 19800101.000002 scala/text/DocCons$.class
+-rw----     2.0 fat     4772 b-  0% stor 19800101.000002 scala/text/DocCons.class
+-rw----     2.0 fat     1653 b-  0% stor 19800101.000002 scala/text/DocGroup$.class
+-rw----     2.0 fat     5393 b-  0% stor 19800101.000002 scala/text/DocGroup.class
+-rw----     2.0 fat     1996 b-  0% stor 19800101.000002 scala/text/DocNest$.class
+-rw----     2.0 fat     4804 b-  0% stor 19800101.000002 scala/text/DocNest.class
+-rw----     2.0 fat     1812 b-  0% stor 19800101.000002 scala/text/DocNil$.class
+-rw----     2.0 fat     1917 b-  0% stor 19800101.000002 scala/text/DocNil.class
+-rw----     2.0 fat     1600 b-  0% stor 19800101.000002 scala/text/DocText$.class
+-rw----     2.0 fat     5393 b-  0% stor 19800101.000002 scala/text/DocText.class
+-rw----     2.0 fat     1452 b-  0% stor 19800101.000002 scala/text/Document$.class
+-rw----     2.0 fat     7300 b-  0% stor 19800101.000002 scala/text/Document.class
+-rw----     2.0 fat      577 b-  0% stor 19800101.000002 scala/throws$.class
+-rw----     2.0 fat     1628 b-  0% stor 19800101.000002 scala/throws.class
+-rw----     2.0 fat      641 b-  0% stor 19800101.000002 scala/transient.class
+-rw----     2.0 fat      533 b-  0% stor 19800101.000002 scala/unchecked.class
+-rw----     2.0 fat        0 bl  0% defN 19800101.000000 scala/util/
+-rw----     2.0 fat      921 b-  0% stor 19800101.000002 scala/util/DynamicVariable$$anon$1.class
+-rw----     2.0 fat     2870 b-  0% stor 19800101.000002 scala/util/DynamicVariable.class
+-rw----     2.0 fat     1346 b-  0% stor 19800101.000002 scala/util/Either$.class
+-rw----     2.0 fat     1663 b-  0% stor 19800101.000002 scala/util/Either$LeftProjection$.class
+-rw----     2.0 fat     6554 b-  0% stor 19800101.000002 scala/util/Either$LeftProjection.class
+-rw----     2.0 fat     1784 b-  0% stor 19800101.000002 scala/util/Either$MergeableEither$.class
+-rw----     2.0 fat     1538 b-  0% stor 19800101.000002 scala/util/Either$MergeableEither.class
+-rw----     2.0 fat     1673 b-  0% stor 19800101.000002 scala/util/Either$RightProjection$.class
+-rw----     2.0 fat     6559 b-  0% stor 19800101.000002 scala/util/Either$RightProjection.class
+-rw----     2.0 fat    13913 b-  0% stor 19800101.000002 scala/util/Either.class
+-rw----     2.0 fat     1419 b-  0% stor 19800101.000002 scala/util/Failure$.class
+-rw----     2.0 fat    10549 b-  0% stor 19800101.000002 scala/util/Failure.class
+-rw----     2.0 fat     1337 b-  0% stor 19800101.000002 scala/util/Left$.class
+-rw----     2.0 fat     4868 b-  0% stor 19800101.000002 scala/util/Left.class
+-rw----     2.0 fat    10014 b-  0% stor 19800101.000002 scala/util/MurmurHash$.class
+-rw----     2.0 fat     1804 b-  0% stor 19800101.000002 scala/util/MurmurHash$mcD$sp.class
+-rw----     2.0 fat     1802 b-  0% stor 19800101.000002 scala/util/MurmurHash$mcF$sp.class
+-rw----     2.0 fat     1730 b-  0% stor 19800101.000002 scala/util/MurmurHash$mcI$sp.class
+-rw----     2.0 fat     1800 b-  0% stor 19800101.000002 scala/util/MurmurHash$mcJ$sp.class
+-rw----     2.0 fat    12744 b-  0% stor 19800101.000002 scala/util/MurmurHash.class
+-rw----     2.0 fat     9547 b-  0% stor 19800101.000002 scala/util/Properties$.class
+-rw----     2.0 fat     4620 b-  0% stor 19800101.000002 scala/util/Properties.class
+-rw----     2.0 fat    24088 b-  0% stor 19800101.000002 scala/util/PropertiesTrait.class
+-rw----     2.0 fat      731 b-  0% stor 19800101.000002 scala/util/Random$.class
+-rw----     2.0 fat     9259 b-  0% stor 19800101.000002 scala/util/Random.class
+-rw----     2.0 fat     1346 b-  0% stor 19800101.000002 scala/util/Right$.class
+-rw----     2.0 fat     4879 b-  0% stor 19800101.000002 scala/util/Right.class
+-rw----     2.0 fat   211558 b-  0% stor 19800101.000002 scala/util/Sorting$.class
+-rw----     2.0 fat     3810 b-  0% stor 19800101.000002 scala/util/Sorting.class
+-rw----     2.0 fat     1315 b-  0% stor 19800101.000002 scala/util/Success$.class
+-rw----     2.0 fat    11815 b-  0% stor 19800101.000002 scala/util/Success.class
+-rw----     2.0 fat     1324 b-  0% stor 19800101.000002 scala/util/Try$.class
+-rw----     2.0 fat     3387 b-  0% stor 19800101.000002 scala/util/Try$WithFilter.class
+-rw----     2.0 fat     7228 b-  0% stor 19800101.000002 scala/util/Try.class
+-rw----     2.0 fat        0 bl  0% defN 19800101.000000 scala/util/control/
+-rw----     2.0 fat     1095 b-  0% stor 19800101.000002 scala/util/control/BreakControl.class
+-rw----     2.0 fat     1393 b-  0% stor 19800101.000002 scala/util/control/Breaks$$anon$1.class
+-rw----     2.0 fat      421 b-  0% stor 19800101.000002 scala/util/control/Breaks$.class
+-rw----     2.0 fat      444 b-  0% stor 19800101.000002 scala/util/control/Breaks$TryBlock.class
+-rw----     2.0 fat     2272 b-  0% stor 19800101.000002 scala/util/control/Breaks.class
+-rw----     2.0 fat      467 b-  0% stor 19800101.000002 scala/util/control/ControlThrowable.class
+-rw----     2.0 fat     9425 b-  0% stor 19800101.000002 scala/util/control/Exception$$anon$1.class
+-rw----     2.0 fat     2109 b-  0% stor 19800101.000002 scala/util/control/Exception$$anonfun$pfFromExceptions$1.class
+-rw----     2.0 fat    14808 b-  0% stor 19800101.000002 scala/util/control/Exception$.class
+-rw----     2.0 fat      912 b-  0% stor 19800101.000002 scala/util/control/Exception$By.class
+-rw----     2.0 fat     8775 b-  0% stor 19800101.000002 scala/util/control/Exception$Catch$$anon$2.class
+-rw----     2.0 fat     2364 b-  0% stor 19800101.000002 scala/util/control/Exception$Catch$.class
+-rw----     2.0 fat     9851 b-  0% stor 19800101.000002 scala/util/control/Exception$Catch.class
+-rw----     2.0 fat     1751 b-  0% stor 19800101.000002 scala/util/control/Exception$Described.class
+-rw----     2.0 fat     3269 b-  0% stor 19800101.000002 scala/util/control/Exception$Finally.class
+-rw----     2.0 fat     9018 b-  0% stor 19800101.000002 scala/util/control/Exception.class
+-rw----     2.0 fat     1123 b-  0% stor 19800101.000002 scala/util/control/NoStackTrace$.class
+-rw----     2.0 fat     1679 b-  0% stor 19800101.000002 scala/util/control/NoStackTrace.class
+-rw----     2.0 fat     1255 b-  0% stor 19800101.000002 scala/util/control/NonFatal$.class
+-rw----     2.0 fat      861 b-  0% stor 19800101.000002 scala/util/control/NonFatal.class
+-rw----     2.0 fat     1347 b-  0% stor 19800101.000002 scala/util/control/TailCalls$.class
+-rw----     2.0 fat     1684 b-  0% stor 19800101.000002 scala/util/control/TailCalls$Call$.class
+-rw----     2.0 fat     3175 b-  0% stor 19800101.000002 scala/util/control/TailCalls$Call.class
+-rw----     2.0 fat     2165 b-  0% stor 19800101.000002 scala/util/control/TailCalls$Cont$.class
+-rw----     2.0 fat     3989 b-  0% stor 19800101.000002 scala/util/control/TailCalls$Cont.class
+-rw----     2.0 fat     1519 b-  0% stor 19800101.000002 scala/util/control/TailCalls$Done$.class
+-rw----     2.0 fat     2849 b-  0% stor 19800101.000002 scala/util/control/TailCalls$Done.class
+-rw----     2.0 fat     7531 b-  0% stor 19800101.000002 scala/util/control/TailCalls$TailRec.class
+-rw----     2.0 fat     4606 b-  0% stor 19800101.000002 scala/util/control/TailCalls.class
+-rw----     2.0 fat        0 bl  0% defN 19800101.000000 scala/util/hashing/
+-rw----     2.0 fat     1071 b-  0% stor 19800101.000002 scala/util/hashing/ByteswapHashing$.class
+-rw----     2.0 fat     1103 b-  0% stor 19800101.000002 scala/util/hashing/ByteswapHashing$Chained.class
+-rw----     2.0 fat     1982 b-  0% stor 19800101.000002 scala/util/hashing/ByteswapHashing.class
+-rw----     2.0 fat     1034 b-  0% stor 19800101.000002 scala/util/hashing/Hashing$$anon$1.class
+-rw----     2.0 fat     1261 b-  0% stor 19800101.000002 scala/util/hashing/Hashing$.class
+-rw----     2.0 fat      753 b-  0% stor 19800101.000002 scala/util/hashing/Hashing$Default.class
+-rw----     2.0 fat     1873 b-  0% stor 19800101.000002 scala/util/hashing/Hashing.class
+-rw----     2.0 fat      983 b-  0% stor 19800101.000002 scala/util/hashing/MurmurHash3$$anon$1.class
+-rw----     2.0 fat     1204 b-  0% stor 19800101.000002 scala/util/hashing/MurmurHash3$$anon$2.class
+-rw----     2.0 fat     1035 b-  0% stor 19800101.000002 scala/util/hashing/MurmurHash3$$anon$3.class
+-rw----     2.0 fat     1045 b-  0% stor 19800101.000002 scala/util/hashing/MurmurHash3$$anon$4.class
+-rw----     2.0 fat     1208 b-  0% stor 19800101.000002 scala/util/hashing/MurmurHash3$$anon$5.class
+-rw----     2.0 fat     7419 b-  0% stor 19800101.000002 scala/util/hashing/MurmurHash3$.class
+-rw----     2.0 fat     1097 b-  0% stor 19800101.000002 scala/util/hashing/MurmurHash3$ArrayHashing$mcB$sp.class
+-rw----     2.0 fat     1097 b-  0% stor 19800101.000002 scala/util/hashing/MurmurHash3$ArrayHashing$mcC$sp.class
+-rw----     2.0 fat     1097 b-  0% stor 19800101.000002 scala/util/hashing/MurmurHash3$ArrayHashing$mcD$sp.class
+-rw----     2.0 fat     1097 b-  0% stor 19800101.000002 scala/util/hashing/MurmurHash3$ArrayHashing$mcF$sp.class
+-rw----     2.0 fat     1097 b-  0% stor 19800101.000002 scala/util/hashing/MurmurHash3$ArrayHashing$mcI$sp.class
+-rw----     2.0 fat     1097 b-  0% stor 19800101.000002 scala/util/hashing/MurmurHash3$ArrayHashing$mcJ$sp.class
+-rw----     2.0 fat     1097 b-  0% stor 19800101.000002 scala/util/hashing/MurmurHash3$ArrayHashing$mcS$sp.class
+-rw----     2.0 fat     1152 b-  0% stor 19800101.000002 scala/util/hashing/MurmurHash3$ArrayHashing$mcV$sp.class
+-rw----     2.0 fat     1097 b-  0% stor 19800101.000002 scala/util/hashing/MurmurHash3$ArrayHashing$mcZ$sp.class
+-rw----     2.0 fat     1986 b-  0% stor 19800101.000002 scala/util/hashing/MurmurHash3$ArrayHashing.class
+-rw----     2.0 fat    13528 b-  0% stor 19800101.000002 scala/util/hashing/MurmurHash3.class
+-rw----     2.0 fat      786 b-  0% stor 19800101.000002 scala/util/hashing/package$.class
+-rw----     2.0 fat      682 b-  0% stor 19800101.000002 scala/util/hashing/package.class
+-rw----     2.0 fat        0 bl  0% defN 19800101.000000 scala/util/matching/
+-rw----     2.0 fat     1461 b-  0% stor 19800101.000002 scala/util/matching/Regex$$anon$2.class
+-rw----     2.0 fat    30543 b-  0% stor 19800101.000002 scala/util/matching/Regex$$anon$4.class
+-rw----     2.0 fat      910 b-  0% stor 19800101.000002 scala/util/matching/Regex$.class
+-rw----     2.0 fat     3395 b-  0% stor 19800101.000002 scala/util/matching/Regex$Groups$.class
+-rw----     2.0 fat      947 b-  0% stor 19800101.000002 scala/util/matching/Regex$Match$.class
+-rw----     2.0 fat     7495 b-  0% stor 19800101.000002 scala/util/matching/Regex$Match.class
+-rw----     2.0 fat     8432 b-  0% stor 19800101.000002 scala/util/matching/Regex$MatchData.class
+-rw----     2.0 fat     2666 b-  0% stor 19800101.000002 scala/util/matching/Regex$MatchIterator$$anon$1.class
+-rw----     2.0 fat     1563 b-  0% stor 19800101.000002 scala/util/matching/Regex$MatchIterator$$anon$3.class
+-rw----     2.0 fat     6448 b-  0% stor 19800101.000002 scala/util/matching/Regex$MatchIterator.class
+-rw----     2.0 fat     1875 b-  0% stor 19800101.000002 scala/util/matching/Regex$Replacement.class
+-rw----     2.0 fat    18855 b-  0% stor 19800101.000002 scala/util/matching/Regex.class
+-rw----     2.0 fat     1478 b-  0% stor 19800101.000002 scala/util/matching/UnanchoredRegex.class
+-rw----     2.0 fat      637 b-  0% stor 19800101.000002 scala/volatile.class
+-rw----     2.0 fat      815 b-  0% stor 19800101.000002 foo/TestClass.class

--- a/tests/deployjar/test
+++ b/tests/deployjar/test
@@ -3,7 +3,6 @@
 
 bazel build :TestBinary_deploy.jar
 
-! unzip -v | grep -q Debian || diff expected  <( \
-  unzip -l "$(bazel info bazel-bin)/deployjar/TestBinary_deploy.jar" \
-  | tail -n+2 \
+diff expected <(
+    zipinfo -m -T --h-t "$(bazel info bazel-bin)/deployjar/TestBinary_deploy.jar"
 )

--- a/tests/plugins/classpath/BUILD
+++ b/tests/plugins/classpath/BUILD
@@ -1,0 +1,55 @@
+load("@rules_scala_annex//rules:scala.bzl", "configure_scala", "scala_library")
+
+scala_library(
+    name = "plugin-lib",
+    srcs = ["plugin-lib.scala"],
+    scala = "@scala_2_12",
+    tags = ["manual"],
+)
+
+_gen_plugin_xml_cmd = """
+cat > $@ << EOF
+<plugin>
+  <name>plugin</name>
+  <classname>plug.it.in.Plugin</classname>
+</plugin>
+"""
+
+genrule(
+    name = "gen-scalac-plugin.xml",
+    outs = ["scalac-plugin.xml"],
+    cmd = _gen_plugin_xml_cmd,
+)
+
+java_binary(
+    name = "resources",
+    classpath_resources = [
+        ":gen-scalac-plugin.xml",
+    ],
+    create_executable = False,
+)
+
+scala_library(
+    name = "plugin",
+    srcs = ["plugin.scala"],
+    resource_jars = [
+        ":resources",
+    ],
+    scala = "@scala_2_12",
+    tags = ["manual"],
+    deps = [
+        ":plugin-lib",
+        "@scala_2_12_scala_compiler//jar",
+        "@scala_2_12_scala_reflect//jar",
+    ],
+)
+
+scala_library(
+    name = "inefficient-usage",
+    srcs = ["usage.scala"],
+    plugins = [
+        ":plugin",
+    ],
+    scala = "@scala_2_12",
+    tags = ["manual"],
+)

--- a/tests/plugins/classpath/plugin-lib.scala
+++ b/tests/plugins/classpath/plugin-lib.scala
@@ -1,0 +1,6 @@
+package plug.it.in
+
+object Lib {
+  val name: String = "just-a-name"
+  val description: String = "just another plugin"
+}

--- a/tests/plugins/classpath/plugin.scala
+++ b/tests/plugins/classpath/plugin.scala
@@ -1,0 +1,28 @@
+package plug.it.in
+
+import scala.tools.nsc.Global
+import scala.tools.nsc.Phase
+import scala.tools.nsc.plugins.{ Plugin => NscPlugin }
+import scala.tools.nsc.plugins.{ PluginComponent => NscPluginComponent }
+
+final class Plugin(override val global: Global) extends NscPlugin {
+  override val name: String = Lib.name
+  override val description: String = Lib.description
+  override val components: List[NscPluginComponent] =
+    PluginComponent :: Nil
+
+  private object PluginComponent extends NscPluginComponent {
+    override val global: Global = Plugin.this.global
+    override val phaseName: String = "dummy-phase"
+    override val runsAfter: List[String] = "parser" :: Nil
+
+    override def newPhase(prev: Phase): Phase =
+      new StdPhase(prev) {
+        val global = Plugin.this.global
+        def apply(unit: PluginComponent.global.CompilationUnit): Unit = {
+          println("scalac plugin phase success")
+          System.exit(0)
+        }
+      }
+  }
+}

--- a/tests/plugins/classpath/test
+++ b/tests/plugins/classpath/test
@@ -1,0 +1,9 @@
+#!/bin/bash -e
+. "$(dirname "$0")"/../../common.sh
+
+bazel build :inefficient-usage 2>&1 | \
+    awk '
+        BEGIN                           {z  = 2}
+        /slightly inefficient/          {z -= 1}
+        /scalac plugin phase success/   {z -= 1}
+        END                             {exit z}'

--- a/tests/plugins/classpath/usage.scala
+++ b/tests/plugins/classpath/usage.scala
@@ -1,0 +1,3 @@
+package anx
+
+object Usage

--- a/tests/proto/expected
+++ b/tests/proto/expected
@@ -1,14 +1,10 @@
-  Length      Date    Time    Name
----------  ---------- -----   ----
-        0  1980-01-01 00:00   META-INF/
-       48  1980-01-01 00:00   META-INF/MANIFEST.MF
-        0  1980-01-01 00:00   anx/
-        0  1980-01-01 00:00   anx/proto/
-        0  1980-01-01 00:00   anx/proto/zero/
-    14895  1980-01-01 00:00   anx/proto/zero/Zero$.class
-     4337  1980-01-01 00:00   anx/proto/zero/Zero$ZeroLens.class
-    19364  1980-01-01 00:00   anx/proto/zero/Zero.class
-     6429  1980-01-01 00:00   anx/proto/zero/ZeroProto$.class
-     1907  1980-01-01 00:00   anx/proto/zero/ZeroProto.class
----------                     -------
-    46980                     10 files
+-rw----     2.0 fat        0 bx  0% stor 19800101.000000 META-INF/
+-rw----     2.0 fat       48 b-  0% stor 19800101.000000 META-INF/MANIFEST.MF
+-rw----     1.0 fat        0 b-  0% stor 19800101.000000 anx/
+-rw----     1.0 fat        0 b-  0% stor 19800101.000000 anx/proto/
+-rw----     1.0 fat        0 b-  0% stor 19800101.000000 anx/proto/zero/
+-rw----     2.0 fat    14895 b-  0% stor 19800101.000002 anx/proto/zero/Zero$.class
+-rw----     2.0 fat     4337 b-  0% stor 19800101.000002 anx/proto/zero/Zero$ZeroLens.class
+-rw----     2.0 fat    19364 b-  0% stor 19800101.000002 anx/proto/zero/Zero.class
+-rw----     2.0 fat     6429 b-  0% stor 19800101.000002 anx/proto/zero/ZeroProto$.class
+-rw----     2.0 fat     1907 b-  0% stor 19800101.000002 anx/proto/zero/ZeroProto.class

--- a/tests/proto/test
+++ b/tests/proto/test
@@ -4,7 +4,6 @@
 [[ "$(bazel version | head -n1 | cut -d: -f2 | tr -d ' ')" =~ 0.15.*|0.16.* ]] || bazel build :zero_scala_proto
 
 bazel build :zero_scala
-! unzip -v | grep -q Debian || diff expected  <( \
-  unzip -l "$(bazel info bazel-bin)/proto/zero_scala.jar" \
-  | tail -n+2 \
+diff expected <(
+    zipinfo -m -T --h-t "$(bazel info bazel-bin)/proto/zero_scala.jar"
 )

--- a/tests/resources/maven/expected
+++ b/tests/resources/maven/expected
@@ -1,7 +1,3 @@
-  Length      Date    Time    Name
----------  ---------- -----   ----
-        0  1980-01-01 00:00   META-INF/
-       48  1980-01-01 00:00   META-INF/MANIFEST.MF
-        8  1980-01-01 00:00   example.txt
----------                     -------
-       56                     3 files
+-rw----     2.0 fat        0 bx  0% stor 19800101.000000 META-INF/
+-rw----     2.0 fat       48 b-  0% stor 19800101.000000 META-INF/MANIFEST.MF
+-rw----     2.0 fat        8 b-  0% stor 19800101.000000 example.txt

--- a/tests/resources/maven/test
+++ b/tests/resources/maven/test
@@ -2,8 +2,6 @@
 . "$(dirname "$0")"/../../common.sh
 
 bazel build :maven
-# note: date formats for unzip vary
-! unzip -v | grep -q Debian || diff expected  <( \
-   unzip -l "$(bazel info bazel-bin)/resources/maven/maven.jar" \
-   | tail -n+2
+diff expected <(
+    zipinfo -m -T --h-t "$(bazel info bazel-bin)/resources/maven/maven.jar"
 )

--- a/tests/resources/plain/expected
+++ b/tests/resources/plain/expected
@@ -1,7 +1,0 @@
-  Length      Date    Time    Name
----------  ---------- -----   ----
-        0  1980-01-01 00:00   META-INF/
-       48  1980-01-01 00:00   META-INF/MANIFEST.MF
-        8  1980-01-01 00:00   resources/plain/example/example.txt
----------                     -------
-       56                     3 files

--- a/tests/resources/plain/expected_merged
+++ b/tests/resources/plain/expected_merged
@@ -1,4 +1,9 @@
 -rw----     2.0 fat        0 bx  0% stor 19800101.000000 META-INF/
 -rw----     2.0 fat       48 b-  0% stor 19800101.000000 META-INF/MANIFEST.MF
--rw-r--r--  0.0 fat        8 b-  0% stor 19800101.000000 resources/plain/example/example.txt
--rw-r--r--  0.0 fat        8 b-  0% stor 19800101.000000 plain/example/example.txt
+-rw----     2.0 fat        0 b-  0% stor 19800101.000000 resources/
+-rw----     2.0 fat        0 b-  0% stor 19800101.000000 resources/plain/
+-rw----     2.0 fat        0 b-  0% stor 19800101.000000 resources/plain/example/
+-rw----     2.0 fat        8 b-  0% stor 19800101.000000 resources/plain/example/example.txt
+-rw----     2.0 fat        0 b-  0% stor 19800101.000000 plain/
+-rw----     2.0 fat        0 b-  0% stor 19800101.000000 plain/example/
+-rw----     2.0 fat        8 b-  0% stor 19800101.000000 plain/example/example.txt

--- a/tests/resources/plain/expected_plain
+++ b/tests/resources/plain/expected_plain
@@ -1,4 +1,3 @@
 -rw----     2.0 fat        0 bx  0% stor 19800101.000000 META-INF/
 -rw----     2.0 fat       48 b-  0% stor 19800101.000000 META-INF/MANIFEST.MF
 -rw-r--r--  0.0 fat        8 b-  0% stor 19800101.000000 resources/plain/example/example.txt
--rw-r--r--  0.0 fat        8 b-  0% stor 19800101.000000 plain/example/example.txt

--- a/tests/resources/plain/expected_plain
+++ b/tests/resources/plain/expected_plain
@@ -1,3 +1,6 @@
 -rw----     2.0 fat        0 bx  0% stor 19800101.000000 META-INF/
 -rw----     2.0 fat       48 b-  0% stor 19800101.000000 META-INF/MANIFEST.MF
--rw-r--r--  0.0 fat        8 b-  0% stor 19800101.000000 resources/plain/example/example.txt
+-rw----     2.0 fat        0 b-  0% stor 19800101.000000 resources/
+-rw----     2.0 fat        0 b-  0% stor 19800101.000000 resources/plain/
+-rw----     2.0 fat        0 b-  0% stor 19800101.000000 resources/plain/example/
+-rw----     2.0 fat        8 b-  0% stor 19800101.000000 resources/plain/example/example.txt

--- a/tests/resources/plain/test
+++ b/tests/resources/plain/test
@@ -2,6 +2,8 @@
 . "$(dirname "$0")"/../../common.sh
 
 bazel build :plain
+ls -la example/
+zipinfo -m -T --h-t "$(bazel info bazel-bin)/resources/plain/plain.jar"
 diff expected_plain <(
     zipinfo -m -T --h-t "$(bazel info bazel-bin)/resources/plain/plain.jar"
 )

--- a/tests/resources/plain/test
+++ b/tests/resources/plain/test
@@ -7,6 +7,8 @@ diff expected_plain <(
 )
 
 bazel build :merged
+ls -la example/
+zipinfo -m -T --h-t "$(bazel info bazel-bin)/resources/plain/merged.jar"
 diff expected_merged <(
     zipinfo -m -T --h-t "$(bazel info bazel-bin)/resources/plain/merged.jar"
 )

--- a/tests/resources/plain/test
+++ b/tests/resources/plain/test
@@ -2,15 +2,11 @@
 . "$(dirname "$0")"/../../common.sh
 
 bazel build :plain
-ls -la example/
-zipinfo -m -T --h-t "$(bazel info bazel-bin)/resources/plain/plain.jar"
 diff expected_plain <(
     zipinfo -m -T --h-t "$(bazel info bazel-bin)/resources/plain/plain.jar"
 )
 
 bazel build :merged
-ls -la example/
-zipinfo -m -T --h-t "$(bazel info bazel-bin)/resources/plain/merged.jar"
 diff expected_merged <(
     zipinfo -m -T --h-t "$(bazel info bazel-bin)/resources/plain/merged.jar"
 )

--- a/tests/resources/plain/test
+++ b/tests/resources/plain/test
@@ -2,14 +2,11 @@
 . "$(dirname "$0")"/../../common.sh
 
 bazel build :plain
-! unzip -v | grep -q Debian || diff expected  <( \
-   unzip -l "$(bazel info bazel-bin)/resources/plain/plain.jar" \
-   | tail -n+2 \
+diff expected_plain <(
+    zipinfo -m -T --h-t "$(bazel info bazel-bin)/resources/plain/plain.jar"
 )
 
-
 bazel build :merged
-! unzip -v | grep -q Debian || diff expected_merged  <( \
-    unzip -l "$(bazel info bazel-bin)/resources/plain/merged.jar" \
-    | tail -n+2 \
+diff expected_merged <(
+    zipinfo -m -T --h-t "$(bazel info bazel-bin)/resources/plain/merged.jar"
 )

--- a/tests/resources/prefix/expected
+++ b/tests/resources/prefix/expected
@@ -1,7 +1,4 @@
-  Length      Date    Time    Name
----------  ---------- -----   ----
-        0  1980-01-01 00:00   META-INF/
-       48  1980-01-01 00:00   META-INF/MANIFEST.MF
-        8  1980-01-01 00:00   example/example.txt
----------                     -------
-       56                     3 files
+-rw----     2.0 fat        0 bx  0% stor 19800101.000000 META-INF/
+-rw----     2.0 fat       48 b-  0% stor 19800101.000000 META-INF/MANIFEST.MF
+-rw----     2.0 fat        0 b-  0% stor 19800101.000000 example/
+-rw----     2.0 fat        8 b-  0% stor 19800101.000000 example/example.txt

--- a/tests/resources/prefix/test
+++ b/tests/resources/prefix/test
@@ -2,9 +2,8 @@
 . "$(dirname "$0")"/../../common.sh
 
 bazel build :prefix
-! unzip -v | grep -q Debian || diff expected  <( \
-  unzip -l "$(bazel info bazel-bin)/resources/prefix/prefix.jar" \
-  | tail -n+2 \
+diff expected <(
+    zipinfo -m -T --h-t "$(bazel info bazel-bin)/resources/prefix/prefix.jar"
 )
 
 ! bazel build :outside


### PR DESCRIPTION
Adds support for scalac plugins that have dependencies. Uses singlejar to smash the dependencies together, on the fly, while emitting a warning about this being slightly inefficient.

In the process of getting the above done, this turned into a yak shave that also does the following:

- Abstracts all usages of singlejar into calls to a new helper method
- Remove use of zipper in favor of singlejar, since singlejar rips out file permissions and gives us reproducible builds across platforms. Addresses #151 
- Updates related resource/jar/unzipping tests to run on all platforms, ensuring we're actually reproducible
